### PR TITLE
Administration: Banning related functions

### DIFF
--- a/Plugins/Administration/Administration.cpp
+++ b/Plugins/Administration/Administration.cpp
@@ -215,7 +215,8 @@ Events::ArgumentStack Administration::OnGetBannedList(Events::ArgumentStack&&)
 {
     Events::ArgumentStack stack;
 
-    Events::InsertArgument(stack, Globals::AppManager()->m_pServerExoApp->GetBannedListString().CStr());
+    std::string list = Globals::AppManager()->m_pServerExoApp->GetBannedListString().CStr();
+    Events::InsertArgument(stack, list);
     return stack;
 }
 

--- a/Plugins/Administration/Administration.cpp
+++ b/Plugins/Administration/Administration.cpp
@@ -57,6 +57,13 @@ Administration::Administration(const Plugin::CreateParams& params)
     REGISTER("SET_DM_PASSWORD",               OnSetDMPassword);
     REGISTER("SHUTDOWN_SERVER",               OnShutdownServer);
     REGISTER("DELETE_PLAYER_CHARACTER",       OnDeletePlayerCharacter);
+    REGISTER("ADD_BANNED_IP",                 OnAddBannedIP);
+    REGISTER("REMOVE_BANNED_IP",              OnRemoveBannedIP);
+    REGISTER("ADD_BANNED_CDKEY",              OnAddBannedCDKey);
+    REGISTER("REMOVE_BANNED_CDKEY",           OnRemoveBannedCDKey);
+    REGISTER("ADD_BANNED_PLAYER_NAME",        OnAddBannedPlayerName);
+    REGISTER("REMOVE_BANNED_PLAYER_NAME",     OnRemoveBannedPlayerName);
+    REGISTER("GET_BANNED_LIST",               OnGetBannedList);
 
 #undef REGISTER
 }
@@ -155,5 +162,63 @@ Events::ArgumentStack Administration::OnDeletePlayerCharacter(Events::ArgumentSt
     }
     return Events::ArgumentStack();
 }
+
+Events::ArgumentStack Administration::OnAddBannedIP(Events::ArgumentStack&& args)
+{
+    const auto ip = Events::ExtractArgument<std::string>(args);
+    LOG_NOTICE("Banning IP %s", ip.c_str());
+    Globals::AppManager()->m_pServerExoApp->AddIPToBannedList(ip.c_str());
+    return Events::ArgumentStack();
+}
+
+Events::ArgumentStack Administration::OnRemoveBannedIP(Events::ArgumentStack&& args)
+{
+    const auto ip = Events::ExtractArgument<std::string>(args);
+    LOG_NOTICE("Unbanning IP %s", ip.c_str());
+    Globals::AppManager()->m_pServerExoApp->RemoveIPFromBannedList(ip.c_str());
+    return Events::ArgumentStack();
+}
+
+Events::ArgumentStack Administration::OnAddBannedCDKey(Events::ArgumentStack&& args)
+{
+    const auto key = Events::ExtractArgument<std::string>(args);
+    LOG_NOTICE("Banning CDKey %s", key.c_str());
+    Globals::AppManager()->m_pServerExoApp->AddCDKeyToBannedList(key.c_str());
+    return Events::ArgumentStack();
+}
+
+Events::ArgumentStack Administration::OnRemoveBannedCDKey(Events::ArgumentStack&& args)
+{
+    const auto key = Events::ExtractArgument<std::string>(args);
+    LOG_NOTICE("Unbanning CDKey %s", key.c_str());
+    Globals::AppManager()->m_pServerExoApp->RemoveCDKeyFromBannedList(key.c_str());
+    return Events::ArgumentStack();
+}
+
+Events::ArgumentStack Administration::OnAddBannedPlayerName(Events::ArgumentStack&& args)
+{
+    const auto playername = Events::ExtractArgument<std::string>(args);
+    LOG_NOTICE("Banning Player name %s", playername.c_str());
+    Globals::AppManager()->m_pServerExoApp->AddPlayerNameToBannedList(playername.c_str());
+    return Events::ArgumentStack();
+}
+
+Events::ArgumentStack Administration::OnRemoveBannedPlayerName(Events::ArgumentStack&& args)
+{
+    const auto playername = Events::ExtractArgument<std::string>(args);
+    LOG_NOTICE("Unbanning Player name %s", playername.c_str());
+    Globals::AppManager()->m_pServerExoApp->RemovePlayerNameFromBannedList(playername.c_str());
+    return Events::ArgumentStack();
+}
+
+Events::ArgumentStack Administration::OnGetBannedList(Events::ArgumentStack&&)
+{
+    Events::ArgumentStack stack;
+
+    Events::InsertArgument(stack, Globals::AppManager()->m_pServerExoApp->GetBannedListString().CStr());
+    return stack;
+}
+
+
 
 }

--- a/Plugins/Administration/Administration.hpp
+++ b/Plugins/Administration/Administration.hpp
@@ -18,6 +18,14 @@ public:
     NWNXLib::Services::Events::ArgumentStack OnSetDMPassword(NWNXLib::Services::Events::ArgumentStack&& args);
     NWNXLib::Services::Events::ArgumentStack OnShutdownServer(NWNXLib::Services::Events::ArgumentStack&& args);
     NWNXLib::Services::Events::ArgumentStack OnDeletePlayerCharacter(NWNXLib::Services::Events::ArgumentStack&& args);
+    NWNXLib::Services::Events::ArgumentStack OnAddBannedIP(NWNXLib::Services::Events::ArgumentStack&& args);
+    NWNXLib::Services::Events::ArgumentStack OnRemoveBannedIP(NWNXLib::Services::Events::ArgumentStack&& args);
+    NWNXLib::Services::Events::ArgumentStack OnAddBannedCDKey(NWNXLib::Services::Events::ArgumentStack&& args);
+    NWNXLib::Services::Events::ArgumentStack OnRemoveBannedCDKey(NWNXLib::Services::Events::ArgumentStack&& args);
+    NWNXLib::Services::Events::ArgumentStack OnAddBannedPlayerName(NWNXLib::Services::Events::ArgumentStack&& args);
+    NWNXLib::Services::Events::ArgumentStack OnRemoveBannedPlayerName(NWNXLib::Services::Events::ArgumentStack&& args);
+    NWNXLib::Services::Events::ArgumentStack OnGetBannedList(NWNXLib::Services::Events::ArgumentStack&& args);
+
 };
 
 }

--- a/Plugins/Administration/NWScript/nwnx_admin.nss
+++ b/Plugins/Administration/NWScript/nwnx_admin.nss
@@ -89,32 +89,32 @@ void NWNX_Administration_DeletePlayerCharacter(object pc, int bPreserveBackup = 
 
 void NWNX_Administration_AddBannedIP(string ip)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "ADD_BANNED_IP", ip)
+    NWNX_PushArgumentString("NWNX_Administration", "ADD_BANNED_IP", ip);
     NWNX_CallFunction("NWNX_Administration", "ADD_BANNED_IP");
 }
 void NWNX_Administration_RemoveBannedIP(string ip)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "REMOVE_BANNED_IP", ip)
+    NWNX_PushArgumentString("NWNX_Administration", "REMOVE_BANNED_IP", ip);
     NWNX_CallFunction("NWNX_Administration", "REMOVE_BANNED_IP");
 }
 void NWNX_Administration_AddBannedCDKey(string key)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "ADD_BANNED_CDKEY", key)
+    NWNX_PushArgumentString("NWNX_Administration", "ADD_BANNED_CDKEY", key);
     NWNX_CallFunction("NWNX_Administration", "ADD_BANNED_CDKEY");
 }
 void NWNX_Administration_RemoveBannedCDKey(string key)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "REMOVE_BANNED_CDKEY", key)
+    NWNX_PushArgumentString("NWNX_Administration", "REMOVE_BANNED_CDKEY", key);
     NWNX_CallFunction("NWNX_Administration", "REMOVE_BANNED_CDKEY");
 }
 void NWNX_Administration_AddBannedPlayerName(string playername)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "ADD_BANNED_PLAYER_NAME", playername)
+    NWNX_PushArgumentString("NWNX_Administration", "ADD_BANNED_PLAYER_NAME", playername);
     NWNX_CallFunction("NWNX_Administration", "ADD_BANNED_PLAYER_NAME");
 }
 void NWNX_Administration_RemoveBannedPlayerName(string playername)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "REMOVE_BANNED_PLAYER_NAME", playername)
+    NWNX_PushArgumentString("NWNX_Administration", "REMOVE_BANNED_PLAYER_NAME", playername);
     NWNX_CallFunction("NWNX_Administration", "REMOVE_BANNED_PLAYER_NAME");
 }
 string NWNX_Administration_GetBannedList()

--- a/Plugins/Administration/NWScript/nwnx_admin.nss
+++ b/Plugins/Administration/NWScript/nwnx_admin.nss
@@ -24,6 +24,20 @@ void NWNX_Administration_BootPCWithMessage(object pc, int strref);
 // The PC will be immediately booted from the game with a "Delete Character" message
 void NWNX_Administration_DeletePlayerCharacter(object pc, int bPreserveBackup = TRUE);
 
+// Ban a given IP - get via GetPCIPAddress()
+void NWNX_Administration_AddBannedIP(string ip);
+void NWNX_Administration_RemoveBannedIP(string ip);
+// Ban a given public cdkey - get via GetPCPublicCDKey
+void NWNX_Administration_AddBannedCDKey(string key);
+void NWNX_Administration_RemoveBannedCDKey(string key);
+// Ban a given player name - get via GetPCPlayerName
+// NOTE: Players can easily change their names
+void NWNX_Administration_AddBannedPlayerName(string playername);
+void NWNX_Administration_RemoveBannedPlayerName(string playername);
+// Get a list of all banned IPs/Keys/names as a string
+string NWNX_Administration_GetBannedList();
+
+
 
 string NWNX_Administration_GetPlayerPassword()
 {
@@ -70,4 +84,41 @@ void NWNX_Administration_DeletePlayerCharacter(object pc, int bPreserveBackup = 
     NWNX_PushArgumentInt("NWNX_Administration", "DELETE_PLAYER_CHARACTER", bPreserveBackup);
     NWNX_PushArgumentObject("NWNX_Administration", "DELETE_PLAYER_CHARACTER", pc);
     NWNX_CallFunction("NWNX_Administration", "DELETE_PLAYER_CHARACTER");
+}
+
+
+void NWNX_Administration_AddBannedIP(string ip)
+{
+    NWNX_PushArgumentString("NWNX_Administration", "ADD_BANNED_IP", ip)
+    NWNX_CallFunction("NWNX_Administration", "ADD_BANNED_IP");
+}
+void NWNX_Administration_RemoveBannedIP(string ip)
+{
+    NWNX_PushArgumentString("NWNX_Administration", "REMOVE_BANNED_IP", ip)
+    NWNX_CallFunction("NWNX_Administration", "REMOVE_BANNED_IP");
+}
+void NWNX_Administration_AddBannedCDKey(string key)
+{
+    NWNX_PushArgumentString("NWNX_Administration", "ADD_BANNED_CDKEY", key)
+    NWNX_CallFunction("NWNX_Administration", "ADD_BANNED_CDKEY");
+}
+void NWNX_Administration_RemoveBannedCDKey(string key)
+{
+    NWNX_PushArgumentString("NWNX_Administration", "REMOVE_BANNED_CDKEY", key)
+    NWNX_CallFunction("NWNX_Administration", "REMOVE_BANNED_CDKEY");
+}
+void NWNX_Administration_AddBannedPlayerName(string playername)
+{
+    NWNX_PushArgumentString("NWNX_Administration", "ADD_BANNED_PLAYER_NAME", playername)
+    NWNX_CallFunction("NWNX_Administration", "ADD_BANNED_PLAYER_NAME");
+}
+void NWNX_Administration_RemoveBannedPlayerName(string playername)
+{
+    NWNX_PushArgumentString("NWNX_Administration", "REMOVE_BANNED_PLAYER_NAME", playername)
+    NWNX_CallFunction("NWNX_Administration", "REMOVE_BANNED_PLAYER_NAME");
+}
+string NWNX_Administration_GetBannedList()
+{
+    NWNX_CallFunction("NWNX_Administration", "GET_BANNED_LIST");
+    return NWNX_GetReturnValueString("NWNX_Administration", "GET_BANNED_LIST");
 }


### PR DESCRIPTION
Pretty straightforward wrappers, addressing #35 and a few other requests.

Tested with this code:

    #include "nwnx_admin"
    void main()
    {
        NWNX_Administration_AddBannedIP("123.123.123.123");
        NWNX_Administration_AddBannedCDKey("ABCDEFG");
        NWNX_Administration_AddBannedPlayerName("Mr.Player Dude");
        WriteTimestampedLogEntry("BANNED LIST: " + NWNX_Administration_GetBannedList());
        NWNX_Administration_RemoveBannedIP("123.123.123.123");
        NWNX_Administration_RemoveBannedCDKey("ABCDEFG");
        NWNX_Administration_RemoveBannedPlayerName("Mr.Player Dude");
        WriteTimestampedLogEntry("BANNED LIST: " + NWNX_Administration_GetBannedList());
    }
