### PR TITLE
Events: don't dereference null pvTarget in UseFeatHook

### DIFF
--- a/Plugins/Events/Events/FeatEvents.cpp
+++ b/Plugins/Events/Events/FeatEvents.cpp
@@ -18,37 +18,37 @@ using namespace NWNXLib::Services;
 FeatEvents::FeatEvents(ViewPtr<Services::HooksProxy> hooker)
 {
     hooker->RequestSharedHook<
-        NWNXLib::API::Functions::CNWSCreature__UseFeat, 
-        int32_t, 
-        NWNXLib::API::CNWSCreature*, 
-        uint16_t, 
-        uint16_t, 
-        NWNXLib::API::Types::ObjectID, 
-        NWNXLib::API::Types::ObjectID, 
+        NWNXLib::API::Functions::CNWSCreature__UseFeat,
+        int32_t,
+        NWNXLib::API::CNWSCreature*,
+        uint16_t,
+        uint16_t,
+        NWNXLib::API::Types::ObjectID,
+        NWNXLib::API::Types::ObjectID,
         NWNXLib::API::Vector*>(FeatEvents::UseFeatHook);
 }
 
 void FeatEvents::UseFeatHook
 (
-    Services::Hooks::CallType type, 
-    NWNXLib::API::CNWSCreature* thisPtr, 
-    uint16_t featID, 
-    uint16_t subFeatID, 
-    NWNXLib::API::Types::ObjectID oidTarget, 
-    NWNXLib::API::Types::ObjectID oidArea, 
+    Services::Hooks::CallType type,
+    NWNXLib::API::CNWSCreature* thisPtr,
+    uint16_t featID,
+    uint16_t subFeatID,
+    NWNXLib::API::Types::ObjectID oidTarget,
+    NWNXLib::API::Types::ObjectID oidArea,
     NWNXLib::API::Vector* pvTarget
 )
 {
     const bool before = type == Services::Hooks::CallType::BEFORE_ORIGINAL;
     Events::PushEventData("FEAT_ID", std::to_string(featID));
     Events::PushEventData("SUBFEAT_ID", std::to_string(subFeatID));
-    
+
     Events::PushEventData("TARGET_OBJECT_ID", Helpers::ObjectIDToString(oidTarget));
     Events::PushEventData("AREA_OBJECT_ID", Helpers::ObjectIDToString(oidArea));
 
-    Events::PushEventData("TARGET_POSITION_X", std::to_string(pvTarget->x));
-    Events::PushEventData("TARGET_POSITION_Y", std::to_string(pvTarget->y));
-    Events::PushEventData("TARGET_POSITION_Z", std::to_string(pvTarget->z));
+    Events::PushEventData("TARGET_POSITION_X", pvTarget ? std::to_string(pvTarget->x) : "0.0");
+    Events::PushEventData("TARGET_POSITION_Y", pvTarget ? std::to_string(pvTarget->y) : "0.0");
+    Events::PushEventData("TARGET_POSITION_Z", pvTarget ? std::to_string(pvTarget->z) : "0.0");
 
     Events::SignalEvent(before ? "NWNX_ON_USE_FEAT_BEFORE" : "NWNX_ON_USE_FEAT_AFTER", thisPtr->m_idSelf);
 }


### PR DESCRIPTION
When called through ActionUseFeat NWScript (and possibly other instances), the target vector is null. The core game code treats this as a (0,0,0), so doing the same here.

Example crash, reported by Vanes in discord:

    linux-gate.so.1(__kernel_rt_sigreturn+0x0)[0xf7712cb0] 
    /nwn/nwnx/NWNX_Events.so(_ZN6Events10FeatEvents11UseFeatHookEN7NWNXLib8Services5Hooks8CallTypeEPNS1_3API12CNWSCreatureEttjjPNS5_6VectorE+0x1e5)[0xf53bcc67] 
    /nwn/nwnx/NWNX_Events.so(+0x10fdc)[0xf53bcfdc] 
    /nwn/nwnx/NWNX_Events.so(_ZN7NWNXLib8Services9HooksImpl23HookLandingHolderSharedINS_7Hooking17CallingConvention8ThisCallEE11HookLandingILj1122784EiPNS_3API12CNWSCreatureEJttjjPNS8_6VectorEEEET0_T1DpT2+0x5b)[0xf53bd047]


Forgive the auto whitespace trimming.