### PR TITLE
Added compatibility with EE per-part coloring (and brief documentation :O)

### DIFF
--- a/NWNXLib/API/Constants.hpp
+++ b/NWNXLib/API/Constants.hpp
@@ -604,6 +604,15 @@ constexpr int32_t ITEM_APPR_ARMOR_MODEL_RHAND =                        16;
 constexpr int32_t ITEM_APPR_ARMOR_MODEL_LHAND =                        17;
 constexpr int32_t ITEM_APPR_ARMOR_MODEL_ROBE =                         18;
 
+
+constexpr int32_t ITEM_APPR_TYPE_SIMPLE_MODEL =                         0;
+constexpr int32_t ITEM_APPR_TYPE_WEAPON_COLOR =                         1;
+constexpr int32_t ITEM_APPR_TYPE_WEAPON_MODEL =                         2;
+constexpr int32_t ITEM_APPR_TYPE_ARMOR_MODEL =                          3;
+constexpr int32_t ITEM_APPR_TYPE_ARMOR_COLOR =                          4;
+constexpr int32_t ITEM_APPR_NUM_TYPES =                                 5;
+
+
 constexpr uint32_t FEAT_ALERTNESS =                                     0;    /* FEAT_0000 */
 constexpr uint32_t FEAT_AMBIDEXTERITY =                                 1;    /* FEAT_0001 */
 constexpr uint32_t FEAT_ARMOR_PROFICIENCY_HEAVY =                       2;    /* FEAT_0002 */

--- a/Plugins/Item/Documentation/README.md
+++ b/Plugins/Item/Documentation/README.md
@@ -1,7 +1,32 @@
 # Item Plugin Reference
 
+## Environment Variables
+
+None
+
 ## Description
 
-Functions exposing additional item properties
+Functions exposing additional item properties.
 
-## Environment Variables
+This plugin allows changing different items properties. Just call the different NWNX_Item_* functions on a valid item target. 
+
+Script function | Description  
+----------------|-------------
+NWNX_Item_SetWeight | Change the weigth of the item. Will not persist through server reset. 
+NWNX_Item_SetBaseGoldPieceValue | Change the item's base value in gold pieces (Total cost = base value + additional value). Will not persist through server reset.
+NWNX_Item_GetBaseGoldPieceValue | Get the item's base value in gold pieces.
+NWNX_Item_SetAddGoldPieceValue | Change the item's additional value in gold pieces (Total cost = base value + additional value). Will persist through server reset.
+NWNX_Item_GetAddGoldPieceValue | Get the item's additional value in gold pieces.
+NWNX_Item_SetBaseItemType | Change the item's base item type (e.g. change an armor into a ring). Changes will not be visible until the item is refreshed (e.g. drop and take the item, or logging out and back in).
+NWNX_Item_SetArmorColor | Change the armor's color. The function allows per-part coloring (new EE feature). Changes will not be visible until the item is refreshed (e.g. drop and take the item, or logging out and back in).
+NWNX_Item_SetWeaponColor | Change the weapon's color. Changes will not be visible until the item is refreshed (e.g. drop and take the item, or logging out and back in).
+NWNX_Item_SetWeaponAppearance | Change the weapon's appearance. Changes will not be visible until the item is refreshed (e.g. drop and take the item, or logging out and back in).
+NWNX_Item_SetArmorAppearance | Change the armor's appearance. Changes will not be visible until the item is refreshed (e.g. drop and take the item, or logging out and back in).
+NWNX_Item_SetItemAppearance | Change item's appearance. A more general function with syntax similar to the NWScript function CopyItemAndModify. Changes will not be visible until the item is refreshed (e.g. drop and take the item, or logging out and back in).
+
+
+
+
+ 
+
+

--- a/Plugins/Item/Item.cpp
+++ b/Plugins/Item/Item.cpp
@@ -1,4 +1,3 @@
-
 // Log currently generates warnings when no arguments are given to format string
 // TODO: Should really clean up the log so it doesn't warn in these cases
 #pragma GCC diagnostic ignored "-Wformat-security"
@@ -278,9 +277,9 @@ ArgumentStack Item::RestoreItemAppearance(ArgumentStack&& args)
 		  pItem->m_nArmorModelPart[idx] = std::stoul(sAppString.substr(stringPos,2), nullptr, 16);
 		  stringPos+=2;
 	       }       
-	     for(texture=0, idx=0; texture<6; texture++)
+	     for(texture=0; texture<6; texture++)
 	       {
-		  for(part=0; part<19; part++, idx++)
+		  for(part=0; part<19; part++)
 		    {
 		       pItem->SetLayeredTextureColorPerPart(texture, part, std::stoul(sAppString.substr(stringPos,2), nullptr, 16));
 		       stringPos+=2;

--- a/Plugins/Item/Item.cpp
+++ b/Plugins/Item/Item.cpp
@@ -19,14 +19,14 @@ static ViewPtr<Item::Item> g_plugin;
 NWNX_PLUGIN_ENTRY Plugin::Info* PluginInfo()
 {
   return new Plugin::Info
-    {
-      "Item",
-	"Functions exposing additional item properties",
-	"Various / sherincall / Bhaal",
-	"marca.argentea at gmail.com",
-	3,
-	true
-    };
+  {
+    "Item",
+    "Functions exposing additional item properties",
+    "Various / sherincall / Bhaal",
+    "marca.argentea at gmail.com",
+    3,
+    true
+  };
 }
 
 NWNX_PLUGIN_ENTRY Plugin* PluginLoad(Plugin::CreateParams params)
@@ -41,7 +41,7 @@ namespace Item {
 Item::Item(const Plugin::CreateParams& params)
   : Plugin(params)
 {
-#define REGISTER(func)							\
+#define REGISTER(func)              \
   GetServices()->m_events->RegisterEvent(#func, std::bind(&Item::func, this, std::placeholders::_1))
 
   REGISTER(SetWeight);
@@ -66,18 +66,18 @@ CNWSItem *Item::item(ArgumentStack& args)
   const auto objectId = Services::Events::ExtractArgument<Types::ObjectID>(args);
 
   if (objectId == Constants::OBJECT_INVALID)
-    {
-      LOG_NOTICE("NWNX_Item function called on OBJECT_INVALID");
-      return nullptr;
-    }
+  {
+    LOG_NOTICE("NWNX_Item function called on OBJECT_INVALID");
+    return nullptr;
+  }
 
 
   auto *pGameObject = Globals::AppManager()->m_pServerExoApp->GetGameObject(objectId);
   if(pGameObject==nullptr || pGameObject->m_nObjectType!=Constants::OBJECT_TYPE_ITEM)
-    {
-      LOG_NOTICE("NWNX_Item function called on non item object");
-      return nullptr;
-    }
+  {
+    LOG_NOTICE("NWNX_Item function called on non item object");
+    return nullptr;
+  }
 
   return static_cast<CNWSItem*>(pGameObject);
 }
@@ -87,10 +87,10 @@ ArgumentStack Item::SetWeight(ArgumentStack&& args)
 {
   ArgumentStack stack;
   if (auto *pItem = item(args))
-    {
-      const auto w = Services::Events::ExtractArgument<int32_t>(args);
-      pItem->m_nWeight = w;
-    }
+  {
+    const auto w = Services::Events::ExtractArgument<int32_t>(args);
+    pItem->m_nWeight = w;
+  }
   return stack;
 }
 
@@ -98,10 +98,10 @@ ArgumentStack Item::SetBaseGoldPieceValue(ArgumentStack&& args)
 {
   ArgumentStack stack;
   if (auto *pItem = item(args))
-    {
-      const auto g = Services::Events::ExtractArgument<int32_t>(args);
-      pItem->m_nBaseUnitCost = g;
-    }
+  {
+    const auto g = Services::Events::ExtractArgument<int32_t>(args);
+    pItem->m_nBaseUnitCost = g;
+  }
   return stack;
 }
 
@@ -109,10 +109,10 @@ ArgumentStack Item::SetAddGoldPieceValue(ArgumentStack&& args)
 {
   ArgumentStack stack;
   if (auto *pItem = item(args))
-    {
-      const auto g = Services::Events::ExtractArgument<int32_t>(args);
-      pItem->m_nAdditionalCost = g;
-    }
+  {
+    const auto g = Services::Events::ExtractArgument<int32_t>(args);
+    pItem->m_nAdditionalCost = g;
+  }
   return stack;
 }
 
@@ -121,9 +121,9 @@ ArgumentStack Item::GetBaseGoldPieceValue(ArgumentStack&& args)
   ArgumentStack stack;
   int32_t retval = -1;
   if (auto *pItem = item(args))
-    {
-      retval = pItem->m_nBaseUnitCost;
-    }
+  {
+    retval = pItem->m_nBaseUnitCost;
+  }
   Services::Events::InsertArgument(stack, retval);
   return stack;
 }
@@ -133,9 +133,9 @@ ArgumentStack Item::GetAddGoldPieceValue(ArgumentStack&& args)
   ArgumentStack stack;
   int32_t retval = -1;
   if (auto *pItem = item(args))
-    {
-      retval = pItem->m_nAdditionalCost;
-    }
+  {
+    retval = pItem->m_nAdditionalCost;
+  }
   Services::Events::InsertArgument(stack, retval);
   return stack;
 }
@@ -144,10 +144,10 @@ ArgumentStack Item::SetBaseItemType(ArgumentStack&& args)
 {
   ArgumentStack stack;
   if (auto *pItem = item(args))
-    {
-      const auto bt = Services::Events::ExtractArgument<int32_t>(args);
-      pItem->m_nBaseItem = bt;
-    }
+  {
+    const auto bt = Services::Events::ExtractArgument<int32_t>(args);
+    pItem->m_nBaseItem = bt;
+  }
   return stack;
 }
 
@@ -155,58 +155,58 @@ ArgumentStack Item::SetItemAppearance(ArgumentStack&& args)
 {
   ArgumentStack stack;
   if(auto *pItem = item(args))
-     {
-        const auto type = Services::Events::ExtractArgument<int32_t>(args);
-        const auto idx   = Services::Events::ExtractArgument<int32_t>(args);
-        const auto val   = Services::Events::ExtractArgument<int32_t>(args);
-	
-        switch(type)
+  {
+    const auto type = Services::Events::ExtractArgument<int32_t>(args);
+    const auto idx   = Services::Events::ExtractArgument<int32_t>(args);
+    const auto val   = Services::Events::ExtractArgument<int32_t>(args);
+
+    switch(type)
+    {
+      case Constants::ITEM_APPR_TYPE_SIMPLE_MODEL :
+        if(val>0)
+        {       
+          pItem->m_nModelPart[0] = val;
+        }       
+        break;
+
+      case Constants::ITEM_APPR_TYPE_WEAPON_COLOR :
+        if(val>=0 && val <= 255 && idx>=0 && idx<= 5)
+        {
+          pItem->m_nLayeredTextureColors[idx] = val;
+        }
+        break;
+      case Constants::ITEM_APPR_TYPE_WEAPON_MODEL :
+        if(val>=0 && idx>=0 && idx<= 2)
+        {
+          pItem->m_nModelPart[idx] = val;
+        }
+        break;
+      case Constants::ITEM_APPR_TYPE_ARMOR_MODEL :
+        if(val>=0 && idx>=0 && idx<= 18)
+        {
+          pItem->m_nArmorModelPart[idx] = val;
+        }
+        break;
+      case Constants::ITEM_APPR_TYPE_ARMOR_COLOR :
+        if(val>=0 && val<=255 && idx>=0 && idx<= 119)
+        {
+          if(idx<=5) //1.69 colors 
           {
-	   case Constants::ITEM_APPR_TYPE_SIMPLE_MODEL :
-	     if(val>0)
-	       {		  
-		  pItem->m_nModelPart[0] = val;
-	       }	     
-	     break;
-	     
-	   case Constants::ITEM_APPR_TYPE_WEAPON_COLOR :
-	     if(val>=0 && val <= 255 && idx>=0 && idx<= 5)
-	       {
-		  pItem->m_nLayeredTextureColors[idx] = val;
-	       }
-	     break;
-	   case Constants::ITEM_APPR_TYPE_WEAPON_MODEL :
-	     if(val>=0 && idx>=0 && idx<= 2)
-	       {
-		  pItem->m_nModelPart[idx] = val;
-	       }
-	     break;
-	   case Constants::ITEM_APPR_TYPE_ARMOR_MODEL :
-	     if(val>=0 && idx>=0 && idx<= 18)
-	       {
-		  pItem->m_nArmorModelPart[idx] = val;
-	       }
-	     break;
-	   case Constants::ITEM_APPR_TYPE_ARMOR_COLOR :
-	     if(val>=0 && val<=255 && idx>=0 && idx<= 119)
-	       {
-		  if(idx<=5) //1.69 colors 
-		    {
-		       pItem->m_nLayeredTextureColors[idx]=val;
-		    }
-		  else //per-part coloring
-		    {
-		       char part = (char)((idx-6)/6);
-		       char texture = (char)(idx-6-part*6);
-		       pItem->SetLayeredTextureColorPerPart(texture, part, val);
-		    }
-	       }
-	     break;
-	  }
-     }
-   return stack;
+            pItem->m_nLayeredTextureColors[idx]=val;
+          }
+          else //per-part coloring
+          {
+            char part = (char)((idx-6)/6);
+            char texture = (char)(idx-6-part*6);
+            pItem->SetLayeredTextureColorPerPart(texture, part, val);
+          }
+        }
+        break;
+    }
+  }
+  return stack;
 }
-   
+
 ArgumentStack Item::GetEntireItemAppearance(ArgumentStack&& args)
 {
   ArgumentStack stack;
@@ -214,84 +214,89 @@ ArgumentStack Item::GetEntireItemAppearance(ArgumentStack&& args)
   char buf[4];
   int idx; 
   char part, texture;
-   
+
 
   if (auto *pItem = item(args))
+  {
+    for(idx = 0; idx < 6; idx++)
     {
-      for(idx = 0; idx < 6; idx++)
-	{
-	  sprintf(buf, "%02X", pItem->m_nLayeredTextureColors[idx]);
-	  retval << buf;
-	}
-
-      for(idx = 0; idx < 3; idx++)
-	{
-	  sprintf(buf, "%02X", pItem->m_nModelPart[idx]);
-	  retval << buf;
-	}
-      for(idx = 0; idx < 19; idx++)
-	{
-	  sprintf(buf, "%02X", pItem->m_nArmorModelPart[idx]);
-	  retval << buf;
-	}
-      for(texture=0; texture<6; texture++)
-	 {
-	    for(part=0; part<19; part++)
-	      {
-		 sprintf(buf, "%02X", pItem->GetLayeredTextureColorPerPart(texture, part));
-		 retval << buf;
-	      }
-	 }  
+      sprintf(buf, "%02X", pItem->m_nLayeredTextureColors[idx]);
+      retval << buf;
     }
 
-  Services::Events::InsertArgument(stack, retval.str());
-  return stack;
+    for(idx = 0; idx < 3; idx++)
+    {
+      sprintf(buf, "%02X", pItem->m_nModelPart[idx]);
+      retval << buf;
+    }
+    for(idx = 0; idx < 19; idx++)
+    {
+      sprintf(buf, "%02X", pItem->m_nArmorModelPart[idx]);
+      retval << buf;
+    }
+    for(texture=0; texture<6; texture++)
+    {
+      for(part=0; part<19; part++)
+      {
+       sprintf(buf, "%02X", pItem->GetLayeredTextureColorPerPart(texture, part));
+       retval << buf;
+     }
+   }  
+ }
+
+ Services::Events::InsertArgument(stack, retval.str());
+ return stack;
 }
 
 ArgumentStack Item::RestoreItemAppearance(ArgumentStack&& args)
 {
-   ArgumentStack stack;
+  ArgumentStack stack;
 
-   if (auto *pItem = item(args))
-     {
-	const auto sAppString = Services::Events::ExtractArgument<std::string>(args);
-	int idx;
-	int stringPos=0;
-	char texture, part;
-	
-	if(sAppString.length()==2*142)
-	  {
-	     for(idx = 0; idx < 6; idx++)
-	       {
-		  pItem->m_nLayeredTextureColors[idx] = std::stoul(sAppString.substr(stringPos,2), nullptr, 16);
-		  stringPos+=2;
-	       }
-	     
-	     for(idx = 0; idx < 3; idx++)
-	       {
-		  pItem->m_nModelPart[idx] = std::stoul(sAppString.substr(stringPos,2), nullptr, 16);
-		  stringPos+=2;
-	       }
-	     for(idx = 0; idx < 19; idx++)
-	       {
-		  pItem->m_nArmorModelPart[idx] = std::stoul(sAppString.substr(stringPos,2), nullptr, 16);
-		  stringPos+=2;
-	       }       
-	     for(texture=0; texture<6; texture++)
-	       {
-		  for(part=0; part<19; part++)
-		    {
-		       pItem->SetLayeredTextureColorPerPart(texture, part, std::stoul(sAppString.substr(stringPos,2), nullptr, 16));
-		       stringPos+=2;
-		    }
-	       }
-	  }
-     }
-   else
-     {
-	LOG_NOTICE("RestoreItemAppearance: invalid string length, must be 284");
-     }
-   return stack;
+  if (auto *pItem = item(args))
+  {
+    const auto sAppString = Services::Events::ExtractArgument<std::string>(args);
+    int  idx;
+    int  stringPos=0;
+    char texture, part;
+    int  strLength = sAppString.length(); 
+
+    
+    if(strLength==2*142 || strLength==2*28)
+    {
+      for(idx = 0; idx < 6; idx++)
+      {
+        pItem->m_nLayeredTextureColors[idx] = std::stoul(sAppString.substr(stringPos,2), nullptr, 16);
+        stringPos+=2;
+      }
+
+      for(idx = 0; idx < 3; idx++)
+      {
+        pItem->m_nModelPart[idx] = std::stoul(sAppString.substr(stringPos,2), nullptr, 16);
+        stringPos+=2;
+      }
+      for(idx = 0; idx < 19; idx++)
+      {
+        pItem->m_nArmorModelPart[idx] = std::stoul(sAppString.substr(stringPos,2), nullptr, 16);
+        stringPos+=2;
+      }       
+      if(strLength==2*142)
+      {
+        for(texture=0; texture<6; texture++)
+        {
+          for(part=0; part<19; part++)
+          {
+            pItem->SetLayeredTextureColorPerPart(texture, part, std::stoul(sAppString.substr(stringPos,2), nullptr, 16));
+            stringPos+=2;
+          }
+        }  
+      }
+    }
+  }
+  else
+  {
+    LOG_NOTICE("RestoreItemAppearance: invalid string length, must be 284");
+  }
+  return stack;
 }
-   
+
 }

--- a/Plugins/Item/NWScript/nwnx_item.nss
+++ b/Plugins/Item/NWScript/nwnx_item.nss
@@ -46,7 +46,7 @@ void NWNX_Item_SetArmorColor(object oItem, int nIndex, int nColor);
 // Set a color value on a weapon. This will not be visible to PCs until
 // the item is refreshed for them (e.g. by logging out and back in).
 // nIndex: ITEM_APPR_WEAPON_COLOR_*
-// nColor range: 1-4
+// nColor range: 0-255
 void NWNX_Item_SetWeaponColor(object oItem, int nIndex, int nColor);
 
 // Set an appearance value on a weapon. This will not be visible to PCs until

--- a/Plugins/Item/NWScript/nwnx_item.nss
+++ b/Plugins/Item/NWScript/nwnx_item.nss
@@ -27,37 +27,62 @@ void NWNX_Item_SetBaseItemType(object oItem, int nBaseItem);
 
 // Set a color value on an armor. This will not be visible to PCs until
 // the item is refreshed for them (e.g. by logging out and back in).
-// nIndex: ITEM_APPR_ARMOR_COLOR_*
-// nColor range: [0, 175]
-// NOTE: Equivalent to SetItemColor NWNX2 function
+// nIndex: ITEM_APPR_ARMOR_COLOR_*    [0]
+// nColor range: 0-255                [1]
+// 
+// [0] Alternatively, if per-part coloring is desired, the following equation can be used 
+// for nIndex to achieve that: 
+//
+//   ITEM_APPR_ARMOR_NUM_COLORS + (ITEM_APPR_ARMOR_MODEL_ * ITEM_APPR_ARMOR_NUM_COLORS) + ITEM_APPR_ARMOR_COLOR_
+//
+// For example, to change the CLOTH1 channel of the torso, nIndex would be:
+//
+//   6 + (7 * 6) + 2 = 50
+//
+// [1] When specifying per-part coloring, the value 255 corresponds with the logical
+// function 'clear colour override', which clears the per-part override for that part.
 void NWNX_Item_SetArmorColor(object oItem, int nIndex, int nColor);
 
 // Set a color value on a weapon. This will not be visible to PCs until
 // the item is refreshed for them (e.g. by logging out and back in).
 // nIndex: ITEM_APPR_WEAPON_COLOR_*
-// nColor range: [1, 4]
+// nColor range: 1-4
 void NWNX_Item_SetWeaponColor(object oItem, int nIndex, int nColor);
 
 // Set an appearance value on a weapon. This will not be visible to PCs until
 // the item is refreshed for them (e.g. by logging out and back in).
 // nIndex: ITEM_APPR_WEAPON_MODEL_* 
-// nValue range: [0,255]
+// nValue range: 0-255
 void NWNX_Item_SetWeaponAppearance(object oItem, int nIndex, int nValue);
 
 // Set an appearance value on an armor. This will not be visible to PCs until
 // the item is refreshed for them (e.g. by logging out and back in).
 // nIndex: ITEM_APPR_ARMOR_MODEL_* 
-// nValue range: [0,255]
+// nValue range: 0-255
 void NWNX_Item_SetArmorAppearance(object oItem, int nIndex, int nValue);
 
-// Set an appearance value on an item. This will not be visible to PCs until
+// Make a single change to the appearance of an item. This will not be visible to PCs until
 // the item is refreshed for them (e.g. by logging out and back in).
-// nIndex range:
-//    - Color:   [0,  5]
-//    - Weapons: [6,  8]
-//    - Armor:   [9, 28]
-// nValue range: [0,255]
-void NWNX_Item_SetItemAppearance(object oItem, int nIndex, int nValue);
+// Helmet models and simple items ignore iIndex.
+// nType                            nIndex                              nValue
+// ITEM_APPR_TYPE_SIMPLE_MODEL      [Ignored]                           Model #
+// ITEM_APPR_TYPE_WEAPON_COLOR      ITEM_APPR_WEAPON_COLOR_*            0-255
+// ITEM_APPR_TYPE_WEAPON_MODEL      ITEM_APPR_WEAPON_MODEL_*            Model #
+// ITEM_APPR_TYPE_ARMOR_MODEL       ITEM_APPR_ARMOR_MODEL_*             Model #
+// ITEM_APPR_TYPE_ARMOR_COLOR       ITEM_APPR_ARMOR_COLOR_* [0]         0-255 [1]
+//
+// [0] Alternatively, where ITEM_APPR_TYPE_ARMOR_COLOR is specified, if per-part coloring is
+// desired, the following equation can be used for nIndex to achieve that:
+// 
+// ITEM_APPR_ARMOR_NUM_COLORS + (ITEM_APPR_ARMOR_MODEL_ * ITEM_APPR_ARMOR_NUM_COLORS) + ITEM_APPR_ARMOR_COLOR_
+// 
+// For example, to change the CLOTH1 channel of the torso, nIndex would be:
+// 
+//     6 + (7 * 6) + 2 = 50
+// 
+// [1] When specifying per-part coloring, the value 255 corresponds with the logical
+// function 'clear colour override', which clears the per-part override for that part.
+void NWNX_Item_SetItemAppearance(object oItem, int nType, int nIndex, int nValue);
 
 /* Return a string containing the entire appearance for oItem which can later be
  * passed to RestoreItemAppearance(). */
@@ -128,11 +153,10 @@ void NWNX_Item_SetBaseItemType(object oItem, int nBaseItem)
     
 void NWNX_Item_SetArmorColor(object oItem, int nIndex, int nColor)
 {
-    if(nIndex>=ITEM_APPR_ARMOR_COLOR_LEATHER1 &&
-       nIndex<=ITEM_APPR_ARMOR_COLOR_METAL2 &&
-       nColor>=0 && nColor<=175)
+    if(nIndex>=0 && nIndex<126 &&
+       nColor>=0 && nColor<=255)
     {
-        NWNX_Item_SetItemAppearance(oItem, nIndex, nColor);
+        NWNX_Item_SetItemAppearance(oItem, ITEM_APPR_TYPE_ARMOR_COLOR, nIndex, nColor);
     }
 }
 
@@ -140,9 +164,9 @@ void NWNX_Item_SetWeaponColor(object oItem, int nIndex, int nColor)
 {
     if(nIndex>=ITEM_APPR_WEAPON_COLOR_BOTTOM &&
        nIndex<=ITEM_APPR_WEAPON_COLOR_TOP &&
-       nColor>=1 && nColor<=4)
+       nColor>=0 && nColor<=255)
     {
-        NWNX_Item_SetItemAppearance(oItem, nIndex, nColor);
+        NWNX_Item_SetItemAppearance(oItem, ITEM_APPR_TYPE_WEAPON_COLOR, nIndex, nColor);
     }
 }
 
@@ -150,28 +174,29 @@ void NWNX_Item_SetWeaponAppearance(object oItem, int nIndex, int nValue)
 {
     if(nIndex>=ITEM_APPR_WEAPON_MODEL_BOTTOM &&
        nIndex<=ITEM_APPR_WEAPON_MODEL_TOP &&
-       nValue>=0 && nValue<=255)
+       nValue>=0)
     {
-        NWNX_Item_SetItemAppearance(oItem, nIndex + 6, nValue);
+        NWNX_Item_SetItemAppearance(oItem, ITEM_APPR_TYPE_WEAPON_MODEL, nIndex, nValue);
     }  
 }
 
 void NWNX_Item_SetArmorAppearance(object oItem, int nIndex, int nValue)
 {
     if(nIndex>=ITEM_APPR_ARMOR_MODEL_RFOOT &&
-       nIndex<=ITEM_APPR_ARMOR_MODEL_ROBE &&
-       nValue>=0 && nValue<=255)
+       nIndex<=ITEM_APPR_ARMOR_MODEL_ROBE
+       nValue>=0)
     {
-        NWNX_Item_SetItemAppearance(oItem, nIndex + 9, nValue);
+        NWNX_Item_SetItemAppearance(oItem, ITEM_APPR_TYPE_ARMOR_MODEL, nIndex, nValue);
     }  
 }
 
-void NWNX_Item_SetItemAppearance(object oItem, int nIndex, int nValue)
+void NWNX_Item_SetItemAppearance(object oItem, int nType, int nIndex, int nValue)
 {
     string sFunc = "SetItemAppearance";
   
     NWNX_PushArgumentInt(NWNX_Item, sFunc, nValue);
     NWNX_PushArgumentInt(NWNX_Item, sFunc, nIndex);
+    NWNX_PushArgumentInt(NWNX_Item, sFunc, nType);
     NWNX_PushArgumentObject(NWNX_Item, sFunc, oItem);
 
     NWNX_CallFunction(NWNX_Item, sFunc);


### PR DESCRIPTION
For example:

```C
// Make a single change to the appearance of an item. This will not be visible to PCs until
// the item is refreshed for them (e.g. by logging out and back in).
// Helmet models and simple items ignore iIndex.
// nType                            nIndex                              nValue
// ITEM_APPR_TYPE_SIMPLE_MODEL      [Ignored]                           Model #
// ITEM_APPR_TYPE_WEAPON_COLOR      ITEM_APPR_WEAPON_COLOR_*            0-255
// ITEM_APPR_TYPE_WEAPON_MODEL      ITEM_APPR_WEAPON_MODEL_*            Model #
// ITEM_APPR_TYPE_ARMOR_MODEL       ITEM_APPR_ARMOR_MODEL_*             Model #
// ITEM_APPR_TYPE_ARMOR_COLOR       ITEM_APPR_ARMOR_COLOR_* [0]         0-255 [1]
//
// [0] Alternatively, where ITEM_APPR_TYPE_ARMOR_COLOR is specified, if per-part coloring is
// desired, the following equation can be used for nIndex to achieve that:
//
// ITEM_APPR_ARMOR_NUM_COLORS + (ITEM_APPR_ARMOR_MODEL_ * ITEM_APPR_ARMOR_NUM_COLORS) + ITEM_APPR_ARMOR_COLOR_
//
// For example, to change the CLOTH1 channel of the torso, nIndex would be:
//
//     6 + (7 * 6) + 2 = 50
//
// [1] When specifying per-part coloring, the value 255 corresponds with the logical
// function 'clear colour override', which clears the per-part override for that part.
void NWNX_Item_SetItemAppearance(object oItem, int nType, int nIndex, int nValue);
```

