### PR TITLE
SQL: Handle null values better

### DIFF
--- a/Plugins/SQL/NWScript/nwnx_sql_t.nss
+++ b/Plugins/SQL/NWScript/nwnx_sql_t.nss
@@ -225,6 +225,26 @@ void main()
     report("Negative prepare query", NWNX_SQL_PrepareQuery("not a valid query!") == 0);
     report("GetLastError", NWNX_SQL_GetLastError() != "");
 
+    // Test with null values
+    NWNX_SQL_ExecuteQuery("INSERT INTO sql_test(colInt, colFloat, colStr, colObjId, colObj) VALUES(5121, null, null, null, null)");
+    report("Select null", NWNX_SQL_ExecuteQuery("SELECT * FROM sql_test WHERE colInt=5121"));
+    if (NWNX_SQL_ReadyToReadNextRow())
+    {
+        NWNX_SQL_ReadNextRow();
+        int n = StringToInt(NWNX_SQL_ReadDataInActiveRow(0));
+        report("ReadInt", n == 5121);
+        float f = StringToFloat(NWNX_SQL_ReadDataInActiveRow(1));
+        report("ReadFloat", f == 0.0);
+        string s = NWNX_SQL_ReadDataInActiveRow(2);
+        report("ReadString", s == "");
+
+        string sObjId = NWNX_SQL_ReadDataInActiveRow(3); // In base 10
+        report("ReadObjectId", sObjId == "");
+
+        object obj = NWNX_SQL_ReadFullObjectInActiveRow(4);
+        report("ReadFullObject", obj == OBJECT_INVALID);
+    }
+
     cleanup();
     WriteTimestampedLogEntry("Testing database " + db_type + " complete.");
     WriteTimestampedLogEntry("NWNX_SQL unit tests end.");

--- a/Plugins/SQL/Targets/MySQL.cpp
+++ b/Plugins/SQL/Targets/MySQL.cpp
@@ -105,6 +105,7 @@ NWNXLib::Maybe<ResultSet> MySQL::ExecuteQuery()
                 MYSQL_BIND binds[columns];
                 memset(binds, 0, sizeof(binds));
                 unsigned long lengths[columns];
+                memset(lengths, 0, sizeof(lengths));
                 for (unsigned i = 0; i < columns; i++)
                     binds[i].length = &lengths[i];
                 mysql_stmt_bind_result(m_stmt, binds);


### PR DESCRIPTION
`mysql_stmt_bind_result()` will not change the length parameter if the result is null, so we end up trying to allocate memory using an uninitialized location for size, which tends to fail with std::bad_alloc. So now we initialize it to zero beforehand.

Verified with the Arelith problematic query. Added tests to nwnx_sql_t.nss. Didn't test on PgSQL.