### PR TITLE
Administration: Add DeletePlayerCharacter() function

### DIFF
--- a/NWNXLib/Platform/FileSystem.cpp
+++ b/NWNXLib/Platform/FileSystem.cpp
@@ -2,7 +2,7 @@
 
 #include <array>
 #include <cassert>
-
+#include <stdio.h>
 #ifdef _WIN32
     #include "Windows.h"
     #include <thread>
@@ -156,6 +156,32 @@ std::string CombinePaths(const std::string& pathOne, const std::string& pathTwo)
 
     const bool hasSeparator = std::equal(separator.begin(), separator.end(), pathOne.rbegin());
     return hasSeparator ? pathOne + pathTwo : pathOne + separator + pathTwo;
+}
+
+
+bool FileExists(const std::string& fileName)
+{
+#ifdef _WIN32
+    DWORD dwAttrib = GetFileAttributes(szPath);
+    return (dwAttrib != INVALID_FILE_ATTRIBUTES && !(dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
+#else
+    return access(fileName.c_str(), F_OK) == 0;
+#endif
+}
+
+void RemoveFile(const std::string& fileName)
+{
+#ifdef _WIN32
+    DeleteFile(fileName.c_str());
+#else
+    unlink(fileName.c_str());
+#endif
+}
+void RenameFile(const std::string& oldName, const std::string& newName)
+{
+    if (FileExists(newName))
+        RemoveFile(newName);
+    rename(oldName.c_str(), newName.c_str());
 }
 
 }

--- a/NWNXLib/Platform/FileSystem.hpp
+++ b/NWNXLib/Platform/FileSystem.hpp
@@ -34,7 +34,9 @@ std::string GetCurExecutablePath();
 std::string StripExtensionFromFileName(const std::string& fileName);
 std::string RemoveFileNameFromPath(const std::string& path);
 std::string CombinePaths(const std::string& pathOne, const std::string& pathTwo);
-
+bool FileExists(const std::string& fileName);
+void RemoveFile(const std::string& fileName);
+void RenameFile(const std::string& oldName, const std::string& newName);
 }
 
 }

--- a/Plugins/Administration/Administration.cpp
+++ b/Plugins/Administration/Administration.cpp
@@ -42,13 +42,19 @@ namespace Administration {
 Administration::Administration(const Plugin::CreateParams& params)
     : Plugin(params)
 {
-    GetServices()->m_events->RegisterEvent("GET_PLAYER_PASSWORD", std::bind(&Administration::OnGetPlayerPassword, this, std::placeholders::_1));
-    GetServices()->m_events->RegisterEvent("SET_PLAYER_PASSWORD", std::bind(&Administration::OnSetPlayerPassword, this, std::placeholders::_1));
-    GetServices()->m_events->RegisterEvent("CLEAR_PLAYER_PASSWORD", std::bind(&Administration::OnClearPlayerPassword, this, std::placeholders::_1));
-    GetServices()->m_events->RegisterEvent("GET_DM_PASSWORD", std::bind(&Administration::OnGetDMPassword, this, std::placeholders::_1));
-    GetServices()->m_events->RegisterEvent("SET_DM_PASSWORD", std::bind(&Administration::OnSetDMPassword, this, std::placeholders::_1));
-    GetServices()->m_events->RegisterEvent("SHUTDOWN_SERVER", std::bind(&Administration::OnShutdownServer, this, std::placeholders::_1));
-    GetServices()->m_events->RegisterEvent("BOOT_PC_WITH_MESSAGE", std::bind(&Administration::OnBootPCWithMessage, this, std::placeholders::_1));
+
+#define REGISTER(name, func) \
+    GetServices()->m_events->RegisterEvent(name, std::bind(&Administration::func, this, std::placeholders::_1))
+
+    REGISTER("GET_PLAYER_PASSWORD",   OnGetPlayerPassword);
+    REGISTER("SET_PLAYER_PASSWORD",   OnSetPlayerPassword);
+    REGISTER("CLEAR_PLAYER_PASSWORD", OnClearPlayerPassword);
+    REGISTER("GET_DM_PASSWORD",       OnGetDMPassword);
+    REGISTER("SET_DM_PASSWORD",       OnSetDMPassword);
+    REGISTER("SHUTDOWN_SERVER",       OnShutdownServer);
+    REGISTER("BOOT_PC_WITH_MESSAGE",  OnBootPCWithMessage);
+
+#undef REGISTER
 }
 
 Administration::~Administration()

--- a/Plugins/Administration/Administration.hpp
+++ b/Plugins/Administration/Administration.hpp
@@ -18,6 +18,7 @@ public:
     NWNXLib::Services::Events::ArgumentStack OnSetDMPassword(NWNXLib::Services::Events::ArgumentStack&& args);
     NWNXLib::Services::Events::ArgumentStack OnShutdownServer(NWNXLib::Services::Events::ArgumentStack&& args);
     NWNXLib::Services::Events::ArgumentStack OnBootPCWithMessage(NWNXLib::Services::Events::ArgumentStack&& args);
+    NWNXLib::Services::Events::ArgumentStack OnDeletePlayerCharacter(NWNXLib::Services::Events::ArgumentStack&& args);
 };
 
 }

--- a/Plugins/Administration/NWScript/nwnx_admin.nss
+++ b/Plugins/Administration/NWScript/nwnx_admin.nss
@@ -17,6 +17,13 @@ void NWNX_Administration_ShutdownServer();
 // Boots the provided player from the server with the provided strref as message.
 void NWNX_Administration_BootPCWithMessage(object pc, int strref);
 
+// Deletes the player character from the servervault
+//    bPreserveBackup - if true, it will leave the file on server,
+//                      only appending ".deleted0" to the bic filename.
+// The PC will be immediately booted from the game with a "Delete Character" message
+void NWNX_Administration_DeletePlayerCharacter(object pc, int bPreserveBackup = TRUE);
+
+
 string NWNX_Administration_GetPlayerPassword()
 {
     NWNX_CallFunction("NWNX_Administration", "GET_PLAYER_PASSWORD");
@@ -56,4 +63,11 @@ void NWNX_Administration_BootPCWithMessage(object pc, int strref)
     NWNX_PushArgumentInt("NWNX_Administration", "BOOT_PC_WITH_MESSAGE", strref);
     NWNX_PushArgumentObject("NWNX_Administration", "BOOT_PC_WITH_MESSAGE", pc);
     NWNX_CallFunction("NWNX_Administration", "BOOT_PC_WITH_MESSAGE");
+}
+
+void NWNX_Administration_DeletePlayerCharacter(object pc, int bPreserveBackup = TRUE)
+{
+    NWNX_PushArgumentInt("NWNX_Administration", "DELETE_PLAYER_CHARACTER", bPreserveBackup);
+    NWNX_PushArgumentObject("NWNX_Administration", "DELETE_PLAYER_CHARACTER", pc);
+    NWNX_CallFunction("NWNX_Administration", "DELETE_PLAYER_CHARACTER");
 }


### PR DESCRIPTION
Ref: #29 

Add function to delete the player's current character, with optional backup. The player is immediately booted with "delete character" message and the .bic is removed/renamed from servervault. 

Added FileExists(), RemoveFile() and RenameFile() utilities to FileSystem.hpp.

Tested manually, as it requires a PC and no way to script a unit test.