### PR TITLE
NWNX_Events: Add OnCastSpell event hooks.

### DIFF
--- a/Plugins/Events/CMakeLists.txt
+++ b/Plugins/Events/CMakeLists.txt
@@ -7,4 +7,5 @@ add_plugin(Events
     "Events/ExamineEvents.cpp"
     "Events/FeatEvents.cpp"
     "Events/ItemEvents.cpp"
-    "Events/StealthEvents.cpp")
+    "Events/StealthEvents.cpp"
+    "Events/SpellEvents.cpp")

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -10,6 +10,7 @@
 #include "Events/FeatEvents.hpp"
 #include "Events/ItemEvents.hpp"
 #include "Events/StealthEvents.hpp"
+#include "Events/SpellEvents.hpp"
 #include "Services/Config/Config.hpp"
 #include "Services/Log/Log.hpp"
 #include "Services/Messaging/Messaging.hpp"
@@ -98,6 +99,11 @@ Events::Events(const Plugin::CreateParams& params)
     if (GetServices()->m_config->Get<bool>("ENABLE_STEALTH_EVENTS", true))
     {
         m_stealthEvents = std::make_unique<StealthEvents>(GetServices()->m_hooks);
+    }
+
+    if (GetServices()->m_config->Get<bool>("ENABLE_SPELL_EVENTS", true))
+    {
+        m_spellEvents = std::make_unique<SpellEvents>(GetServices()->m_hooks);
     }
 }
 

--- a/Plugins/Events/Events.hpp
+++ b/Plugins/Events/Events.hpp
@@ -17,6 +17,7 @@ class ExamineEvents;
 class FeatEvents;
 class ItemEvents;
 class StealthEvents;
+class SpellEvents;
 
 class Events : public NWNXLib::Plugin
 {
@@ -52,6 +53,7 @@ private:
     std::unique_ptr<FeatEvents> m_featEvents;
     std::unique_ptr<ItemEvents> m_itemEvents;
     std::unique_ptr<StealthEvents> m_stealthEvents;
+    std::unique_ptr<SpellEvents> m_spellEvents;
 };
 
 }

--- a/Plugins/Events/Events/SpellEvents.cpp
+++ b/Plugins/Events/Events/SpellEvents.cpp
@@ -1,0 +1,61 @@
+#include "Events/SpellEvents.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/Functions.hpp"
+#include "Events.hpp"
+#include "Helpers.hpp"
+
+namespace Events {
+
+using namespace NWNXLib;
+
+SpellEvents::SpellEvents(ViewPtr<Services::HooksProxy> hooker)
+{
+    hooker->RequestSharedHook<
+        NWNXLib::API::Functions::CNWSObject__SpellCastAndImpact, 
+        int32_t, 
+        NWNXLib::API::CNWSObject*, 
+        uint32_t,
+        NWNXLib::API::Vector,
+        uint32_t,
+        int8_t,
+        uint32_t,
+        bool,
+        bool,
+        int8_t,
+        bool>(SpellEvents::CastSpellHook);
+}
+
+void SpellEvents::CastSpellHook
+(
+    Services::Hooks::CallType type, 
+    NWNXLib::API::CNWSObject* thisPtr, 
+    uint32_t spellID, 
+    NWNXLib::API::Vector targetPosition,
+    NWNXLib::API::Types::ObjectID oidTarget, 
+    int8_t multiClass, 
+    NWNXLib::API::Types::ObjectID oidItem,
+    bool spellCountered,
+    bool counteringSpell,
+    int8_t projectilePathType,
+    bool isInstantSpell
+)
+{
+    const bool before = type == Services::Hooks::CallType::BEFORE_ORIGINAL;
+    Events::PushEventData("SPELL_ID", std::to_string(spellID));
+
+    Events::PushEventData("TARGET_POSITION_X", std::to_string(targetPosition.x));
+    Events::PushEventData("TARGET_POSITION_Y", std::to_string(targetPosition.y));
+    Events::PushEventData("TARGET_POSITION_Z", std::to_string(targetPosition.z));
+
+    Events::PushEventData("TARGET_OBJECT_ID", Helpers::ObjectIDToString(oidTarget));
+    Events::PushEventData("MULTI_CLASS", std::to_string(multiClass));
+    Events::PushEventData("ITEM_OBJECT_ID", Helpers::ObjectIDToString(oidItem));
+    Events::PushEventData("SPELL_COUNTERED", std::to_string(spellCountered));
+    Events::PushEventData("COUNTERING_SPELL", std::to_string(counteringSpell));
+    Events::PushEventData("PROJECTILE_PATH_TYPE", std::to_string(projectilePathType));
+    Events::PushEventData("IS_INSTANT_SPELL", std::to_string(isInstantSpell));
+
+    Events::SignalEvent(before ? "NWNX_ON_CAST_SPELL_BEFORE" : "NWNX_ON_CAST_SPELL_AFTER", thisPtr->m_idSelf);
+}
+
+}

--- a/Plugins/Events/Events/SpellEvents.hpp
+++ b/Plugins/Events/Events/SpellEvents.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "API/Vector.hpp"
+#include "Common.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include "ViewPtr.hpp"
+
+namespace Events {
+
+class SpellEvents
+{
+public:
+    SpellEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
+
+private:
+    static void CastSpellHook
+    (
+        NWNXLib::Services::Hooks::CallType, 
+        NWNXLib::API::CNWSObject*, 
+        uint32_t,
+        NWNXLib::API::Vector,
+        NWNXLib::API::Types::ObjectID, 
+        int8_t,
+        NWNXLib::API::Types::ObjectID,
+        bool,
+        bool,
+        int8_t,
+        bool
+    );
+};
+
+}

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -20,6 +20,8 @@
 //     NWNX_ON_DM_SET_EXP (TODO: Upgrade - Currently disabled)
 //     NWNX_ON_CLIENT_DISCONNECT_BEFORE
 //     NWNX_ON_CLIENT_DISCONNECT_AFTER
+//     NWNX_ON_CAST_SPELL_BEFORE
+//     NWNX_ON_CAST_SPELL_AFTER
 //
 
 // Scripts can subscribe to events.


### PR DESCRIPTION
Adds a hook for OnCastSpell which fires whenever a spell lands on its target either from an item or from a normal creature spell casting sequence.