### PR TITLE
PerObjectStorage service

### DIFF
--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -13,6 +13,7 @@
 #include "Services/Patching/Patching.hpp"
 #include "Services/Tasks/Tasks.hpp"
 #include "Services/Messaging/Messaging.hpp"
+#include "Services/PerObjectStorage/PerObjectStorage.hpp"
 
 #include <cstring>
 
@@ -89,6 +90,7 @@ std::unique_ptr<Services::ServiceList> NWNXCore::ConstructCoreServices()
     services->m_patching = std::make_unique<Patching>();
     services->m_config = std::make_unique<Config>();
     services->m_messaging = std::make_unique<Messaging>();
+    services->m_perObjectStorage = std::make_unique<PerObjectStorage>();
 
     return services;
 }
@@ -105,6 +107,7 @@ std::unique_ptr<Services::ProxyServiceList> NWNXCore::ConstructProxyServices(con
     proxyServices->m_patching = std::make_unique<Services::PatchingProxy>(*m_services->m_patching);
     proxyServices->m_config = std::make_unique<Services::ConfigProxy>(*m_services->m_config, plugin);
     proxyServices->m_messaging = std::make_unique<Services::MessagingProxy>(*m_services->m_messaging);
+    proxyServices->m_perObjectStorage = std::make_unique<Services::PerObjectStorageProxy>(*m_services->m_perObjectStorage, plugin);
 
     ConfigureLogLevel(plugin, *proxyServices->m_config);
 
@@ -139,6 +142,8 @@ void NWNXCore::InitialSetupHooks()
 
     m_services->m_hooks->RequestExclusiveHook<API::Functions::CAppManager__DestroyServer>(&DestroyServerHandler);
     m_services->m_hooks->RequestSharedHook<API::Functions::CServerExoAppInternal__MainLoop, int32_t>(&MainLoopInternalHandler);
+
+    m_services->m_hooks->RequestSharedHook<API::Functions::CGameObject__CGameObjectDtor__0, void>(&Services::PerObjectStorage::CGameObject_dtor_hook);
 
     g_setStringHook = m_services->m_hooks->FindHookByAddress(API::Functions::CNWSScriptVarTable__SetString);
     g_getStringHook = m_services->m_hooks->FindHookByAddress(API::Functions::CNWSScriptVarTable__GetString);

--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -143,7 +143,7 @@ void NWNXCore::InitialSetupHooks()
     m_services->m_hooks->RequestExclusiveHook<API::Functions::CAppManager__DestroyServer>(&DestroyServerHandler);
     m_services->m_hooks->RequestSharedHook<API::Functions::CServerExoAppInternal__MainLoop, int32_t>(&MainLoopInternalHandler);
 
-    m_services->m_hooks->RequestSharedHook<API::Functions::CGameObject__CGameObjectDtor__0, void>(&Services::PerObjectStorage::CGameObject_dtor_hook);
+    m_services->m_hooks->RequestSharedHook<API::Functions::CGameObjectArray__Delete__1, void>(&Services::PerObjectStorage::CGameObjectArray__Delete__1_hook);
 
     g_setStringHook = m_services->m_hooks->FindHookByAddress(API::Functions::CNWSScriptVarTable__SetString);
     g_getStringHook = m_services->m_hooks->FindHookByAddress(API::Functions::CNWSScriptVarTable__GetString);

--- a/Core/NWNXCore.hpp
+++ b/Core/NWNXCore.hpp
@@ -7,6 +7,7 @@
 #include "Services/Services.hpp"
 #include "Services/Hooks/Hooks.hpp"
 #include "Services/Plugins/Plugins.hpp"
+#include "Services/PerObjectStorage/PerObjectStorage.hpp"
 
 #include <functional>
 #include <map>

--- a/NWNXLib/Common.hpp
+++ b/NWNXLib/Common.hpp
@@ -16,6 +16,7 @@ class Metrics;
 class Patching;
 class Config;
 class Messaging;
+class PerObjectStorage;
 
 class EventsProxy;
 class HooksProxy;
@@ -25,6 +26,7 @@ class MetricsProxy;
 class PatchingProxy;
 class ConfigProxy;
 class MessagingProxy;
+class PerObjectStorageProxy;
 
 }
 

--- a/NWNXLib/Services/CMakeLists.txt
+++ b/NWNXLib/Services/CMakeLists.txt
@@ -6,5 +6,6 @@ add_subdirectory(Patching)
 add_subdirectory(Plugins)
 add_subdirectory(Tasks)
 add_subdirectory(Messaging)
+add_subdirectory(PerObjectStorage)
 
 nwnxlib_scope()

--- a/NWNXLib/Services/PerObjectStorage/CMakeLists.txt
+++ b/NWNXLib/Services/PerObjectStorage/CMakeLists.txt
@@ -1,0 +1,1 @@
+nwnxlib_add("PerObjectStorage.cpp")

--- a/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
+++ b/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
@@ -1,0 +1,205 @@
+#include "Services/PerObjectStorage/PerObjectStorage.hpp"
+#include "API/Constants.hpp"
+
+namespace NWNXLib {
+
+namespace Services {
+
+
+void PerObjectStorage::Set(API::Types::ObjectID object, std::string key, int value)
+{
+    // TODO: check if the object is actually valid
+    if (object == API::Constants::OBJECT_INVALID)
+        return;
+
+    m_objectStorage[object]->GetIntMap().emplace(key, value);
+}
+void PerObjectStorage::Set(API::Types::ObjectID object, std::string key, float value)
+{
+    // TODO: check if the object is actually valid
+    if (object == API::Constants::OBJECT_INVALID)
+        return;
+
+    m_objectStorage[object]->GetFloatMap().emplace(key, value);
+}
+void PerObjectStorage::Set(API::Types::ObjectID object, std::string key, std::string value)
+{
+    // TODO: check if the object is actually valid
+    if (object == API::Constants::OBJECT_INVALID)
+        return;
+
+    m_objectStorage[object]->GetStringMap().emplace(key, value);
+}
+void PerObjectStorage::Set(API::Types::ObjectID object, std::string key, void *value, CleanupFunc cleanup)
+{
+    // TODO: check if the object is actually valid
+    if (object == API::Constants::OBJECT_INVALID)
+        return;
+
+    m_objectStorage[object]->GetPointerMap().emplace(key, std::make_pair<>(value, cleanup));
+}
+
+
+
+void PerObjectStorage::Remove(API::Types::ObjectID object, std::string key)
+{
+    auto it = m_objectStorage.find(object);
+    if (it != m_objectStorage.end())
+    {
+        it->second->GetStringMap().erase(key);
+        it->second->GetIntMap().erase(key);
+        it->second->GetFloatMap().erase(key);
+        it->second->GetPointerMap().erase(key);
+    }
+}
+
+PerObjectStorage::PerObjectStorage()
+{
+
+}
+PerObjectStorage::~PerObjectStorage()
+{
+
+}
+
+PerObjectStorage::ObjectStorage::IntMap& PerObjectStorage::ObjectStorage::GetIntMap()
+{
+    if (!m_IntMap)
+        m_IntMap = std::make_unique<IntMap>();
+    return *m_IntMap;
+}
+PerObjectStorage::ObjectStorage::FloatMap& PerObjectStorage::ObjectStorage::GetFloatMap()
+{
+    if (!m_FloatMap)
+        m_FloatMap = std::make_unique<FloatMap>();
+    return *m_FloatMap;
+}
+PerObjectStorage::ObjectStorage::StringMap& PerObjectStorage::ObjectStorage::GetStringMap()
+{
+    if (!m_StringMap)
+        m_StringMap = std::make_unique<StringMap>();
+    return *m_StringMap;
+}
+PerObjectStorage::ObjectStorage::PointerMap& PerObjectStorage::ObjectStorage::GetPointerMap()
+{
+    if (!m_PointerMap)
+        m_PointerMap = std::make_unique<PointerMap>();
+    return *m_PointerMap;
+}
+
+PerObjectStorage::ObjectStorage::ObjectStorage(API::Types::ObjectID owner)
+{
+    m_oidOwner = owner;
+}
+PerObjectStorage::ObjectStorage::~ObjectStorage()
+{
+    for (auto it: *m_PointerMap)
+    {
+        auto ptr = it.second.first;
+        auto cleanup = it.second.second;
+        cleanup(ptr);
+    }
+}
+
+
+
+PerObjectStorageProxy::PerObjectStorageProxy(PerObjectStorage& perObjectStorage, std::string pluginName)
+    : ServiceProxy<PerObjectStorage>(perObjectStorage)
+{
+    m_pluginName = pluginName;
+}
+PerObjectStorageProxy::~PerObjectStorageProxy()
+{
+    // TODO cleanup all storage from this plugin
+}
+
+void PerObjectStorageProxy::Set(API::Types::ObjectID object, std::string key, int value)
+{
+    m_proxyBase.Set(object, m_pluginName + "!" + key, value);
+}
+void PerObjectStorageProxy::Set(API::Types::ObjectID object, std::string key, float value)
+{
+    m_proxyBase.Set(object, m_pluginName + "!" + key, value);
+}
+void PerObjectStorageProxy::Set(API::Types::ObjectID object, std::string key, std::string value)
+{
+    m_proxyBase.Set(object, m_pluginName + "!" + key, value);
+}
+void PerObjectStorageProxy::Set(API::Types::ObjectID object, std::string key, void *value, PerObjectStorage::CleanupFunc cleanup)
+{
+    m_proxyBase.Set(object, m_pluginName + "!" + key, value, cleanup);
+}
+
+void PerObjectStorageProxy::Remove(API::Types::ObjectID object, std::string key)
+{
+    m_proxyBase.Remove(object, m_pluginName + "!" + key);
+}
+
+
+
+template <> Maybe<int> PerObjectStorage::Get<int>(API::Types::ObjectID object, std::string key);
+template <> Maybe<float> PerObjectStorage::Get<float>(API::Types::ObjectID object, std::string key);
+template <> Maybe<std::string> PerObjectStorage::Get<std::string>(API::Types::ObjectID object, std::string key);
+template <> Maybe<void*> PerObjectStorage::Get<void*>(API::Types::ObjectID object, std::string key);
+
+template <> Maybe<int> PerObjectStorage::Get<int>(API::Types::ObjectID object, std::string key)
+{
+    auto it = m_objectStorage.find(object);
+    if (it != m_objectStorage.end())
+    {
+        auto map = it->second->GetIntMap();
+        auto it2 = map.find(key);
+        if (it2 != map.end())
+            return Maybe<int>(std::move(it2->second));
+    }
+    return Maybe<int>();
+}
+template <> Maybe<float> PerObjectStorage::Get<float>(API::Types::ObjectID object, std::string key)
+{
+    auto it = m_objectStorage.find(object);
+    if (it != m_objectStorage.end())
+    {
+        auto map = it->second->GetFloatMap();
+        auto it2 = map.find(key);
+        if (it2 != map.end())
+            return Maybe<float>(std::move(it2->second));
+    }
+    return Maybe<float>();
+}
+template <> Maybe<std::string> PerObjectStorage::Get<std::string>(API::Types::ObjectID object, std::string key)
+{
+    auto it = m_objectStorage.find(object);
+    if (it != m_objectStorage.end())
+    {
+        auto map = it->second->GetStringMap();
+        auto it2 = map.find(key);
+        if (it2 != map.end())
+            return Maybe<std::string>(std::move(it2->second));
+    }
+    return Maybe<std::string>();
+}
+
+template <> Maybe<void*> PerObjectStorage::Get<void*>(API::Types::ObjectID object, std::string key)
+{
+    auto it = m_objectStorage.find(object);
+    if (it != m_objectStorage.end())
+    {
+        auto map = it->second->GetPointerMap();
+        auto it2 = map.find(key);
+        if (it2 != map.end())
+            return Maybe<void*>(std::move(it2->second.first));
+    }
+    return Maybe<void*>();
+}
+
+void PerObjectStorage::CGameObject_dtor_hook(Services::Hooks::CallType type, API::CGameObject *thisPtr)
+{
+    if (type != Services::Hooks::CallType::BEFORE_ORIGINAL)
+        return;
+
+    m_objectStorage.erase(thisPtr->m_idSelf);
+}
+
+
+}
+}

--- a/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
+++ b/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
@@ -208,7 +208,7 @@ template <> Maybe<void*> PerObjectStorage::Get<void*>(API::Types::ObjectID objec
 void PerObjectStorage::CGameObjectArray__Delete__1_hook(Services::Hooks::CallType type, API::CGameObjectArray* thisPtr, uint32_t id, API::CGameObject **ptr)
 {
     // unreferenced variables
-    (void)(sizeof(thisPtr), sizeof(ptr));
+    (void)(sizeof(thisPtr) & sizeof(ptr));
 
     if (type != Services::Hooks::CallType::AFTER_ORIGINAL)
         return;

--- a/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
+++ b/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
@@ -5,6 +5,7 @@ namespace NWNXLib {
 
 namespace Services {
 
+std::unordered_map<API::Types::ObjectID, std::unique_ptr<PerObjectStorage::ObjectStorage>> PerObjectStorage::g_objectStorage;
 
 void PerObjectStorage::Set(API::Types::ObjectID object, std::string key, int value)
 {
@@ -12,7 +13,7 @@ void PerObjectStorage::Set(API::Types::ObjectID object, std::string key, int val
     if (object == API::Constants::OBJECT_INVALID)
         return;
 
-    m_objectStorage[object]->GetIntMap().emplace(key, value);
+    g_objectStorage[object]->GetIntMap().emplace(key, value);
 }
 void PerObjectStorage::Set(API::Types::ObjectID object, std::string key, float value)
 {
@@ -20,7 +21,7 @@ void PerObjectStorage::Set(API::Types::ObjectID object, std::string key, float v
     if (object == API::Constants::OBJECT_INVALID)
         return;
 
-    m_objectStorage[object]->GetFloatMap().emplace(key, value);
+    g_objectStorage[object]->GetFloatMap().emplace(key, value);
 }
 void PerObjectStorage::Set(API::Types::ObjectID object, std::string key, std::string value)
 {
@@ -28,7 +29,7 @@ void PerObjectStorage::Set(API::Types::ObjectID object, std::string key, std::st
     if (object == API::Constants::OBJECT_INVALID)
         return;
 
-    m_objectStorage[object]->GetStringMap().emplace(key, value);
+    g_objectStorage[object]->GetStringMap().emplace(key, value);
 }
 void PerObjectStorage::Set(API::Types::ObjectID object, std::string key, void *value, CleanupFunc cleanup)
 {
@@ -36,15 +37,15 @@ void PerObjectStorage::Set(API::Types::ObjectID object, std::string key, void *v
     if (object == API::Constants::OBJECT_INVALID)
         return;
 
-    m_objectStorage[object]->GetPointerMap().emplace(key, std::make_pair<>(value, cleanup));
+    g_objectStorage[object]->GetPointerMap().emplace(key, std::make_pair<>(value, cleanup));
 }
 
 
 
 void PerObjectStorage::Remove(API::Types::ObjectID object, std::string key)
 {
-    auto it = m_objectStorage.find(object);
-    if (it != m_objectStorage.end())
+    auto it = g_objectStorage.find(object);
+    if (it != g_objectStorage.end())
     {
         it->second->GetStringMap().erase(key);
         it->second->GetIntMap().erase(key);
@@ -144,8 +145,8 @@ template <> Maybe<void*> PerObjectStorage::Get<void*>(API::Types::ObjectID objec
 
 template <> Maybe<int> PerObjectStorage::Get<int>(API::Types::ObjectID object, std::string key)
 {
-    auto it = m_objectStorage.find(object);
-    if (it != m_objectStorage.end())
+    auto it = g_objectStorage.find(object);
+    if (it != g_objectStorage.end())
     {
         auto map = it->second->GetIntMap();
         auto it2 = map.find(key);
@@ -156,8 +157,8 @@ template <> Maybe<int> PerObjectStorage::Get<int>(API::Types::ObjectID object, s
 }
 template <> Maybe<float> PerObjectStorage::Get<float>(API::Types::ObjectID object, std::string key)
 {
-    auto it = m_objectStorage.find(object);
-    if (it != m_objectStorage.end())
+    auto it = g_objectStorage.find(object);
+    if (it != g_objectStorage.end())
     {
         auto map = it->second->GetFloatMap();
         auto it2 = map.find(key);
@@ -168,8 +169,8 @@ template <> Maybe<float> PerObjectStorage::Get<float>(API::Types::ObjectID objec
 }
 template <> Maybe<std::string> PerObjectStorage::Get<std::string>(API::Types::ObjectID object, std::string key)
 {
-    auto it = m_objectStorage.find(object);
-    if (it != m_objectStorage.end())
+    auto it = g_objectStorage.find(object);
+    if (it != g_objectStorage.end())
     {
         auto map = it->second->GetStringMap();
         auto it2 = map.find(key);
@@ -181,8 +182,8 @@ template <> Maybe<std::string> PerObjectStorage::Get<std::string>(API::Types::Ob
 
 template <> Maybe<void*> PerObjectStorage::Get<void*>(API::Types::ObjectID object, std::string key)
 {
-    auto it = m_objectStorage.find(object);
-    if (it != m_objectStorage.end())
+    auto it = g_objectStorage.find(object);
+    if (it != g_objectStorage.end())
     {
         auto map = it->second->GetPointerMap();
         auto it2 = map.find(key);
@@ -197,7 +198,7 @@ void PerObjectStorage::CGameObject_dtor_hook(Services::Hooks::CallType type, API
     if (type != Services::Hooks::CallType::BEFORE_ORIGINAL)
         return;
 
-    m_objectStorage.erase(thisPtr->m_idSelf);
+    g_objectStorage.erase(thisPtr->m_idSelf);
 }
 
 

--- a/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
+++ b/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
@@ -163,7 +163,7 @@ template <> Maybe<int> PerObjectStorage::Get<int>(API::Types::ObjectID object, s
         auto map = it->second->GetIntMap();
         auto it2 = map.find(key);
         if (it2 != map.end())
-            return Maybe<int>(std::move(it2->second));
+            return Maybe<int>(it2->second);
     }
     return Maybe<int>();
 }
@@ -175,7 +175,7 @@ template <> Maybe<float> PerObjectStorage::Get<float>(API::Types::ObjectID objec
         auto map = it->second->GetFloatMap();
         auto it2 = map.find(key);
         if (it2 != map.end())
-            return Maybe<float>(std::move(it2->second));
+            return Maybe<float>(it2->second);
     }
     return Maybe<float>();
 }
@@ -187,7 +187,7 @@ template <> Maybe<std::string> PerObjectStorage::Get<std::string>(API::Types::Ob
         auto map = it->second->GetStringMap();
         auto it2 = map.find(key);
         if (it2 != map.end())
-            return Maybe<std::string>(std::move(it2->second));
+            return Maybe<std::string>(it2->second);
     }
     return Maybe<std::string>();
 }
@@ -200,7 +200,7 @@ template <> Maybe<void*> PerObjectStorage::Get<void*>(API::Types::ObjectID objec
         auto map = it->second->GetPointerMap();
         auto it2 = map.find(key);
         if (it2 != map.end())
-            return Maybe<void*>(std::move(it2->second.first));
+            return Maybe<void*>(it2->second.first);
     }
     return Maybe<void*>();
 }

--- a/NWNXLib/Services/PerObjectStorage/PerObjectStorage.hpp
+++ b/NWNXLib/Services/PerObjectStorage/PerObjectStorage.hpp
@@ -54,7 +54,7 @@ private:
 
         ObjectStorage(API::Types::ObjectID owner);
         ~ObjectStorage();
-    private:
+
         API::Types::ObjectID        m_oidOwner;
         std::unique_ptr<IntMap>     m_IntMap;
         std::unique_ptr<FloatMap>   m_FloatMap;

--- a/NWNXLib/Services/PerObjectStorage/PerObjectStorage.hpp
+++ b/NWNXLib/Services/PerObjectStorage/PerObjectStorage.hpp
@@ -61,7 +61,7 @@ private:
         std::unique_ptr<PointerMap> m_PointerMap;
     };
 
-    static std::unordered_map<API::Types::ObjectID, std::unique_ptr<ObjectStorage>> m_objectStorage;
+    static std::unordered_map<API::Types::ObjectID, std::unique_ptr<ObjectStorage>> g_objectStorage;
 };
 
 class PerObjectStorageProxy : public ServiceProxy<PerObjectStorage>

--- a/NWNXLib/Services/PerObjectStorage/PerObjectStorage.hpp
+++ b/NWNXLib/Services/PerObjectStorage/PerObjectStorage.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "API/CGameObject.hpp"
+#include "Maybe.hpp"
+#include "Services/Services.hpp"
+#include "Services/Hooks/Hooks.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <unordered_map>
+
+namespace NWNXLib {
+
+namespace Services {
+
+class PerObjectStorage : public ServiceBase
+{
+public:
+    using CleanupFunc = void (*)(void*);
+    void Set(API::Types::ObjectID object, std::string key, int value);
+    void Set(API::Types::ObjectID object, std::string key, float value);
+    void Set(API::Types::ObjectID object, std::string key, std::string value);
+    void Set(API::Types::ObjectID object, std::string key, void *value, CleanupFunc cleanup = nullptr);
+
+    // Gets the value, but doesn't remove it
+    template <typename T> Maybe<T>
+    Get(API::Types::ObjectID object, std::string key);
+
+    // Removes without cleanup
+    void Remove(API::Types::ObjectID object, std::string key);
+
+    PerObjectStorage();
+    ~PerObjectStorage();
+
+    static void CGameObject_dtor_hook(Services::Hooks::CallType type, API::CGameObject *thisPtr);
+private:
+
+    class ObjectStorage
+    {
+        // TODO maybe pack it up into a a single map?
+    public:
+        using IntMap     = std::unordered_map<std::string, int>;
+        using FloatMap   = std::unordered_map<std::string, float>;
+        using StringMap  = std::unordered_map<std::string, std::string>;
+        using PointerMap = std::unordered_map<std::string, std::pair<void*, CleanupFunc>>;
+
+        IntMap&     GetIntMap();
+        FloatMap&   GetFloatMap();
+        StringMap&  GetStringMap();
+        PointerMap& GetPointerMap();
+
+        ObjectStorage(API::Types::ObjectID owner);
+        ~ObjectStorage();
+    private:
+        API::Types::ObjectID        m_oidOwner;
+        std::unique_ptr<IntMap>     m_IntMap;
+        std::unique_ptr<FloatMap>   m_FloatMap;
+        std::unique_ptr<StringMap>  m_StringMap;
+        std::unique_ptr<PointerMap> m_PointerMap;
+    };
+
+    static std::unordered_map<API::Types::ObjectID, std::unique_ptr<ObjectStorage>> m_objectStorage;
+};
+
+class PerObjectStorageProxy : public ServiceProxy<PerObjectStorage>
+{
+public:
+    PerObjectStorageProxy(PerObjectStorage& perObjectStorage, std::string pluginName);
+    ~PerObjectStorageProxy();
+
+    void Set(API::Types::ObjectID object, std::string key, int value);
+    void Set(API::Types::ObjectID object, std::string key, float value);
+    void Set(API::Types::ObjectID object, std::string key, std::string value);
+    void Set(API::Types::ObjectID object, std::string key, void *value, PerObjectStorage::CleanupFunc cleanup = nullptr);
+
+    // Gets the value, but doesn't remove it
+    template <typename T> Maybe<T>
+    Get(API::Types::ObjectID object, std::string key)
+    {
+        return m_proxyBase.Get<T>(object, m_pluginName + "!" + key);
+    }
+
+    // Removes without cleanup
+    void Remove(API::Types::ObjectID object, std::string key);
+
+private:
+    std::string m_pluginName;
+};
+
+
+}
+
+}

--- a/NWNXLib/Services/PerObjectStorage/PerObjectStorage.hpp
+++ b/NWNXLib/Services/PerObjectStorage/PerObjectStorage.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "API/Types.hpp"
-#include "API/CGameObject.hpp"
+#include "API/CGameObjectArray.hpp"
 #include "Maybe.hpp"
 #include "Services/Services.hpp"
 #include "Services/Hooks/Hooks.hpp"
@@ -34,7 +34,8 @@ public:
     PerObjectStorage();
     ~PerObjectStorage();
 
-    static void CGameObject_dtor_hook(Services::Hooks::CallType type, API::CGameObject *thisPtr);
+    // Should really hook the CGameObject destructor, but that doesn't work currently..
+    static void CGameObjectArray__Delete__1_hook(Services::Hooks::CallType type, API::CGameObjectArray* thisPtr, uint32_t, API::CGameObject**);
 private:
 
     class ObjectStorage
@@ -61,6 +62,7 @@ private:
         std::unique_ptr<PointerMap> m_PointerMap;
     };
 
+    static ObjectStorage& GetObjectStorage(API::Types::ObjectID object);
     static std::unordered_map<API::Types::ObjectID, std::unique_ptr<ObjectStorage>> g_objectStorage;
 };
 

--- a/NWNXLib/Services/Services.hpp
+++ b/NWNXLib/Services/Services.hpp
@@ -21,6 +21,7 @@ struct ServiceList
     std::unique_ptr<Patching> m_patching;
     std::unique_ptr<Config> m_config;
     std::unique_ptr<Messaging> m_messaging;
+    std::unique_ptr<PerObjectStorage> m_perObjectStorage;
 };
 
 // Contains proxies through which the services should be accessed.
@@ -34,6 +35,7 @@ struct ProxyServiceList
     std::unique_ptr<PatchingProxy> m_patching;
     std::unique_ptr<ConfigProxy> m_config;
     std::unique_ptr<MessagingProxy> m_messaging;
+    std::unique_ptr<PerObjectStorageProxy> m_perObjectStorage;
 };
 
 struct ServiceBase


### PR DESCRIPTION
A new service that allows us to store arbitrary data on any `CGameObject` to fetch afterwards - meant to replace various adhoc maps, or using the `CNWSScriptVarTable` for NWNX.

Still a lot to do, and not very thoroughly tested, but should not break anything by its mere presence. Several inefficiencies and workarounds for now:
- In the future, we'll use a dedicated pointer in `CGameObject`
- Cannot hook `CGameObject::~CGameObject` because multiple destructors exist and API is not generating the addresses. Or... base class destructor is simply not called?
- Using 4 different maps for now. Should probably be merged using something like `variant`


Testing: Writing, reading and erasing from the object storage in the creature plugin. Destroying the creature and checking whether the cleanup is done.