### PR TITLE
Add event data for getting the item property index used for the OnUsedItem Event

### DIFF
--- a/Plugins/Events/Events/ItemEvents.cpp
+++ b/Plugins/Events/Events/ItemEvents.cpp
@@ -14,12 +14,20 @@ ItemEvents::ItemEvents(ViewPtr<Services::HooksProxy> hooker)
         uint8_t, API::Types::ObjectID, API::Vector, API::Types::ObjectID>(&UseItemHook);
 }
 
-void ItemEvents::UseItemHook(Services::Hooks::CallType type, API::CNWSCreature* thisPtr, API::Types::ObjectID item, uint8_t,
-    uint8_t, API::Types::ObjectID target, API::Vector, API::Types::ObjectID)
+void ItemEvents::UseItemHook(
+    Services::Hooks::CallType type, 
+    API::CNWSCreature* thisPtr, 
+    API::Types::ObjectID item, 
+    uint8_t propIndex,
+    uint8_t, 
+    API::Types::ObjectID target, 
+    API::Vector, 
+    API::Types::ObjectID)
 {
     const bool before = type == Services::Hooks::CallType::BEFORE_ORIGINAL;
     Events::PushEventData("ITEM_OBJECT_ID", Helpers::ObjectIDToString(item));
     Events::PushEventData("TARGET_OBJECT_ID", Helpers::ObjectIDToString(target));
+    Events::PushEventData("ITEM_PROPERTY_INDEX", std::to_string(propIndex));
     Events::SignalEvent(before ? "NWNX_ON_USE_ITEM_BEFORE" : "NWNX_ON_USE_ITEM_AFTER", thisPtr->m_idSelf);
 }
 


### PR DESCRIPTION
Adds ITEM_PROPERTY_INDEX to the UseItem event. Useful for retrieving which individual item property is used on an item.