### PR TITLE
utils: be very paranoid when getting the current script name

### DIFF
--- a/NWNXLib/Utils.cpp
+++ b/NWNXLib/Utils.cpp
@@ -19,7 +19,14 @@ std::string ObjectIDToString(const API::Types::ObjectID id)
 std::string GetCurrentScript()
 {
     auto *pVM = API::Globals::VirtualMachine();
-    return std::string(pVM->m_pVirtualMachineScript[pVM->m_nRecursionLevel].m_sScriptName.CStr());
+    if (!pVM || !pVM->m_pVirtualMachineScript || pVM->m_nRecursionLevel < 0)
+        return std::string("");
+
+    auto script = pVM->m_pVirtualMachineScript[pVM->m_nRecursionLevel];
+    if (script.m_sScriptName.IsEmpty())
+        return std::string("");
+
+    return std::string(script.m_sScriptName.CStr());
 }
 void ExecuteScript(const std::string& script, API::Types::ObjectID oidOwner)
 {


### PR DESCRIPTION
Fix Arelith crash:

```#0  0xf772caf9 in __kernel_vsyscall ()
#1  0xf6fe8dd0 in raise () from /lib/i386-linux-gnu/libc.so.6
#2  0xf6fea297 in abort () from /lib/i386-linux-gnu/libc.so.6
#3  0x56952e51 in ?? ()
#4  <signal handler called>
#5  0xf703bb06 in ?? () from /lib/i386-linux-gnu/libc.so.6
#6  0xf74e5f01 in std::char_traits<char>::length (__s=0x1 <error: Cannot access memory at address 0x1>)
    at /usr/include/c++/6/bits/char_traits.h:267
#7  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string (__a=...,
    __s=0x1 <error: Cannot access memory at address 0x1>, this=0xff836ac8)
    at /usr/include/c++/6/bits/basic_string.h:456
#8  NWNXLib::Utils::GetCurrentScript[abi:cxx11]() () at /scratch/NWNXLib/Utils.cpp:22
#9  0xf74e043d in (anonymous namespace)::NotifyLegacyCall (str=0x730d9598 "NWNX!FUNCS!SETTAG")
    at /scratch/Core/NWNXCore.cpp:37
#10 0xf74e086e in Core::NWNXCore::GetStringHandler (thisPtr=0x71f24134, index=0x7384780c)
    at /scratch/Core/NWNXCore.cpp:324
#11 0xf74e2afc in NWNXLib::Services::HooksImpl::HookLandingHolderExclusive<NWNXLib::Hooking::CallingConvention::ThisCall>::HookLanding<2178272u, NWNXLib::API::CExoString, NWNXLib::API::CNWSScriptVarTable*, NWNXLib::API::CExoString*> (
    arg1=0x71f24134, args#0=0x7384780c) at /scratch/NWNXLib/./Services/Hooks/HooksImpl.inl:111
#12 0x567c408e in ?? ()
#13 0x5679aa03 in ?? ()
#14 0x5677afd8 in ?? ()
#15 0x566be6c3 in ?? ()
#16 0x56635911 in ?? ()
#17 0x5665110b in ?? ()
#18 0x5676be6d in ?? ()
#19 0x56773819 in ?? ()
#20 0xf5d8fbb9 in NWNXLib::Hooking::FunctionHook::CallOriginal<NWNXLib::Hooking::CallingConvention::ThisCall, int, NWNXLib::API::CNWSMessage*, unsigned int, unsigned char*, unsigned int> (this=0x5c34eb90)```