### PR TITLE
Added document stubs and environment var refs where appropriate

### DIFF
--- a/Plugins/AOO/Documentation/README.md
+++ b/Plugins/AOO/Documentation/README.md
@@ -1,0 +1,7 @@
+# AOO Plugin Reference
+
+## Description
+
+Allows disabling _Attack Of Opportunity_ for certain creatures.
+
+## Environment Variables

--- a/Plugins/Administration/Documentation/README.md
+++ b/Plugins/Administration/Documentation/README.md
@@ -1,0 +1,7 @@
+# Administration Plugin Reference
+
+## Description
+
+Provide functions to administer a server (get/set passwords, boot players, etc.)
+
+## Environment Variables

--- a/Plugins/BehaviourTree/Documentation/README.md
+++ b/Plugins/BehaviourTree/Documentation/README.md
@@ -1,0 +1,5 @@
+# BehaviourTree Plugin Reference
+
+## Description
+
+## Environment Variables

--- a/Plugins/Chat/Documentation/README.md
+++ b/Plugins/Chat/Documentation/README.md
@@ -1,0 +1,7 @@
+# Chat Plugin Reference
+
+## Description
+
+Allows chat events to be captured, skipped, and manual chat messages to be dispatched.
+
+## Environment Variables

--- a/Plugins/Creature/Documentation/README.md
+++ b/Plugins/Creature/Documentation/README.md
@@ -1,0 +1,7 @@
+# Creature Plugin Reference
+
+## Description
+
+Functions exposing additional creature properties.
+
+## Environment Variables

--- a/Plugins/Data/Documentation/README.md
+++ b/Plugins/Data/Documentation/README.md
@@ -1,0 +1,7 @@
+# Data Plugin Reference
+
+## Description
+
+Provides a number of data structures for NWN code to use (simulated arrays)
+
+## Environment Variables

--- a/Plugins/MoveSpeed/Documentation/README.md
+++ b/Plugins/MoveSpeed/Documentation/README.md
@@ -1,0 +1,5 @@
+# MoveSpeed Plugin Reference
+
+## Description
+
+## Environment Variables

--- a/Plugins/Names/Documentation/README.md
+++ b/Plugins/Names/Documentation/README.md
@@ -1,0 +1,7 @@
+# Names Plugin Reference
+
+## Description
+
+Dynamic name modification (for PCs).
+
+## Environment Variables

--- a/Plugins/Object/Documentation/README.md
+++ b/Plugins/Object/Documentation/README.md
@@ -1,0 +1,7 @@
+# Object Plugin Reference
+
+## Description
+
+Functions exposing additional object properties
+
+## Environment Variables

--- a/Plugins/Player/Documentation/README.md
+++ b/Plugins/Player/Documentation/README.md
@@ -1,0 +1,7 @@
+# Player Plugin Reference
+
+## Description
+
+Functions exposing additional player properties and commands.
+
+## Environment Variables

--- a/Plugins/SQL/Documentation/README.md
+++ b/Plugins/SQL/Documentation/README.md
@@ -1,5 +1,9 @@
 # SQL Plugin Reference
 
+## Description
+
+General data access, storage and manipulation of persistent data in a database.
+
 ## Environment Variables
 
 ### NWNX_SQL_TYPE

--- a/Plugins/ServerLogRedirector/Documentation/README.md
+++ b/Plugins/ServerLogRedirector/Documentation/README.md
@@ -1,0 +1,7 @@
+# ServerLogRedirector Plugin Reference
+
+## Description
+
+Redirects server log output to the NWNX logger.
+
+## Environment Variables

--- a/Plugins/ThreadWatchdog/Documentation/README.md
+++ b/Plugins/ThreadWatchdog/Documentation/README.md
@@ -1,0 +1,5 @@
+# ThreadWatchdog Plugin Reference
+
+## Description
+
+## Environment Variables

--- a/Plugins/Time/Documentation/README.md
+++ b/Plugins/Time/Documentation/README.md
@@ -1,0 +1,7 @@
+# Time Plugin Reference
+
+## Description
+
+Functions exposing system time information (get time, date, unix time).
+
+## Environment Variables

--- a/Plugins/Tweaks/Documentation/README.md
+++ b/Plugins/Tweaks/Documentation/README.md
@@ -1,0 +1,7 @@
+# Tweaks Plugin Reference
+
+## Description
+
+Provides various game tweaks.
+
+## Environment Variables


### PR DESCRIPTION
Documentation isn't meant to be complete but provides somewhere for plugin maintainers to land their docs/examples/whatever.

Environment variables were pulled from the source when plugins used them (profiler, sql, core for example).