### PR TITLE
Deprecate {Get,Set}EventHandler

### DIFF
--- a/Plugins/Object/NWScript/nwnx_object.nss
+++ b/Plugins/Object/NWScript/nwnx_object.nss
@@ -76,10 +76,12 @@ object NWNX_Object_StringToObject(string id);
 
 // Gets the provided event handler for the provided object.
 // The constant used here will very depending on what type obj is. See NWNX_OBJECT_SCRIPT_* constants.
+// DEPRECATED - Use GetEventScript() built-in function instead
 string NWNX_Object_GetEventHandler(object obj, int handler);
 
 // Sets the provided event handler for the provided object to the provided script.
 // The constant used here will very depending on what type obj is. See NWNX_OBJECT_SCRIPT_* constants.
+// DEPRECATED - Use SetEventScript() built-in function instead
 void NWNX_Object_SetEventHandler(object obj, int handler, string script);
 
 // Set the provided object's position to the provided vector.
@@ -147,24 +149,48 @@ object NWNX_Object_StringToObject(string id)
 
 string NWNX_Object_GetEventHandler(object obj, int handler)
 {
-    string sFunc = "GetEventHandler";
-
-    NWNX_PushArgumentInt(NWNX_Object, sFunc, handler);
-    NWNX_PushArgumentObject(NWNX_Object, sFunc, obj);
-    NWNX_CallFunction(NWNX_Object, sFunc);
-
-    return NWNX_GetReturnValueString(NWNX_Object, sFunc);
+    WriteTimestampedLogEntry("NWNX_Object: GetEventHandler() is deprecated. Use native GetEventScript() instead");
+    switch (GetObjectType(obj))
+    {
+        case OBJECT_TYPE_CREATURE:       handler += 5000;  break;
+        case OBJECT_TYPE_TRIGGER:        handler += 7000;  break;
+        case OBJECT_TYPE_DOOR:           handler += 10000; break;
+        case OBJECT_TYPE_AREA_OF_EFFECT: handler += 11000; break;
+        case OBJECT_TYPE_PLACEABLE:      handler += 9000;  break;
+        case OBJECT_TYPE_STORE:          handler += 14000; break;
+        case OBJECT_TYPE_ENCOUNTER:      handler += 13000; break;
+        default:
+            if (obj == GetModule())
+                handler += 3000;
+            else if (GetIsAreaNatural(obj) != AREA_INVALID)
+                handler += 4000;
+            else
+                return "";
+    }
+    return GetEventScript(obj, handler);
 }
 
 void NWNX_Object_SetEventHandler(object obj, int handler, string script)
 {
-    string sFunc = "SetEventHandler";
-
-    NWNX_PushArgumentString(NWNX_Object, sFunc, script);
-    NWNX_PushArgumentInt(NWNX_Object, sFunc, handler);
-    NWNX_PushArgumentObject(NWNX_Object, sFunc, obj);
-    NWNX_CallFunction(NWNX_Object, sFunc);
-
+    WriteTimestampedLogEntry("NWNX_Object: SetEventHandler() is deprecated. Use native SetEventScript() instead");
+    switch (GetObjectType(obj))
+    {
+        case OBJECT_TYPE_CREATURE:       handler += 5000;  break;
+        case OBJECT_TYPE_TRIGGER:        handler += 7000;  break;
+        case OBJECT_TYPE_DOOR:           handler += 10000; break;
+        case OBJECT_TYPE_AREA_OF_EFFECT: handler += 11000; break;
+        case OBJECT_TYPE_PLACEABLE:      handler += 9000;  break;
+        case OBJECT_TYPE_STORE:          handler += 14000; break;
+        case OBJECT_TYPE_ENCOUNTER:      handler += 13000; break;
+        default:
+            if (obj == GetModule())
+                handler += 3000;
+            else if (GetIsAreaNatural(obj) != AREA_INVALID)
+                handler += 4000;
+            else
+                return;
+    }
+    SetEventScript(obj, handler, script);
 }
 
 void NWNX_Object_SetPosition(object obj, vector pos)

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -61,8 +61,6 @@ Object::Object(const Plugin::CreateParams& params)
     REGISTER(GetLocalVariableCount);
     REGISTER(GetLocalVariable);
     REGISTER(StringToObject);
-    REGISTER(GetEventHandler);
-    REGISTER(SetEventHandler);
     REGISTER(SetPosition);
     REGISTER(SetCurrentHitPoints);
     REGISTER(SetMaxHitPoints);
@@ -108,67 +106,6 @@ static inline CNWSScriptVarTable *_getScriptVarTable(CGameObject *pObject)
             return &static_cast<CNWSObject*>(pObject)->m_ScriptVars;
     }
 }
-static inline CExoString *_getScriptList(CGameObject *pObject, int32_t *pSize)
-{
-    ASSERT(pObject);
-    switch (pObject->m_nObjectType)
-    {
-        case Constants::OBJECT_TYPE_AREA:
-        {
-            CNWSArea *pArea = static_cast<CNWSArea*>(pObject);
-            *pSize = static_cast<int32_t>(std::size(pArea->m_sScripts));
-            return pArea->m_sScripts;
-        }
-        case Constants::OBJECT_TYPE_MODULE:
-        {
-            CNWSModule *pModule = static_cast<CNWSModule*>(pObject);
-            *pSize = static_cast<int32_t>(std::size(pModule->m_sScripts));
-            return pModule->m_sScripts;
-        }
-        case Constants::OBJECT_TYPE_CREATURE:
-        {
-            CNWSCreature *pCreature = static_cast<CNWSCreature*>(pObject);
-            *pSize = static_cast<int32_t>(std::size(pCreature->m_sScripts));
-            return pCreature->m_sScripts;
-        }
-        case Constants::OBJECT_TYPE_PLACEABLE:
-        {
-            CNWSPlaceable *pPlaceable = static_cast<CNWSPlaceable*>(pObject);
-            *pSize = static_cast<int32_t>(std::size(pPlaceable->m_sScripts));
-            return pPlaceable->m_sScripts;
-        }
-        case Constants::OBJECT_TYPE_TRIGGER:
-        {
-            CNWSTrigger *pTrigger = static_cast<CNWSTrigger*>(pObject);
-            *pSize = static_cast<int32_t>(std::size(pTrigger->m_sScripts));
-            return pTrigger->m_sScripts;
-        }
-        case Constants::OBJECT_TYPE_ENCOUNTER:
-        {
-            CNWSEncounter *pEncounter = static_cast<CNWSEncounter*>(pObject);
-            *pSize = static_cast<int32_t>(std::size(pEncounter->m_sScripts));
-            return pEncounter->m_sScripts;
-        }
-        case Constants::OBJECT_TYPE_AREA_OF_EFFECT:
-        {
-            CNWSAreaOfEffectObject *pAreaOfEffectObject = static_cast<CNWSAreaOfEffectObject*>(pObject);
-            *pSize = static_cast<int32_t>(std::size(pAreaOfEffectObject->m_sScripts));
-            return pAreaOfEffectObject->m_sScripts;
-        }
-        case Constants::OBJECT_TYPE_DOOR:
-        {
-            CNWSDoor *pDoor = static_cast<CNWSDoor*>(pObject);
-            *pSize = static_cast<int32_t>(std::size(pDoor->m_sScripts));
-            return pDoor->m_sScripts;
-        }
-
-        default:
-            ASSERT_FAIL_MSG("Object does not have any scripts");
-            *pSize = 0;
-            return nullptr;
-    }
-}
-
 
 ArgumentStack Object::GetLocalVariableCount(ArgumentStack&& args)
 {
@@ -215,54 +152,6 @@ ArgumentStack Object::StringToObject(ArgumentStack&& args)
         retval = Constants::OBJECT_INVALID;
 
     Services::Events::InsertArgument(stack, retval);
-    return stack;
-}
-
-ArgumentStack Object::GetEventHandler(ArgumentStack&& args)
-{
-    ArgumentStack stack;
-    std::string retval = "";
-    if (auto *pObject = object(args))
-    {
-        const auto handler = Services::Events::ExtractArgument<int32_t>(args);
-        int32_t size;
-
-        auto *pScripts = _getScriptList(pObject, &size);
-        if (handler >= 0 && handler < size)
-        {
-            retval = pScripts[handler].CStr();
-        }
-        else
-        {
-            LOG_NOTICE("Invalid script handler id (%d) for object type %s",
-                         handler, Constants::ObjectTypeToString(pObject->m_nObjectType));
-        }
-    }
-    Services::Events::InsertArgument(stack, retval);
-    return stack;
-}
-
-ArgumentStack Object::SetEventHandler(ArgumentStack&& args)
-{
-    ArgumentStack stack;
-    if (auto *pObject = object(args))
-    {
-        const auto handler = Services::Events::ExtractArgument<int32_t>(args);
-        const auto script  = Services::Events::ExtractArgument<std::string>(args);
-
-        int32_t size;
-
-        auto *pScripts = _getScriptList(pObject, &size);
-        if (handler >= 0 && handler < size)
-        {
-            pScripts[handler] = script.c_str();
-        }
-        else
-        {
-            LOG_NOTICE("Invalid script handler id (%d) for object type %s",
-                         handler, Constants::ObjectTypeToString(pObject->m_nObjectType));
-        }
-    }
     return stack;
 }
 

--- a/Plugins/Object/Object.hpp
+++ b/Plugins/Object/Object.hpp
@@ -19,8 +19,6 @@ private:
     ArgumentStack GetLocalVariableCount(ArgumentStack&& args);
     ArgumentStack GetLocalVariable     (ArgumentStack&& args);
     ArgumentStack StringToObject       (ArgumentStack&& args);
-    ArgumentStack GetEventHandler      (ArgumentStack&& args);
-    ArgumentStack SetEventHandler      (ArgumentStack&& args);
     ArgumentStack SetPosition          (ArgumentStack&& args);
     ArgumentStack SetCurrentHitPoints  (ArgumentStack&& args);
     ArgumentStack SetMaxHitPoints      (ArgumentStack&& args);


### PR DESCRIPTION
Implemented in the base game. Add a compatibility layer in the NSS for now, remove the C++ side.