### PR TITLE
Added updates to build and include the org.nwnx.nwnx2.jvm.jar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,9 @@ jobs:
       - run: CC="gcc -m32" CXX="g++ -m32" cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .
       - run: make all
       - run: Scripts/packageNWScript.sh
-      - run: zip Binaries/NWNX-EE.zip Binaries/NWNX_*.so
-      - run: rm Binaries/NWNX_*.so
+      - run: Scripts/packageJarFile.sh
+      - run: zip Binaries/NWNX-EE.zip Binaries/NWNX_*.so Binaries/*.jar
+      - run: rm Binaries/NWNX_*.so Binaries/*.jar
       - persist_to_workspace:
           root: .
           paths:

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -20,6 +20,7 @@ RUN apt-get install -y ruby-dev
 # NWNX_JVM
 RUN mkdir -p /usr/share/man/man1
 RUN apt-get install -y openjdk-8-jdk-headless
+RUN apt-get install -y ant
 
 # slim down the image again.
 RUN rm -r /var/lib/apt/lists /var/cache/apt

--- a/Scripts/buildnwnx.sh
+++ b/Scripts/buildnwnx.sh
@@ -54,3 +54,4 @@ make ${JOBS} all
 popd
 
 ./Scripts/packageNWScript.sh
+./Scripts/packageJarFile.sh

--- a/Scripts/packageJarFile.sh
+++ b/Scripts/packageJarFile.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+pushd Plugins/JVM/java
+
+ant jar
+
+popd
+
+cp Plugins/JVM/java/dist/org.nwnx.nwnx2.jvm.jar Binaries


### PR DESCRIPTION
The NWNX_JVM plugin requires the org.nwnx.nwnx2.jvm.jar file.  This adds the scripts and updates the builder image to build the jar file.

The CI build is updated to package the .jar file with the .so files for distribution.