### PR TITLE
Fix log crashes when printing large messages

### DIFF
--- a/NWNXLib/Log.cpp
+++ b/NWNXLib/Log.cpp
@@ -47,13 +47,15 @@ void InternalTrace(Channel::Enum channel, Channel::Enum allowedChannel, const ch
     }
 
     char buffer[2048];
-    std::sprintf(buffer, "%s [%02d:%02d:%02d] [%s:%d] %s: %s\n",
+    std::sprintf(buffer, "%s [%02d:%02d:%02d] [%s:%d] %s: ",
             SEVERITY_NAMES[static_cast<size_t>(channel)],
             date.m_hour, date.m_minute, date.m_second,
-            filename, line, plugin, message);
+            filename, line, plugin);
 
-    std::printf(buffer);
+    std::printf("%s%s\n", buffer, message);
     InternalOutputDebugString(buffer);
+    InternalOutputDebugString(message);
+    InternalOutputDebugString("\n");
 
     if (channel == Channel::SEV_FATAL)
     {

--- a/NWNXLib/Log.inl
+++ b/NWNXLib/Log.inl
@@ -11,8 +11,9 @@ void Trace(Channel::Enum channel, const char* plugin, const char* file, int line
         return;
     }
 
-    char formatBuffer[1536];
-    std::sprintf(formatBuffer, format, args ...);
+    // 128k should be the VM boundary, so largest message we'd need to print.
+    static char formatBuffer[128*1024];
+    std::snprintf(formatBuffer, sizeof(formatBuffer), format, args ...);
 
     InternalTrace(channel, allowedChannel, plugin, file, line, formatBuffer);
 }


### PR DESCRIPTION
See #67 - when printing large messages, such as serialized objects passed as arguments, we overflow the relatively tiny print buffer.

This PR makes it larger, and also stops crashing when insane messages are sent.