### PR TITLE
Change methods for accessing creature ability scores

### DIFF
--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -70,7 +70,9 @@ Creature::Creature(const Plugin::CreateParams& params)
     REGISTER(GetClassByLevel);
     REGISTER(SetBaseAC);
     REGISTER(GetBaseAC);
-    REGISTER(SetAbilityScore);
+    REGISTER(SetRawAbilityScore);
+    REGISTER(GetRawAbilityScore);
+    REGISTER(ModifyRawAbilityScore);
     REGISTER(GetMemorisedSpell);
     REGISTER(GetMemorisedSpellCountByLevel);
     REGISTER(SetMemorisedSpell);
@@ -421,7 +423,7 @@ ArgumentStack Creature::GetBaseAC(ArgumentStack&& args)
     return stack;
 }
 
-ArgumentStack Creature::SetAbilityScore(ArgumentStack&& args)
+ArgumentStack Creature::SetRawAbilityScore(ArgumentStack&& args)
 {
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
@@ -450,7 +452,83 @@ ArgumentStack Creature::SetAbilityScore(ArgumentStack&& args)
                 pCreature->m_pStats->SetCHABase(static_cast<uint8_t>(value));
                 break;
             default:
-                GetServices()->m_log->Notice("Calling NWNX_Creature_SetAbilityScore with invalid ability ID:%d", ability);
+                GetServices()->m_log->Notice("Calling NWNX_Creature_SetRawAbilityScore with invalid ability ID:%d", ability);
+                assert(0);
+                break;
+        }
+    }
+    return stack;
+}
+
+ArgumentStack Creature::GetRawAbilityScore(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    int32_t retval = -1;
+
+    if (auto *pCreature = creature(args))
+    {
+        const auto ability = Services::Events::ExtractArgument<int32_t>(args);
+
+        switch (ability)
+        {
+            case Constants::ABILITY_STRENGTH:
+                retval = pCreature->m_pStats->m_nStrengthBase;
+                break;
+            case Constants::ABILITY_DEXTERITY:
+                retval = pCreature->m_pStats->m_nDexterityBase;
+                break;
+            case Constants::ABILITY_CONSTITUTION:
+                retval = pCreature->m_pStats->m_nConstitutionBase;
+                break;
+            case Constants::ABILITY_INTELLIGENCE:
+                retval = pCreature->m_pStats->m_nIntelligenceBase;
+                break;
+            case Constants::ABILITY_WISDOM:
+                retval = pCreature->m_pStats->m_nWisdomBase;
+                break;
+            case Constants::ABILITY_CHARISMA:
+                retval = pCreature->m_pStats->m_nCharismaBase;
+                break;
+            default:
+                GetServices()->m_log->Notice("Calling NWNX_Creature_GetRawAbilityScore with invalid ability ID:%d", ability);
+                assert(0);
+                break;
+        }
+    }
+    Services::Events::InsertArgument(stack, retval);
+    return stack;
+}
+
+ArgumentStack Creature::ModifyRawAbilityScore(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pCreature = creature(args))
+    {
+        const auto ability = Services::Events::ExtractArgument<int32_t>(args);
+        const auto offset  = Services::Events::ExtractArgument<int32_t>(args); assert(value <= 255);
+
+        switch (ability)
+        {
+            case Constants::ABILITY_STRENGTH:
+                pCreature->m_pStats->SetSTRBase(static_cast<uint8_t>(pCreature->m_pStats->m_nStrengthBase + offset));
+                break;
+            case Constants::ABILITY_DEXTERITY:
+                pCreature->m_pStats->SetDEXBase(static_cast<uint8_t>(pCreature->m_pStats->m_nDexterityBase + offset));
+                break;
+            case Constants::ABILITY_CONSTITUTION:
+                pCreature->m_pStats->SetCONBase(static_cast<uint8_t>(pCreature->m_pStats->m_nConstitutionBase + offset), 1/*bRecalculateHP*/);
+                break;
+            case Constants::ABILITY_INTELLIGENCE:
+                pCreature->m_pStats->SetINTBase(static_cast<uint8_t>(pCreature->m_pStats->m_nIntelligenceBase + offset));
+                break;
+            case Constants::ABILITY_WISDOM:
+                pCreature->m_pStats->SetWISBase(static_cast<uint8_t>(pCreature->m_pStats->m_nWisdomBase + offset));
+                break;
+            case Constants::ABILITY_CHARISMA:
+                pCreature->m_pStats->SetCHABase(static_cast<uint8_t>(pCreature->m_pStats->m_nCharismaBase + offset));
+                break;
+            default:
+                GetServices()->m_log->Notice("Calling NWNX_Creature_ModifyRawAbilityScore with invalid ability ID:%d", ability);
                 assert(0);
                 break;
         }
@@ -858,5 +936,4 @@ ArgumentStack Creature::SetSkillRank(ArgumentStack&& args)
     }
     return stack;
 }
-
 }

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -33,7 +33,9 @@ private:
     ArgumentStack GetClassByLevel               (ArgumentStack&& args);
     ArgumentStack SetBaseAC                     (ArgumentStack&& args);
     ArgumentStack GetBaseAC                     (ArgumentStack&& args);
-    ArgumentStack SetAbilityScore               (ArgumentStack&& args);
+    ArgumentStack SetRawAbilityScore            (ArgumentStack&& args);
+    ArgumentStack GetRawAbilityScore            (ArgumentStack&& args);
+    ArgumentStack ModifyRawAbilityScore         (ArgumentStack&& args);
     ArgumentStack GetMemorisedSpell             (ArgumentStack&& args);
     ArgumentStack GetMemorisedSpellCountByLevel (ArgumentStack&& args);
     ArgumentStack SetMemorisedSpell             (ArgumentStack&& args);

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -350,6 +350,7 @@ int NWNX_Creature_GetBaseAC(object creature)
 
 void NWNX_Creature_SetAbilityScore(object creature, int ability, int value)
 {
+    WriteTimestampedLogEntry("NWNX_Creature: SetAbilityScore() is deprecated. Use native NWNX_Creature_SetRawAbilityScore() instead");
     string sFunc = "SetRawAbilityScore";
 
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, value);

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -351,13 +351,7 @@ int NWNX_Creature_GetBaseAC(object creature)
 void NWNX_Creature_SetAbilityScore(object creature, int ability, int value)
 {
     WriteTimestampedLogEntry("NWNX_Creature: SetAbilityScore() is deprecated. Use native NWNX_Creature_SetRawAbilityScore() instead");
-    string sFunc = "SetRawAbilityScore";
-
-    NWNX_PushArgumentInt(NWNX_Creature, sFunc, value);
-    NWNX_PushArgumentInt(NWNX_Creature, sFunc, ability);
-    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
-
-    NWNX_CallFunction(NWNX_Creature, sFunc);
+    NWNX_Creature_SetRawAbilityScore(creature, ability, value);
 }
 
 void NWNX_Creature_SetRawAbilityScore(object creature, int ability, int value)

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -81,8 +81,18 @@ void NWNX_Creature_SetBaseAC(object creature, int ac);
 // Returns the base AC for the provided creature.
 int NWNX_Creature_GetBaseAC(object creature);
 
-// Sets the provided ability of provided creature's to the provided value.
+// DEPRECATED. Please use NWNX_Creature_SetRawAbilityScore now. This will be removed in future NWNX releases.
+// Sets the provided ability score of provided creature to the provided value.
 void NWNX_Creature_SetAbilityScore(object creature, int ability, int value);
+
+// Sets the provided ability score of provided creature to the provided value. Does not apply racial bonuses/penalties.
+void NWNX_Creature_SetRawAbilityScore(object creature, int ability, int value);
+
+// Gets the provided ability score of provided creature. Does not apply racial bonuses/penalties.
+int NWNX_Creature_GetRawAbilityScore(object creature, int ability);
+
+// Adjusts the provided ability score of a provided creature. Does not apply racial bonuses/penalties.
+void NWNX_Creature_ModifyRawAbilityScore(object creature, int ability, int modifier);
 
 // Gets the memorised spell of the provided creature for the provided class, level, and index.
 // Index bounds: 0 <= index < NWNX_Creature_GetMemorisedSpellCountByLevel(creature, class, level).
@@ -144,6 +154,7 @@ void NWNX_Creature_SetSoundset(object creature, int soundset);
 
 // Set the base ranks in a skill for creature
 void NWNX_Creature_SetSkillRank(object creature, int skill, int rank);
+
 
 const string NWNX_Creature = "NWNX_Creature";
 
@@ -339,9 +350,42 @@ int NWNX_Creature_GetBaseAC(object creature)
 
 void NWNX_Creature_SetAbilityScore(object creature, int ability, int value)
 {
-    string sFunc = "SetAbilityScore";
+    string sFunc = "SetRawAbilityScore";
 
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, value);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, ability);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_SetRawAbilityScore(object creature, int ability, int value)
+{
+    string sFunc = "SetRawAbilityScore";
+
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, value);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, ability);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+int NWNX_Creature_GetRawAbilityScore(object creature, int ability)
+{
+    string sFunc = "GetRawAbilityScore";
+
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, ability);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_ModifyRawAbilityScore(object creature, int ability, int modifier)
+{
+    string sFunc = "ModifyRawAbilityScore";
+
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, modifier);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, ability);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 


### PR DESCRIPTION
Renames SetAbilityScore to SetRawAbilityScore.
Adds GetRawAbilityScore (excludes racial bonuses/penalties)
Adds ModifyAbilityScore (excludes racial bonuses/penalties)
Deprecates NWNX_Creature_SetAbilityScore in the NWScript file.

This change is being made because of issues with racial bonuses. The NWScript GetAbilityScore() method returns racial bonuses which were throwing off calls like this:

int str = GetAbilityScore(oPC, ABILITY_STRENGTH) + 1;
NWNX_CREATURE_SetAbilityScore(oPC, ABILITY_STRENGTH, str);

Based on discussion with @mtijanic I made the changes above.