### PR TITLE
Modify default Log level to SEV_INFO 

### DIFF
--- a/NWNXLib/Log.cpp
+++ b/NWNXLib/Log.cpp
@@ -91,7 +91,7 @@ Channel::Enum GetLogLevel(const char* plugin)
 {
     // TODO: Is this thread safe? I think so if we're just looking up but I don't know.
     auto entry = s_LogLevelMap.find(plugin);
-    return entry == std::end(s_LogLevelMap) ? Channel::SEV_NOTICE : entry->second;
+    return entry == std::end(s_LogLevelMap) ? Channel::SEV_INFO : entry->second;
 }
 
 void SetLogLevel(const char* plugin, Channel::Enum logLevel)

--- a/Plugins/SQL/SQL.cpp
+++ b/Plugins/SQL/SQL.cpp
@@ -228,12 +228,12 @@ Events::ArgumentStack SQL::OnExecutePreparedQuery(Events::ArgumentStack&&)
         if (m_target->GetAffectedRows() >= 0)
         {
             // this was not a result set type query
-            LOG_INFO("Successful SQL query. Query ID: '%i', Query: '%s', Rows affected: '%u'.",
+            LOG_DEBUG("Successful SQL query. Query ID: '%i', Query: '%s', Rows affected: '%u'.",
                 queryId, m_activeQuery.c_str(), m_target->GetAffectedRows());
         }
         else
         {
-            LOG_INFO("Successful SQL query. Query ID: '%i', Query: '%s', Results Count: '%u'.",
+            LOG_DEBUG("Successful SQL query. Query ID: '%i', Query: '%s', Results Count: '%u'.",
                 queryId, m_activeQuery.c_str(), m_activeResults.size());
         }
     }


### PR DESCRIPTION
Modify default Log level to SEV_INFO to show ServerLogRedirector messages - should sweep NWNX_SQL to review INFO vs DEBUG messages as this plugin seems verbose with lots of info messages