### PR TITLE
Fix for PgSQL reconnect issue

### DIFF
--- a/Plugins/SQL/SQL.cpp
+++ b/Plugins/SQL/SQL.cpp
@@ -173,6 +173,7 @@ Events::ArgumentStack SQL::OnExecutePreparedQuery(Events::ArgumentStack&&)
     // It is up to the user to check the return value, and repeat the query if needed.
     if (!m_target->IsConnected())
     {
+        GetServices()->m_log->Debug("Not Connected");
         if (!Reconnect())
         {
             GetServices()->m_log->Error("Database connection lost. Aborting.");

--- a/Plugins/SQL/Targets/PostgreSQL.cpp
+++ b/Plugins/SQL/Targets/PostgreSQL.cpp
@@ -66,7 +66,8 @@ bool PostgreSQL::IsConnected()
     bool connected = true;
 
     PGPing ping = PQping(m_connectString.c_str());
-    if (ping != PQPING_OK) {
+    if (ping != PQPING_OK)
+    {
         connected = false;
     }
     return connected;

--- a/Plugins/SQL/Targets/PostgreSQL.cpp
+++ b/Plugins/SQL/Targets/PostgreSQL.cpp
@@ -41,7 +41,7 @@ void PostgreSQL::Connect(NWNXLib::ViewPtr<NWNXLib::Services::ConfigProxy> config
 
     // hide the password in the log file
     m_log->Info("Connect String:  %s password=xxxxxxxx\n", m_connectString.c_str());
-    m_log->Debug("              : %s", pass); // but add it if we're in debug logging.
+    m_log->Debug("              :  %s", pass.c_str()); // but add it if we're in debug logging.
 
     m_connectString += " " + pass;
 

--- a/Plugins/SQL/Targets/PostgreSQL.hpp
+++ b/Plugins/SQL/Targets/PostgreSQL.hpp
@@ -32,6 +32,7 @@ private:
     size_t m_paramCount = 0;
     std::vector<std::string> m_params;
     std::string m_lastError;
+    std::string m_connectString;
 };
 
 }


### PR DESCRIPTION
with the existing code, the PGsql target is unusable.

I swear I tested this before.  I don't know why, but it freaked out with the parent level SQL changes.  Commented in the code, but basically, it doesn't like anything executed between the prepare and execute.  I guess it uses the same unnamed buffer.  And using named prepares is out because it forces the NWN scripters to call Destroy (not optional -- REQUIRED -- at that point or prepared queries will build up in the server forever.  it's not clear if they are ever reaped unless DEALLOCATED by the user).

Also, as a bonus.. don't willy-nilly echo the database password to the log files.