### PR TITLE
Creature: New functions

### DIFF
--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -100,6 +100,7 @@ Creature::Creature(const Plugin::CreateParams& params)
     REGISTER(RestoreFeats);
     REGISTER(RestoreSpecialAbilities);
     REGISTER(RestoreSpells);
+    REGISTER(RestoreItems);
 
 #undef REGISTER
 }
@@ -1061,6 +1062,17 @@ ArgumentStack Creature::RestoreSpells(ArgumentStack&& args)
     }
     return stack;
 }
+
+ArgumentStack Creature::RestoreItems(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pCreature = creature(args))
+    {
+        pCreature->RestoreItemProperties();
+    }
+    return stack;
+}
+
 
 
 }

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -94,6 +94,7 @@ Creature::Creature(const Plugin::CreateParams& params)
     REGISTER(SetSoundset);
     REGISTER(SetSkillRank);
     REGISTER(SetClassByPosition);
+    REGISTER(SetBaseAttackBonus);
 
 #undef REGISTER
 }
@@ -968,6 +969,21 @@ ArgumentStack Creature::SetClassByPosition(ArgumentStack&& args)
         assert(classID <= 255);
 
         pCreature->m_pStats->SetClass(static_cast<uint8_t>(position), static_cast<uint8_t>(classID));
+    }
+    return stack;
+}
+
+ArgumentStack Creature::SetBaseAttackBonus(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pCreature = creature(args))
+    {
+        const auto bab = Services::Events::ExtractArgument<int32_t>(args);
+        assert(bab >= 0);
+        assert(bab <= 254);
+
+        pCreature->m_pStats->m_nBaseAttackBonus = static_cast<uint8_t>(bab);
+        assert(pCreature->m_pStats->GetBaseAttackBonus(false) == bab);
     }
     return stack;
 }

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -97,6 +97,9 @@ Creature::Creature(const Plugin::CreateParams& params)
     REGISTER(SetBaseAttackBonus);
     REGISTER(GetAttacksPerRound);
     REGISTER(SetGender);
+    REGISTER(RestoreFeats);
+    REGISTER(RestoreSpecialAbilities);
+    REGISTER(RestoreSpells);
 
 #undef REGISTER
 }
@@ -1018,5 +1021,46 @@ ArgumentStack Creature::SetGender(ArgumentStack&& args)
     }
     return stack;
 }
+
+ArgumentStack Creature::RestoreFeats(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pCreature = creature(args))
+    {
+        pCreature->m_pStats->ResetFeatRemainingUses();
+    }
+    return stack;
+}
+
+ArgumentStack Creature::RestoreSpecialAbilities(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pCreature = creature(args))
+    {
+        pCreature->m_pStats->ResetSpellLikeAbilities();
+    }
+    return stack;
+}
+
+ArgumentStack Creature::RestoreSpells(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pCreature = creature(args))
+    {
+        const auto level = Services::Events::ExtractArgument<int32_t>(args);
+
+        if (level >= 0 && level <= 9)
+        {
+            pCreature->m_pStats->ReadySpellLevel(level);
+        }
+        else
+        {
+            for (int i = 0; i <= 9; i++)
+               pCreature->m_pStats->ReadySpellLevel(i);
+        }
+    }
+    return stack;
+}
+
 
 }

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -102,6 +102,8 @@ Creature::Creature(const Plugin::CreateParams& params)
     REGISTER(RestoreSpells);
     REGISTER(RestoreItems);
     REGISTER(SetSize);
+    REGISTER(GetSkillPointsRemaining);
+    REGISTER(SetSkillPointsRemaining);
 
 #undef REGISTER
 }
@@ -1086,6 +1088,29 @@ ArgumentStack Creature::SetSize(ArgumentStack&& args)
     return stack;
 }
 
+ArgumentStack Creature::GetSkillPointsRemaining(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    int32_t retval = -1;
+    if (auto *pCreature = creature(args))
+    {
+        retval = pCreature->m_pStats->m_nSkillPointsRemaining;
+    }
+    Services::Events::InsertArgument(stack, retval);
+    return stack;
+}
 
+ArgumentStack Creature::SetSkillPointsRemaining(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pCreature = creature(args))
+    {
+        const auto points = Services::Events::ExtractArgument<int32_t>(args);
+        assert(points >= 0); assert(points <= 65535);
+
+        pCreature->m_pStats->m_nSkillPointsRemaining = static_cast<uint16_t>(points);
+    }
+    return stack;
+}
 
 }

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -101,6 +101,7 @@ Creature::Creature(const Plugin::CreateParams& params)
     REGISTER(RestoreSpecialAbilities);
     REGISTER(RestoreSpells);
     REGISTER(RestoreItems);
+    REGISTER(SetSize);
 
 #undef REGISTER
 }
@@ -1069,6 +1070,18 @@ ArgumentStack Creature::RestoreItems(ArgumentStack&& args)
     if (auto *pCreature = creature(args))
     {
         pCreature->RestoreItemProperties();
+    }
+    return stack;
+}
+
+ArgumentStack Creature::SetSize(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pCreature = creature(args))
+    {
+        const auto size = Services::Events::ExtractArgument<int32_t>(args);
+
+        pCreature->m_nCreatureSize = size;
     }
     return stack;
 }

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -96,6 +96,7 @@ Creature::Creature(const Plugin::CreateParams& params)
     REGISTER(SetClassByPosition);
     REGISTER(SetBaseAttackBonus);
     REGISTER(GetAttacksPerRound);
+    REGISTER(SetGender);
 
 #undef REGISTER
 }
@@ -1003,6 +1004,18 @@ ArgumentStack Creature::GetAttacksPerRound(ArgumentStack&& args)
             retval = pCreature->m_pStats->m_nOverrideBaseAttackBonus;
     }
     Services::Events::InsertArgument(stack, retval);
+    return stack;
+}
+
+ArgumentStack Creature::SetGender(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pCreature = creature(args))
+    {
+        const auto gender = Services::Events::ExtractArgument<int32_t>(args);
+
+        pCreature->m_pStats->m_nGender = gender;
+    }
     return stack;
 }
 

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -95,6 +95,7 @@ Creature::Creature(const Plugin::CreateParams& params)
     REGISTER(SetSkillRank);
     REGISTER(SetClassByPosition);
     REGISTER(SetBaseAttackBonus);
+    REGISTER(GetAttacksPerRound);
 
 #undef REGISTER
 }
@@ -987,4 +988,22 @@ ArgumentStack Creature::SetBaseAttackBonus(ArgumentStack&& args)
     }
     return stack;
 }
+
+ArgumentStack Creature::GetAttacksPerRound(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    int32_t retval = -1;
+    if (auto *pCreature = creature(args))
+    {
+        const auto bBaseAPR = Services::Events::ExtractArgument<int32_t>(args);
+
+        if (bBaseAPR || pCreature->m_pStats->m_nOverrideBaseAttackBonus == 0)
+            retval = pCreature->m_pStats->GetAttacksPerRound();
+        else
+            retval = pCreature->m_pStats->m_nOverrideBaseAttackBonus;
+    }
+    Services::Events::InsertArgument(stack, retval);
+    return stack;
+}
+
 }

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -58,6 +58,7 @@ private:
     ArgumentStack SetSkillRank                  (ArgumentStack&& args);
     ArgumentStack SetClassByPosition            (ArgumentStack&& args);
     ArgumentStack SetBaseAttackBonus            (ArgumentStack&& args);
+    ArgumentStack GetAttacksPerRound            (ArgumentStack&& args);
 
 
     NWNXLib::API::CNWSCreature *creature(ArgumentStack& args);

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -63,6 +63,7 @@ private:
     ArgumentStack RestoreFeats                  (ArgumentStack&& args);
     ArgumentStack RestoreSpecialAbilities       (ArgumentStack&& args);
     ArgumentStack RestoreSpells                 (ArgumentStack&& args);
+    ArgumentStack RestoreItems                  (ArgumentStack&& args);
 
 
     NWNXLib::API::CNWSCreature *creature(ArgumentStack& args);

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -57,6 +57,7 @@ private:
     ArgumentStack SetSoundset                   (ArgumentStack&& args);
     ArgumentStack SetSkillRank                  (ArgumentStack&& args);
     ArgumentStack SetClassByPosition            (ArgumentStack&& args);
+    ArgumentStack SetBaseAttackBonus            (ArgumentStack&& args);
 
 
     NWNXLib::API::CNWSCreature *creature(ArgumentStack& args);

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -59,6 +59,7 @@ private:
     ArgumentStack SetClassByPosition            (ArgumentStack&& args);
     ArgumentStack SetBaseAttackBonus            (ArgumentStack&& args);
     ArgumentStack GetAttacksPerRound            (ArgumentStack&& args);
+    ArgumentStack SetGender                     (ArgumentStack&& args);
 
 
     NWNXLib::API::CNWSCreature *creature(ArgumentStack& args);

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -65,7 +65,8 @@ private:
     ArgumentStack RestoreSpells                 (ArgumentStack&& args);
     ArgumentStack RestoreItems                  (ArgumentStack&& args);
     ArgumentStack SetSize                       (ArgumentStack&& args);
-
+    ArgumentStack GetSkillPointsRemaining       (ArgumentStack&& args);
+    ArgumentStack SetSkillPointsRemaining       (ArgumentStack&& args);
 
     NWNXLib::API::CNWSCreature *creature(ArgumentStack& args);
 

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -60,6 +60,9 @@ private:
     ArgumentStack SetBaseAttackBonus            (ArgumentStack&& args);
     ArgumentStack GetAttacksPerRound            (ArgumentStack&& args);
     ArgumentStack SetGender                     (ArgumentStack&& args);
+    ArgumentStack RestoreFeats                  (ArgumentStack&& args);
+    ArgumentStack RestoreSpecialAbilities       (ArgumentStack&& args);
+    ArgumentStack RestoreSpells                 (ArgumentStack&& args);
 
 
     NWNXLib::API::CNWSCreature *creature(ArgumentStack& args);

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -64,6 +64,7 @@ private:
     ArgumentStack RestoreSpecialAbilities       (ArgumentStack&& args);
     ArgumentStack RestoreSpells                 (ArgumentStack&& args);
     ArgumentStack RestoreItems                  (ArgumentStack&& args);
+    ArgumentStack SetSize                       (ArgumentStack&& args);
 
 
     NWNXLib::API::CNWSCreature *creature(ArgumentStack& args);

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -168,6 +168,12 @@ void NWNX_Creature_SetClassByPosition(object creature, int position, int classID
 //       the bonus attacks per round for a creature, not the BAB.
 void NWNX_Creature_SetBaseAttackBonus(object creature, int bab);
 
+// Gets the creatures current attacks per round (using equipped weapon)
+// bBaseAPR - If true, will return the base attacks per round, based on BAB and
+//            equipped weapons, regardless of overrides set by 
+//            calls to SetBaseAttackBonus() builtin function..
+void NWNX_Creature_GetAttacksPerRound(object creature, int bBaseAPR);
+
 const string NWNX_Creature = "NWNX_Creature";
 
 
@@ -651,4 +657,14 @@ void NWNX_Creature_SetBaseAttackBonus(object creature, int bab)
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 
     NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+int NWNX_Creature_GetAttacksPerRound(object creature, int bBaseAPR)
+{
+    string sFunc = "GetAttacksPerRound";
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, bBaseAPR);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
 }

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -170,9 +170,9 @@ void NWNX_Creature_SetBaseAttackBonus(object creature, int bab);
 
 // Gets the creatures current attacks per round (using equipped weapon)
 // bBaseAPR - If true, will return the base attacks per round, based on BAB and
-//            equipped weapons, regardless of overrides set by 
-//            calls to SetBaseAttackBonus() builtin function..
-void NWNX_Creature_GetAttacksPerRound(object creature, int bBaseAPR);
+//            equipped weapons, regardless of overrides set by
+//            calls to SetBaseAttackBonus() builtin function.
+void NWNX_Creature_GetAttacksPerRound(object creature, int bBaseAPR = FALSE);
 
 const string NWNX_Creature = "NWNX_Creature";
 
@@ -659,7 +659,7 @@ void NWNX_Creature_SetBaseAttackBonus(object creature, int bab)
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
 
-int NWNX_Creature_GetAttacksPerRound(object creature, int bBaseAPR)
+int NWNX_Creature_GetAttacksPerRound(object creature, int bBaseAPR = FALSE)
 {
     string sFunc = "GetAttacksPerRound";
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, bBaseAPR);

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -190,6 +190,9 @@ void NWNX_Creature_RestoreSpells(object creature, int level = -1);
 // Restore uses for all items carried by the creature
 void NWNX_Creature_RestoreItems(object creature);
 
+// Sets the creature size. Use CREATURE_SIZE_* constants
+void NWNX_Creature_SetSize(object creature, int size);
+
 const string NWNX_Creature = "NWNX_Creature";
 
 
@@ -722,6 +725,15 @@ void NWNX_Creature_RestoreSpells(object creature, int level = -1)
 void NWNX_Creature_RestoreItems(object creature)
 {
     string sFunc = "RestoreItems";
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_SetSize(object creature, int size)
+{
+    string sFunc = "SetSize";
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, size);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 
     NWNX_CallFunction(NWNX_Creature, sFunc);

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -177,6 +177,16 @@ int NWNX_Creature_GetAttacksPerRound(object creature, int bBaseAPR = FALSE);
 // Sets the creature gender
 void NWNX_Creature_SetGender(object creature, int gender);
 
+// Restore all creature feat uses
+void NWNX_Creature_RestoreFeats(object creature);
+
+// Restore all creature special ability uses
+void NWNX_Creature_RestoreSpecialAbilities(object creature);
+
+// Restore all creature spells per day for given level.
+// If level is -1, all spells are restored
+void NWNX_Creature_RestoreSpells(object creature, int level = -1);
+
 const string NWNX_Creature = "NWNX_Creature";
 
 
@@ -676,6 +686,31 @@ void NWNX_Creature_SetGender(object creature, int gender)
 {
     string sFunc = "SetGender";
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, gender);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_RestoreFeats(object creature)
+{
+    string sFunc = "RestoreFeats";
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_RestoreSpecialAbilities(object creature)
+{
+    string sFunc = "RestoreSpecialAbilities";
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_RestoreSpells(object creature, int level = -1)
+{
+    string sFunc = "RestoreSpells";
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, level);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 
     NWNX_CallFunction(NWNX_Creature, sFunc);

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -187,6 +187,9 @@ void NWNX_Creature_RestoreSpecialAbilities(object creature);
 // If level is -1, all spells are restored
 void NWNX_Creature_RestoreSpells(object creature, int level = -1);
 
+// Restore uses for all items carried by the creature
+void NWNX_Creature_RestoreItems(object creature);
+
 const string NWNX_Creature = "NWNX_Creature";
 
 
@@ -711,6 +714,14 @@ void NWNX_Creature_RestoreSpells(object creature, int level = -1)
 {
     string sFunc = "RestoreSpells";
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, level);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_RestoreItems(object creature)
+{
+    string sFunc = "RestoreItems";
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 
     NWNX_CallFunction(NWNX_Creature, sFunc);

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -172,7 +172,7 @@ void NWNX_Creature_SetBaseAttackBonus(object creature, int bab);
 // bBaseAPR - If true, will return the base attacks per round, based on BAB and
 //            equipped weapons, regardless of overrides set by
 //            calls to SetBaseAttackBonus() builtin function.
-void NWNX_Creature_GetAttacksPerRound(object creature, int bBaseAPR = FALSE);
+int NWNX_Creature_GetAttacksPerRound(object creature, int bBaseAPR = FALSE);
 
 const string NWNX_Creature = "NWNX_Creature";
 

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -174,6 +174,9 @@ void NWNX_Creature_SetBaseAttackBonus(object creature, int bab);
 //            calls to SetBaseAttackBonus() builtin function.
 int NWNX_Creature_GetAttacksPerRound(object creature, int bBaseAPR = FALSE);
 
+// Sets the creature gender
+void NWNX_Creature_SetGender(object creature, int gender);
+
 const string NWNX_Creature = "NWNX_Creature";
 
 
@@ -667,4 +670,13 @@ int NWNX_Creature_GetAttacksPerRound(object creature, int bBaseAPR = FALSE)
 
     NWNX_CallFunction(NWNX_Creature, sFunc);
     return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_SetGender(object creature, int gender)
+{
+    string sFunc = "SetGender";
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, gender);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
 }

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -193,6 +193,12 @@ void NWNX_Creature_RestoreItems(object creature);
 // Sets the creature size. Use CREATURE_SIZE_* constants
 void NWNX_Creature_SetSize(object creature, int size);
 
+// Gets the creature's remaining unspent skill points
+int NWNX_Creature_GetSkillPointsRemaining(object creature);
+
+// sets the creature's remaining unspent skill points
+void NWNX_Creature_SetSkillPointsRemaining(object creature, int skillpoints);
+
 const string NWNX_Creature = "NWNX_Creature";
 
 
@@ -734,6 +740,25 @@ void NWNX_Creature_SetSize(object creature, int size)
 {
     string sFunc = "SetSize";
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, size);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+int NWNX_Creature_GetSkillPointsRemaining(object creature)
+{
+    string sFunc = "GetSkillPointsRemaining";
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
+}
+
+
+void NWNX_Creature_SetSkillPointsRemaining(object creature, int skillpoints)
+{
+    string sFunc = "SetSkillPointsRemaining";
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, skillpoints);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 
     NWNX_CallFunction(NWNX_Creature, sFunc);

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -160,6 +160,14 @@ void NWNX_Creature_SetSkillRank(object creature, int skill, int rank);
 // ClassID should be a valid ID number in classes.2da and be between 0 and 255.
 void NWNX_Creature_SetClassByPosition(object creature, int position, int classID);
 
+// Set creature's base attack bonus (BAB)
+// Modifying the BAB will also affect the creature's attacks per round and its
+// eligability for feats, prestige classes, etc.
+// The BAB value should be between 0 and 254.
+// NOTE: The base game has a function SetBaseAttackBonus(), which actually sets
+//       the bonus attacks per round for a creature, not the BAB.
+void NWNX_Creature_SetBaseAttackBonus(object creature, int bab);
+
 const string NWNX_Creature = "NWNX_Creature";
 
 
@@ -631,6 +639,15 @@ void NWNX_Creature_SetClassByPosition(object creature, int position, int classID
     string sFunc = "SetClassByPosition";
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, classID);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, position);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_SetBaseAttackBonus(object creature, int bab)
+{
+    string sFunc = "SetBaseAttackBonus";
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, bab);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 
     NWNX_CallFunction(NWNX_Creature, sFunc);

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -101,6 +101,15 @@ void main()
     NWNX_Creature_SetSkillRank(oCreature, SKILL_LISTEN, nSkillRanks + 5);
     report("SetSkillRank", GetSkillRank(SKILL_LISTEN, oCreature, TRUE) > nSkillRanks);
 
+    int nBAB = GetBaseAttackBonus(oCreature);
+    NWNX_Creature_SetBaseAttackBonus(oCreature, 6);
+    report("SetBaseAttackBonus", GetBaseAttackBonus(oCreature) == 6);
+    SetBaseAttackBonus(4, oCreature);
+    report("GetAttacksPerRound - base", NWNX_Creature_GetAttacksPerRound(oCreature, TRUE) == 2);
+    report("GetAttacksPerRound - override", NWNX_Creature_GetAttacksPerRound(oCreature, FALSE) == 4);
+    RestoreBaseAttackBonus(oCreature);
+    report("GetAttacksPerRound - base", NWNX_Creature_GetAttacksPerRound(oCreature, TRUE) == 2);
+    report("GetAttacksPerRound - override", NWNX_Creature_GetAttacksPerRound(oCreature, FALSE) == 2);
 
     WriteTimestampedLogEntry("NWNX_Creature unit test end.");
 }

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -111,5 +111,9 @@ void main()
     report("GetAttacksPerRound - base", NWNX_Creature_GetAttacksPerRound(oCreature, TRUE) == 2);
     report("GetAttacksPerRound - override", NWNX_Creature_GetAttacksPerRound(oCreature, FALSE) == 2);
 
+    int nGender = GetGender(oCreature);
+    NWNX_Creature_SetGender(oCreature, !nGender);
+    report("SetGender", GetGender(oCreature) != nGender);
+
     WriteTimestampedLogEntry("NWNX_Creature unit test end.");
 }

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -119,5 +119,10 @@ void main()
     NWNX_Creature_SetSize(oCreature, nSize + 1);
     report("SetSize", GetCreatureSize(oCreature) != nSize);
 
+    int nSkillPointsRemaining = NWNX_Creature_GetSkillPointsRemaining(oCreature);
+    report("GetSkillPointsRemaining", nSkillPointsRemaining >= 0);
+    NWNX_Creature_SetSkillPointsRemaining(oCreature, nSkillPointsRemaining+1);
+    report("SetSkillPointsRemaining", NWNX_Creature_GetSkillPointsRemaining(oCreature) == nSkillPointsRemaining+1);
+
     WriteTimestampedLogEntry("NWNX_Creature unit test end.");
 }

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -115,5 +115,9 @@ void main()
     NWNX_Creature_SetGender(oCreature, !nGender);
     report("SetGender", GetGender(oCreature) != nGender);
 
+    int nSize = GetCreatureSize(oCreature);
+    NWNX_Creature_SetSize(oCreature, nSize + 1);
+    report("SetSize", GetCreatureSize(oCreature) != nSize);
+
     WriteTimestampedLogEntry("NWNX_Creature unit test end.");
 }

--- a/Plugins/Object/NWScript/nwnx_object.nss
+++ b/Plugins/Object/NWScript/nwnx_object.nss
@@ -107,7 +107,7 @@ string NWNX_Object_Serialize(object obj);
 object NWNX_Object_Deserialize(string serialized);
 
 // Returns the dialog resref of the object.
-object NWNX_Object_GetDialogResref(object obj);
+string NWNX_Object_GetDialogResref(object obj);
 
 const string NWNX_Object = "NWNX_Object";
 


### PR DESCRIPTION
They're all pretty straightforward, just adding some missing functionality:

```

// Set creature's base attack bonus (BAB)
// Modifying the BAB will also affect the creature's attacks per round and its
// eligability for feats, prestige classes, etc.
// The BAB value should be between 0 and 254.
// NOTE: The base game has a function SetBaseAttackBonus(), which actually sets
//       the bonus attacks per round for a creature, not the BAB.
void NWNX_Creature_SetBaseAttackBonus(object creature, int bab);
// Gets the creatures current attacks per round (using equipped weapon)
// bBaseAPR - If true, will return the base attacks per round, based on BAB and
//            equipped weapons, regardless of overrides set by
//            calls to SetBaseAttackBonus() builtin function.
int NWNX_Creature_GetAttacksPerRound(object creature, int bBaseAPR = FALSE);
// Sets the creature gender
void NWNX_Creature_SetGender(object creature, int gender);
// Restore all creature feat uses
void NWNX_Creature_RestoreFeats(object creature);
// Restore all creature special ability uses
void NWNX_Creature_RestoreSpecialAbilities(object creature);
// Restore all creature spells per day for given level.
// If level is -1, all spells are restored
void NWNX_Creature_RestoreSpells(object creature, int level = -1);
// Restore uses for all items carried by the creature
void NWNX_Creature_RestoreItems(object creature);
// Sets the creature size. Use CREATURE_SIZE_* constants
void NWNX_Creature_SetSize(object creature, int size);
// Gets the creature's remaining unspent skill points
int NWNX_Creature_GetSkillPointsRemaining(object creature);
// sets the creature's remaining unspent skill points
void NWNX_Creature_SetSkillPointsRemaining(object creature, int skillpoints);
```

The restore functions don't get unit tests because I'm lazy.