### PR TITLE
WIP: Administration: cleanup for the 8158 BootPC() improvement

### DIFF
--- a/Plugins/Administration/Administration.cpp
+++ b/Plugins/Administration/Administration.cpp
@@ -57,7 +57,6 @@ Administration::Administration(const Plugin::CreateParams& params)
     REGISTER("GET_DM_PASSWORD",               OnGetDMPassword);
     REGISTER("SET_DM_PASSWORD",               OnSetDMPassword);
     REGISTER("SHUTDOWN_SERVER",               OnShutdownServer);
-    REGISTER("BOOT_PC_WITH_MESSAGE",          OnBootPCWithMessage);
     REGISTER("DELETE_PLAYER_CHARACTER",       OnDeletePlayerCharacter);
 
 #undef REGISTER
@@ -112,24 +111,6 @@ Events::ArgumentStack Administration::OnShutdownServer(Events::ArgumentStack&&)
 {
     GetServices()->m_log->Notice("Shutting down the server!");
     std::quick_exit(0);
-}
-
-Events::ArgumentStack Administration::OnBootPCWithMessage(Events::ArgumentStack&& args)
-{
-    const auto objectId = Events::ExtractArgument<Types::ObjectID>(args);
-    const auto strref = static_cast<uint32_t>(Events::ExtractArgument<int32_t>(args));
-
-    CServerExoApp* exoApp = Globals::AppManager()->m_pServerExoApp;
-    CNWSPlayer* player = exoApp->GetClientObjectByObjectId(objectId);
-
-    if (!player)
-    {
-        throw std::runtime_error("Attempted to boot invalid player.");
-    }
-
-    g_plugin->GetServices()->m_log->Notice("Booting player '0x%08x' for strref '%i'.", player->m_nPlayerID, strref);
-    exoApp->GetNetLayer()->DisconnectPlayer(player->m_nPlayerID, strref, 1, "");
-    return Events::ArgumentStack();
 }
 
 Events::ArgumentStack Administration::OnDeletePlayerCharacter(Events::ArgumentStack&& args)

--- a/Plugins/Administration/Administration.hpp
+++ b/Plugins/Administration/Administration.hpp
@@ -17,7 +17,6 @@ public:
     NWNXLib::Services::Events::ArgumentStack OnGetDMPassword(NWNXLib::Services::Events::ArgumentStack&& args);
     NWNXLib::Services::Events::ArgumentStack OnSetDMPassword(NWNXLib::Services::Events::ArgumentStack&& args);
     NWNXLib::Services::Events::ArgumentStack OnShutdownServer(NWNXLib::Services::Events::ArgumentStack&& args);
-    NWNXLib::Services::Events::ArgumentStack OnBootPCWithMessage(NWNXLib::Services::Events::ArgumentStack&& args);
     NWNXLib::Services::Events::ArgumentStack OnDeletePlayerCharacter(NWNXLib::Services::Events::ArgumentStack&& args);
 };
 

--- a/Plugins/Administration/NWScript/nwnx_admin.nss
+++ b/Plugins/Administration/NWScript/nwnx_admin.nss
@@ -14,6 +14,7 @@ void NWNX_Administration_SetDMPassword(string password);
 // Signals the server to immediately shut down.
 void NWNX_Administration_ShutdownServer();
 
+// DEPRECATED: Use BootPC() native function
 // Boots the provided player from the server with the provided strref as message.
 void NWNX_Administration_BootPCWithMessage(object pc, int strref);
 
@@ -60,9 +61,8 @@ void NWNX_Administration_ShutdownServer()
 
 void NWNX_Administration_BootPCWithMessage(object pc, int strref)
 {
-    NWNX_PushArgumentInt("NWNX_Administration", "BOOT_PC_WITH_MESSAGE", strref);
-    NWNX_PushArgumentObject("NWNX_Administration", "BOOT_PC_WITH_MESSAGE", pc);
-    NWNX_CallFunction("NWNX_Administration", "BOOT_PC_WITH_MESSAGE");
+    WriteTimestampedLogEntry("NWNX_Administration: BootPCWithMessage() is deprecated. Use native BootPC() instead");
+    BootPC(pc, GetStringByStrRef(strref));
 }
 
 void NWNX_Administration_DeletePlayerCharacter(object pc, int bPreserveBackup = TRUE)


### PR DESCRIPTION
The change is complete, but I want to do cleanup for the DeletePlayerCharacter as well. Sending the PR early so no one else duplicates the work. Feel free to merge this and I'll send part 2 in a follow up PR.

Administration: Remove BootPCWithMessage() and mark deprecated in nwscript

With 8158, the native BootPC() takes a string param which is much better than the NWNX function.
For compatibility, emulating the old behaviour in nwscript, but adding a deprecation note. Can remove fully in a future version.