### PR TITLE
Creature: Note behavior when calling SetBaseAttackBonus with bab=0

### DIFF
--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -1043,7 +1043,6 @@ ArgumentStack Creature::SetBaseAttackBonus(ArgumentStack&& args)
         ASSERT(bab <= 254);
 
         pCreature->m_pStats->m_nBaseAttackBonus = static_cast<uint8_t>(bab);
-        ASSERT(pCreature->m_pStats->GetBaseAttackBonus(false) == bab);
     }
     return stack;
 }

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -196,6 +196,8 @@ void NWNX_Creature_SetClassByPosition(object creature, int position, int classID
 // Modifying the BAB will also affect the creature's attacks per round and its
 // eligability for feats, prestige classes, etc.
 // The BAB value should be between 0 and 254.
+// Setting BAB to 0 will cause the creature to revert to its original BAB based
+// on its classes and levels. A creature can never have an actual BAB of zero.
 // NOTE: The base game has a function SetBaseAttackBonus(), which actually sets
 //       the bonus attacks per round for a creature, not the BAB.
 void NWNX_Creature_SetBaseAttackBonus(object creature, int bab);


### PR DESCRIPTION
Setting BAB to zero will reset the bab instead, note this in the .nss

Also removing the assert, as it wasn't doing anything useful anyway..