### PR TITLE
events: re-enable DM action events

### DIFF
--- a/Plugins/Events/CMakeLists.txt
+++ b/Plugins/Events/CMakeLists.txt
@@ -4,7 +4,7 @@ add_plugin(Events
     "Events/AssociateEvents.cpp"
     "Events/ClientEvents.cpp"
     "Events/CombatEvents.cpp"
-    # "Events/DMActionEvents.cpp" TODO: Upgrade
+    "Events/DMActionEvents.cpp"
     "Events/ExamineEvents.cpp"
     "Events/FeatEvents.cpp"
     "Events/ItemEvents.cpp"

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -81,8 +81,7 @@ Events::Events(const Plugin::CreateParams& params)
 
     if (GetServices()->m_config->Get<bool>("ENABLE_DM_ACTION_EVENTS", true))
     {
-        // TODO: Upgrade
-        //m_dmActionEvents = std::make_unique<DMActionEvents>(GetServices()->m_patching); Disabled for 8141 compat
+        m_dmActionEvents = std::make_unique<DMActionEvents>(GetServices()->m_hooks);
     }
 
     if (GetServices()->m_config->Get<bool>("ENABLE_EXAMINE_EVENTS", true))

--- a/Plugins/Events/Events/DMActionEvents.cpp
+++ b/Plugins/Events/Events/DMActionEvents.cpp
@@ -22,10 +22,13 @@ DMActionEvents::DMActionEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> h
         CNWSMessage*, CNWSPlayer*, uint8_t, int32_t>(&HandleDMMessageHook);
 }
 template <typename T>
-static T& PeekMessage(CNWSMessage *pMessage, int32_t offset)
+static T PeekMessage(CNWSMessage *pMessage, int32_t offset)
 {
+    static_assert(std::is_pod<T>::value);
+    T value;
     uint8_t *ptr = pMessage->m_pnReadBuffer + pMessage->m_nReadBufferPtr + offset;
-    return *(T*)ptr;
+    std::memcpy(&value, ptr, sizeof(T));
+    return value;
 }
 
 void DMActionEvents::HandleDMMessageHook(Services::Hooks::CallType type,

--- a/Plugins/Events/Events/DMActionEvents.cpp
+++ b/Plugins/Events/Events/DMActionEvents.cpp
@@ -34,7 +34,8 @@ void DMActionEvents::HandleDMMessageHook(Services::Hooks::CallType type,
     // unused variabes
     (void)(sizeof(thisPtr) & sizeof(bGroup));
 
-    const char *suffix = (type == Services::Hooks::CallType::BEFORE_ORIGINAL) ? "_BEFORE" : "_AFTER";
+    const bool before = (type == Services::Hooks::CallType::BEFORE_ORIGINAL);
+    const char *suffix = before ? "_BEFORE" : "_AFTER";
     std::string event = "NWNX_ON_";
 
     Types::ObjectID oidDM = pPlayer ? pPlayer->m_oidNWSObject : Constants::OBJECT_INVALID;
@@ -114,20 +115,47 @@ void DMActionEvents::HandleDMMessageHook(Services::Hooks::CallType type,
             event += "JUMP_TO_POINT";
             break;
         case 0x60:
+        {
             event += "GIVE_XP";
-            Events::PushEventData("AMOUNT", std::to_string(PeekMessage<int32_t>(thisPtr, 0)));
-            Events::PushEventData("TARGET", Helpers::ObjectIDToString(PeekMessage<Types::ObjectID>(thisPtr, 4)));
+            static std::string amount;
+            static std::string target;
+            if (before) // Need to persist for AFTER as well
+            {
+                amount = std::to_string(PeekMessage<int32_t>(thisPtr, 0));
+                target = Helpers::ObjectIDToString(PeekMessage<Types::ObjectID>(thisPtr, 4));
+            }
+            Events::PushEventData("AMOUNT", amount);
+            Events::PushEventData("TARGET", target);
             break;
+        }
         case 0x61:
-            Events::PushEventData("NUM_LEVELS", std::to_string(PeekMessage<int32_t>(thisPtr, 0)));
-            Events::PushEventData("TARGET", Helpers::ObjectIDToString(PeekMessage<Types::ObjectID>(thisPtr, 4)));
+        {
             event += "GIVE_LEVEL";
+            static std::string numLevels;
+            static std::string target;
+            if (before) // Need to persist for AFTER as well
+            {
+                numLevels = std::to_string(PeekMessage<int32_t>(thisPtr, 0));
+                target = Helpers::ObjectIDToString(PeekMessage<Types::ObjectID>(thisPtr, 4));
+            }
+            Events::PushEventData("NUM_LEVELS", numLevels);
+            Events::PushEventData("TARGET", target);
             break;
+        }
         case 0x62:
+        {
             event += "GIVE_GOLD";
-            Events::PushEventData("AMOUNT", std::to_string(PeekMessage<int32_t>(thisPtr, 0)));
-            Events::PushEventData("TARGET", Helpers::ObjectIDToString(PeekMessage<Types::ObjectID>(thisPtr, 4)));
+            static std::string amount;
+            static std::string target;
+            if (before) // Need to persist for AFTER as well
+            {
+                amount = std::to_string(PeekMessage<int32_t>(thisPtr, 0));
+                target = Helpers::ObjectIDToString(PeekMessage<Types::ObjectID>(thisPtr, 4));
+            }
+            Events::PushEventData("AMOUNT", amount);
+            Events::PushEventData("TARGET", target);
             break;
+        }
         case 0x63:
         case 0x64: // Not a typo.
             event += "SET_FACTION";

--- a/Plugins/Events/Events/DMActionEvents.cpp
+++ b/Plugins/Events/Events/DMActionEvents.cpp
@@ -104,6 +104,7 @@ void DMActionEvents::HandleDMMessageHook(Services::Hooks::CallType type,
             event += "TOGGLE_IMMORTAL";
             break;
         case 0x50:
+            event += "JUMP_TO_POINT";
             break;
         case 0x60:
             event += "GIVE_XP";
@@ -115,11 +116,10 @@ void DMActionEvents::HandleDMMessageHook(Services::Hooks::CallType type,
             event += "GIVE_GOLD";
             break;
         case 0x63:
-        case 0x64:
+        case 0x64: // Not a typo.
             event += "SET_FACTION";
             break;
         case 0x80:
-            event += "GIVE_ITEM";
             event += "GIVE_ITEM";
             break;
         case 0x81:

--- a/Plugins/Events/Events/DMActionEvents.cpp
+++ b/Plugins/Events/Events/DMActionEvents.cpp
@@ -1,36 +1,157 @@
 #include "Events/DMActionEvents.hpp"
+#include "API/Functions.hpp"
+#include "API/CNWSPlayer.hpp"
 #include "API/CNWSCreature.hpp"
 #include "API/CNWSCreatureStats.hpp"
+#include "API/Types.hpp"
 #include "API/Version.hpp"
+#include "API/Constants.hpp"
 #include "Events.hpp"
 #include "Services/Patching/Patching.hpp"
-
+#include "Helpers.hpp"
 namespace Events {
 
 using namespace NWNXLib;
 using namespace NWNXLib::API;
 using namespace NWNXLib::Platform;
 
-DMActionEvents::DMActionEvents(NWNXLib::ViewPtr<NWNXLib::Services::PatchingProxy> patching)
+DMActionEvents::DMActionEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker)
 {
-    patching->PatchWithCall(0x0818C825, 0x0818C82A - 0x0818C825, &SetExperiencePatch); NWNX_EXPECT_VERSION(8109);
-    patching->PatchWithCall(0x0818C8E2, 0x0818C8E7 - 0x0818C8E2, &AddGoldPatch); NWNX_EXPECT_VERSION(8109);
+    hooker->RequestSharedHook<Functions::CNWSMessage__HandlePlayerToServerDungeonMasterMessage, int32_t,
+        CNWSMessage*, CNWSPlayer*, uint8_t, int32_t>(&HandleDMMessageHook);
 }
 
-void DMActionEvents::SetExperiencePatch(CNWSCreatureStats* stats, uint32_t exp, int32_t doLevel)
+void DMActionEvents::HandleDMMessageHook(Services::Hooks::CallType type,
+    CNWSMessage *thisPtr, CNWSPlayer *pPlayer, uint8_t nMinor, int32_t bGroup)
 {
-    const uint32_t oldExp = stats->m_nExperience;
-    stats->SetExperience(exp, doLevel);
-    Events::PushEventData("OLD_EXP", std::to_string(oldExp));
-    Events::PushEventData("NEW_EXP", std::to_string(exp));
-    Events::SignalEvent("NWNX_ON_DM_SET_EXP", stats->m_pBaseCreature->m_idSelf);
-}
+    // unused variabes
+    (void)(sizeof(thisPtr) & sizeof(bGroup));
 
-void DMActionEvents::AddGoldPatch(CNWSCreature* target, int32_t gold, int32_t display)
-{
-    target->AddGold(gold, display);
-    Events::PushEventData("GOLD", std::to_string(gold));
-    Events::SignalEvent("NWNX_ON_DM_GIVE_GOLD", target->m_idSelf);
+    const char *suffix = (type == Services::Hooks::CallType::BEFORE_ORIGINAL) ? "_BEFORE" : "_AFTER";
+    std::string event = "NWNX_ON_";
+
+    Types::ObjectID oidDM = pPlayer ? pPlayer->m_oidNWSObject : Constants::OBJECT_INVALID;
+
+    switch (nMinor)
+    {
+        case 0x0a:
+            event += "SPAWN_CREATURE";
+            break;
+        case 0x0b:
+            event += "SPAWN_ITEM";
+            break;
+        case 0x0c:
+            event += "SPAWN_TRIGGER";
+            break;
+        case 0x0d:
+            event += "SPAWN_WAYPOINT";
+            break;
+        case 0x0e:
+            event += "SPAWN_ENCOUNTER";
+            break;
+        case 0x0f:
+            event += "SPAWN_PORTAL";
+            break;
+        case 0x10:
+            event += "SPAWN_PLACEABLE";
+            break;
+        case 0x11:
+            event += "CHANGE_DIFFICULTY";
+            break;
+        case 0x12:
+            event += "VIEW_INVENTORY";
+            break;
+        case 0x13:
+            event += "SPAWN_TRAP_ON_OBJECT";
+            break;
+        case 0x20:
+            event += "HEAL";
+            break;
+        case 0x21:
+            event += "KILL";
+            break;
+        case 0x22:
+            event += "JUMP";
+            break;
+        case 0x23:
+            event += "POSSESS";
+            break;
+        case 0x24:
+            event += "TOGGLE_IMMORTAL";
+            break;
+        case 0x25:
+            event += "FORCE_REST";
+            break;
+        case 0x26:
+            event += "LIMBO";
+            break;
+        case 0x2b:
+            event += "TOGGLE_AI";
+            break;
+        case 0x2c:
+            event += "TOGGLE_LOCK";
+            break;
+        case 0x2d:
+            event += "DISABLE_TRAP";
+            break;
+        case 0x30:
+            event += "APPEAR";
+            break;
+        case 0x31:
+            event += "DISAPPEAR";
+            break;
+        case 0x32:
+            event += "TOGGLE_IMMORTAL";
+            break;
+        case 0x50:
+            break;
+        case 0x60:
+            event += "GIVE_XP";
+            break;
+        case 0x61:
+            event += "GIVE_LEVEL";
+            break;
+        case 0x62:
+            event += "GIVE_GOLD";
+            break;
+        case 0x63:
+        case 0x64:
+            event += "SET_FACTION";
+            break;
+        case 0x80:
+            event += "GIVE_ITEM";
+            event += "GIVE_ITEM";
+            break;
+        case 0x81:
+            event += "TAKE_ITEM";
+            break;
+        case 0x82:
+            event += "JUMP_TARGET_TO_POINT";
+            break;
+        case 0x83:
+            event += "JUMP_ALL_PLAYERS_TO_POINT";
+            break;
+        case 0x84:
+            event += "SET_STAT";
+            break;
+        case 0x85:
+            event += "GET_VARIABLE";
+            break;
+        case 0x86:
+            event += "SET_VARIABLE";
+            break;
+        case 0x87:
+            event += "SET_TIME";
+            break;
+        case 0x88:
+            event += "SET_DATE";
+            break;
+
+        default:
+            return;
+    }
+
+    Events::SignalEvent(event + suffix, oidDM);
 }
 
 }

--- a/Plugins/Events/Events/DMActionEvents.hpp
+++ b/Plugins/Events/Events/DMActionEvents.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "API/Types.hpp"
+#include "Services/Hooks/Hooks.hpp"
 #include "Common.hpp"
 #include "ViewPtr.hpp"
 #include <cstdint>
@@ -9,11 +11,11 @@ namespace Events {
 class DMActionEvents
 {
 public:
-    DMActionEvents(NWNXLib::ViewPtr<NWNXLib::Services::PatchingProxy> patching);
+    DMActionEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
 
 private:
-    static void SetExperiencePatch(NWNXLib::API::CNWSCreatureStats*, uint32_t, int32_t);
-    static void AddGoldPatch(NWNXLib::API::CNWSCreature*, int32_t, int32_t);
+    static void HandleDMMessageHook(NWNXLib::Services::Hooks::CallType, 
+        NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*, uint8_t, int32_t);
 };
 
 }


### PR DESCRIPTION
For now, mostly only notify before and after, no arguments are passed. The events are triggered on the DM object.

Give gold/xp/level get their arguments since they are most requested. For others, check before/after etc for now.

~~The old behavior for XP/Gold can be emulated by checking the value on before and after.~~

When the API for skipping events lands, I'll change this to an exclusive hook and then I can properly extract the arguments from the message - ~~CNWSMessage does not have Peek() options, only Pop(). ~~