### PR TITLE
Removed a few redundant calls in nwnx_items.nss.

### DIFF
--- a/Plugins/Item/Documentation/README.md
+++ b/Plugins/Item/Documentation/README.md
@@ -18,10 +18,6 @@ NWNX_Item_GetBaseGoldPieceValue | Get the item's base value in gold pieces.
 NWNX_Item_SetAddGoldPieceValue | Change the item's additional value in gold pieces (Total cost = base value + additional value). Will persist through server reset.
 NWNX_Item_GetAddGoldPieceValue | Get the item's additional value in gold pieces.
 NWNX_Item_SetBaseItemType | Change the item's base item type (e.g. change an armor into a ring). Changes will not be visible until the item is refreshed (e.g. drop and take the item, or logging out and back in).
-NWNX_Item_SetArmorColor | Change the armor's color. The function allows per-part coloring (new EE feature). Changes will not be visible until the item is refreshed (e.g. drop and take the item, or logging out and back in).
-NWNX_Item_SetWeaponColor | Change the weapon's color. Changes will not be visible until the item is refreshed (e.g. drop and take the item, or logging out and back in).
-NWNX_Item_SetWeaponAppearance | Change the weapon's appearance. Changes will not be visible until the item is refreshed (e.g. drop and take the item, or logging out and back in).
-NWNX_Item_SetArmorAppearance | Change the armor's appearance. Changes will not be visible until the item is refreshed (e.g. drop and take the item, or logging out and back in).
 NWNX_Item_SetItemAppearance | Change item's appearance. A more general function with syntax similar to the NWScript function CopyItemAndModify. Changes will not be visible until the item is refreshed (e.g. drop and take the item, or logging out and back in).
 
 

--- a/Plugins/Item/NWScript/nwnx_item.nss
+++ b/Plugins/Item/NWScript/nwnx_item.nss
@@ -25,42 +25,6 @@ int NWNX_Item_GetAddGoldPieceValue(object oItem);
 // and back in).
 void NWNX_Item_SetBaseItemType(object oItem, int nBaseItem);
 
-// Set a color value on an armor. This will not be visible to PCs until
-// the item is refreshed for them (e.g. by logging out and back in).
-// nIndex: ITEM_APPR_ARMOR_COLOR_*    [0]
-// nColor range: 0-255                [1]
-// 
-// [0] Alternatively, if per-part coloring is desired, the following equation can be used 
-// for nIndex to achieve that: 
-//
-//   ITEM_APPR_ARMOR_NUM_COLORS + (ITEM_APPR_ARMOR_MODEL_ * ITEM_APPR_ARMOR_NUM_COLORS) + ITEM_APPR_ARMOR_COLOR_
-//
-// For example, to change the CLOTH1 channel of the torso, nIndex would be:
-//
-//   6 + (7 * 6) + 2 = 50
-//
-// [1] When specifying per-part coloring, the value 255 corresponds with the logical
-// function 'clear colour override', which clears the per-part override for that part.
-void NWNX_Item_SetArmorColor(object oItem, int nIndex, int nColor);
-
-// Set a color value on a weapon. This will not be visible to PCs until
-// the item is refreshed for them (e.g. by logging out and back in).
-// nIndex: ITEM_APPR_WEAPON_COLOR_*
-// nColor range: 0-255
-void NWNX_Item_SetWeaponColor(object oItem, int nIndex, int nColor);
-
-// Set an appearance value on a weapon. This will not be visible to PCs until
-// the item is refreshed for them (e.g. by logging out and back in).
-// nIndex: ITEM_APPR_WEAPON_MODEL_* 
-// nValue range: 0-255
-void NWNX_Item_SetWeaponAppearance(object oItem, int nIndex, int nValue);
-
-// Set an appearance value on an armor. This will not be visible to PCs until
-// the item is refreshed for them (e.g. by logging out and back in).
-// nIndex: ITEM_APPR_ARMOR_MODEL_* 
-// nValue range: 0-255
-void NWNX_Item_SetArmorAppearance(object oItem, int nIndex, int nValue);
-
 // Make a single change to the appearance of an item. This will not be visible to PCs until
 // the item is refreshed for them (e.g. by logging out and back in).
 // Helmet models and simple items ignore iIndex.
@@ -149,45 +113,6 @@ void NWNX_Item_SetBaseItemType(object oItem, int nBaseItem)
     NWNX_PushArgumentObject(NWNX_Item, sFunc, oItem);
     
     NWNX_CallFunction(NWNX_Item, sFunc);
-}
-    
-void NWNX_Item_SetArmorColor(object oItem, int nIndex, int nColor)
-{
-    if(nIndex>=0 && nIndex<126 &&
-       nColor>=0 && nColor<=255)
-    {
-        NWNX_Item_SetItemAppearance(oItem, ITEM_APPR_TYPE_ARMOR_COLOR, nIndex, nColor);
-    }
-}
-
-void NWNX_Item_SetWeaponColor(object oItem, int nIndex, int nColor)
-{
-    if(nIndex>=ITEM_APPR_WEAPON_COLOR_BOTTOM &&
-       nIndex<=ITEM_APPR_WEAPON_COLOR_TOP &&
-       nColor>=0 && nColor<=255)
-    {
-        NWNX_Item_SetItemAppearance(oItem, ITEM_APPR_TYPE_WEAPON_COLOR, nIndex, nColor);
-    }
-}
-
-void NWNX_Item_SetWeaponAppearance(object oItem, int nIndex, int nValue)
-{
-    if(nIndex>=ITEM_APPR_WEAPON_MODEL_BOTTOM &&
-       nIndex<=ITEM_APPR_WEAPON_MODEL_TOP &&
-       nValue>=0)
-    {
-        NWNX_Item_SetItemAppearance(oItem, ITEM_APPR_TYPE_WEAPON_MODEL, nIndex, nValue);
-    }  
-}
-
-void NWNX_Item_SetArmorAppearance(object oItem, int nIndex, int nValue)
-{
-    if(nIndex>=ITEM_APPR_ARMOR_MODEL_RFOOT &&
-       nIndex<=ITEM_APPR_ARMOR_MODEL_ROBE
-       nValue>=0)
-    {
-        NWNX_Item_SetItemAppearance(oItem, ITEM_APPR_TYPE_ARMOR_MODEL, nIndex, nValue);
-    }  
 }
 
 void NWNX_Item_SetItemAppearance(object oItem, int nType, int nIndex, int nValue)


### PR DESCRIPTION
These calls wrap a call to another function, but there are problems with this:

- There is input validation (which is mirrored in C++) which will silently swallow an error. It will still silently swallow an error afte this change, but at least the logic isn't duplicated twice.
- It seems just as easy for me for users to call SetItemAppearance() with the constant they need, so I don't feel these wrappers add anything by way of user friendliness.

What do you guys think about this? Wherever possible I want to keep the nwnx_* files wrapping actual function calls unless there's a big case to be made for the user friendliness wins.