### PR TITLE
Assert improvements

### DIFF
--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -337,6 +337,12 @@ void NWNXCore::CreateServerHandler(API::CAppManager* app)
     // We need to set the NWNXLib log level (separate from Core now) to match the core log level.
     Log::SetLogLevel("NWNXLib", Log::GetLogLevel(NWNX_CORE_PLUGIN_NAME));
 
+    Maybe<bool> crashOnAssertFailure = g_core->m_coreServices->m_config->Get<bool>("CRASH_ON_ASSERT_FAILURE");
+    if (crashOnAssertFailure)
+    {
+        Assert::SetCrashOnFailure(*crashOnAssertFailure);
+    }
+
     if (g_core->m_coreServices->m_config->Get<bool>("SKIP", false))
     {
         LOG_NOTICE("Not loading NWNX due to configuration.");

--- a/NWNXLib/Assert.hpp
+++ b/NWNXLib/Assert.hpp
@@ -36,6 +36,8 @@ void Fail(const char* condition, const char* file, int line, const char* message
 template <typename ... Args>
 void Fail(const char* condition, const char* file, int line, const char* format, Args ... args);
 
+void SetCrashOnFailure(bool crash);
+
 #include "Assert.inl"
 
 }

--- a/NWNXLib/Log.cpp
+++ b/NWNXLib/Log.cpp
@@ -1,10 +1,8 @@
 #include "Log.hpp"
 #include "Assert.hpp"
 #include "Platform/FileSystem.hpp"
+#include "Platform/Debug.hpp"
 
-#ifdef _WIN32
-    #include "Windows.h"
-#endif
 
 #include <cstring>
 #include <unordered_map>
@@ -13,14 +11,6 @@ namespace NWNXLib {
 
 namespace Log {
 
-void InternalOutputDebugString(const char* str)
-{
-#ifdef _WIN32
-    OutputDebugStringA(str);
-#else
-    (void)str;
-#endif
-}
 
 void Trace(Channel::Enum channel, const char* plugin, const char* file, int line, const char* message)
 {
@@ -71,9 +61,9 @@ void InternalTrace(Channel::Enum channel, Channel::Enum allowedChannel, const ch
         std::fclose(logFile);
     }
 
-    InternalOutputDebugString(buffer);
-    InternalOutputDebugString(message);
-    InternalOutputDebugString("\n");
+    Platform::Debug::OutputDebugString(buffer);
+    Platform::Debug::OutputDebugString(message);
+    Platform::Debug::OutputDebugString("\n");
 
     if (channel == Channel::SEV_FATAL)
     {

--- a/NWNXLib/Platform/CMakeLists.txt
+++ b/NWNXLib/Platform/CMakeLists.txt
@@ -5,4 +5,5 @@ nwnxlib_add(
     "FileSystem.cpp"
     "Memory.cpp"
     "Syslog.cpp"
-    "Time.cpp")
+    "Time.cpp"
+    "Debug.cpp")

--- a/NWNXLib/Platform/Debug.cpp
+++ b/NWNXLib/Platform/Debug.cpp
@@ -49,20 +49,21 @@ void OutputDebugString(const char *str)
 
 std::string GetStackTrace(uint8_t levels)
 {
-    char buffer[2048] = {};
+    char buffer[64*1024];
     void* stackTrace[256];
 
+    buffer[0] = 0;
 #ifdef _WIN32
     int numCapturedFrames = CaptureStackBackTrace(0, levels, stackTrace, NULL);
 
     if (numCapturedFrames)
     {
-        std::strcat(buffer, "\n  Backtrace:\n");
+        std::strncat(buffer, "\n  Backtrace:\n", sizeof(buffer)-1);
         for (int i = 0; i < numCapturedFrames; ++i)
         {
             char backtraceBuffer[32];
-            std::sprintf(backtraceBuffer, "    [0x%p]\n", stackTrace[i]);
-            std::strcat(buffer, backtraceBuffer);
+            std::snprintf(backtraceBuffer, sizeof(backtraceBuffer), "    [0x%p]\n", stackTrace[i]);
+            std::strncat(buffer, backtraceBuffer, sizeof(buffer)-1);
         }
     }
 #else
@@ -71,12 +72,12 @@ std::string GetStackTrace(uint8_t levels)
     if (numCapturedFrames)
     {
         char** resolvedFrames = backtrace_symbols(stackTrace, levels);
-        std::strcat(buffer, "\n  Backtrace:\n");
+        std::strncat(buffer, "\n  Backtrace:\n", sizeof(buffer)-1);
         for (int i = 0; i < numCapturedFrames; ++i)
         {
-            char backtraceBuffer[256];
-            std::sprintf(backtraceBuffer, "    %s\n", resolvedFrames[i]);
-            std::strcat(buffer, backtraceBuffer);
+            char backtraceBuffer[2048];
+            std::snprintf(backtraceBuffer, sizeof(backtraceBuffer), "    %s\n", resolvedFrames[i]);
+            std::strncat(buffer, backtraceBuffer, sizeof(buffer)-1);
         }
     }
 #endif // _WIN32

--- a/NWNXLib/Platform/Debug.cpp
+++ b/NWNXLib/Platform/Debug.cpp
@@ -1,0 +1,90 @@
+#include "Platform/Debug.hpp"
+#include <cstring>
+#include <cstdio>
+
+#ifdef _WIN32
+    #include "Windows.h"
+#else
+    #include <execinfo.h>
+    #include <signal.h>
+#endif
+
+namespace NWNXLib {
+
+namespace Platform {
+
+namespace Debug {
+
+bool IsDebuggerPresent()
+{
+#ifdef _WIN32
+    return ::IsDebuggerPresent();
+#else
+    bool present = false;
+    char buf[1024] = {};
+
+    FILE *f = fopen("/proc/self/status", "r");
+    if (f == NULL)
+        return false;
+
+    if (fread(buf, 1, sizeof(buf)-1, f))
+    {
+        char *tracer_pid = strstr(buf, "TracerPid:");
+        if (tracer_pid)
+            present = !!atoi(tracer_pid + sizeof("TracerPid:") - 1);
+    }
+    fclose(f);
+    return present;
+#endif
+}
+
+void OutputDebugString(const char *str)
+{
+#ifdef _WIN32
+    OutputDebugStringA(str);
+#else
+    (void)str;
+#endif
+}
+
+std::string GetStackTrace(uint8_t levels)
+{
+    char buffer[2048] = {};
+    void* stackTrace[256];
+
+#ifdef _WIN32
+    int numCapturedFrames = CaptureStackBackTrace(0, levels, stackTrace, NULL);
+
+    if (numCapturedFrames)
+    {
+        std::strcat(buffer, "\n  Backtrace:\n");
+        for (int i = 0; i < numCapturedFrames; ++i)
+        {
+            char backtraceBuffer[32];
+            std::sprintf(backtraceBuffer, "    [0x%p]\n", stackTrace[i]);
+            std::strcat(buffer, backtraceBuffer);
+        }
+    }
+#else
+    int numCapturedFrames = backtrace(stackTrace, levels);
+
+    if (numCapturedFrames)
+    {
+        char** resolvedFrames = backtrace_symbols(stackTrace, levels);
+        std::strcat(buffer, "\n  Backtrace:\n");
+        for (int i = 0; i < numCapturedFrames; ++i)
+        {
+            char backtraceBuffer[256];
+            std::sprintf(backtraceBuffer, "    %s\n", resolvedFrames[i]);
+            std::strcat(buffer, backtraceBuffer);
+        }
+    }
+#endif // _WIN32
+    return std::string(buffer);
+}
+
+}
+
+}
+
+}

--- a/NWNXLib/Platform/Debug.hpp
+++ b/NWNXLib/Platform/Debug.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace NWNXLib {
+
+namespace Platform {
+
+namespace Debug {
+
+bool IsDebuggerPresent();
+void OutputDebugString(const char *str);
+std::string GetStackTrace(uint8_t levels);
+
+}
+}
+}


### PR DESCRIPTION
- Move platform specific stuff to Platform::Debug
- Use `strncat`/`snprintf` to avoid buffer overruns
- Change crash logic, expose `"CRASH_ON_ASSERT_FAILURE"` environment.
- Detect debugger presence, only break if it is there.