### PR TITLE
tweaks: Player dying HP limit

### DIFF
--- a/NWNXLib/Utils.cpp
+++ b/NWNXLib/Utils.cpp
@@ -3,6 +3,21 @@
 #include "API/CAppManager.hpp"
 #include "API/CServerExoApp.hpp"
 #include "API/CVirtualMachine.hpp"
+#include "API/Constants.hpp"
+#include "API/CNWSArea.hpp"
+#include "API/CNWSAreaOfEffectObject.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/CNWSDoor.hpp"
+#include "API/CNWSEncounter.hpp"
+#include "API/CNWSItem.hpp"
+#include "API/CNWSModule.hpp"
+#include "API/CNWSObject.hpp"
+#include "API/CNWSPlaceable.hpp"
+#include "API/CNWSSoundObject.hpp"
+#include "API/CNWSStore.hpp"
+#include "API/CNWSTrigger.hpp"
+#include "API/CNWSWaypoint.hpp"
+
 #include <sstream>
 
 namespace NWNXLib {
@@ -33,6 +48,99 @@ void ExecuteScript(const std::string& script, API::Types::ObjectID oidOwner)
     API::CExoString exoStr = script.c_str();
     API::Globals::VirtualMachine()->RunScript(&exoStr, oidOwner, 1);
 }
+
+
+API::CNWSArea* AsNWSArea(API::CGameObject* obj)
+{
+    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_AREA)
+        return static_cast<API::CNWSArea*>(obj);
+    return nullptr;
+}
+API::CNWSAreaOfEffectObject* AsNWSAreaOfEffectObject(API::CGameObject* obj)
+{
+    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_AREA_OF_EFFECT)
+        return static_cast<API::CNWSAreaOfEffectObject*>(obj);
+    return nullptr;
+}
+API::CNWSCreature* AsNWSCreature(API::CGameObject* obj)
+{
+    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_CREATURE)
+        return static_cast<API::CNWSCreature*>(obj);
+    return nullptr;
+}
+API::CNWSDoor* AsNWSDoor(API::CGameObject* obj)
+{
+    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_DOOR)
+        return static_cast<API::CNWSDoor*>(obj);
+    return nullptr;
+}
+API::CNWSEncounter* AsNWSEncounter(API::CGameObject* obj)
+{
+    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_ENCOUNTER)
+        return static_cast<API::CNWSEncounter*>(obj);
+    return nullptr;
+}
+API::CNWSItem* AsNWSItem(API::CGameObject* obj)
+{
+    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_ITEM)
+        return static_cast<API::CNWSItem*>(obj);
+    return nullptr;
+}
+API::CNWSModule* AsNWSModule(API::CGameObject* obj)
+{
+    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_MODULE)
+        return static_cast<API::CNWSModule*>(obj);
+    return nullptr;
+}
+API::CNWSObject* AsNWSObject(API::CGameObject* obj)
+{
+    switch (obj->m_nObjectType)
+    {
+        case API::Constants::OBJECT_TYPE_AREA_OF_EFFECT:
+        case API::Constants::OBJECT_TYPE_CREATURE:
+        case API::Constants::OBJECT_TYPE_DOOR:
+        case API::Constants::OBJECT_TYPE_ENCOUNTER:
+        case API::Constants::OBJECT_TYPE_ITEM:
+        case API::Constants::OBJECT_TYPE_PLACEABLE:
+        case API::Constants::OBJECT_TYPE_SOUND:
+        case API::Constants::OBJECT_TYPE_STORE:
+        case API::Constants::OBJECT_TYPE_TRIGGER:
+        case API::Constants::OBJECT_TYPE_WAYPOINT:
+            return static_cast<API::CNWSObject*>(obj);
+    }
+    return nullptr;
+}
+API::CNWSPlaceable* AsNWSPlaceable(API::CGameObject* obj)
+{
+    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_PLACEABLE)
+        return static_cast<API::CNWSPlaceable*>(obj);
+    return nullptr;
+}
+API::CNWSSoundObject* AsNWSSoundObject(API::CGameObject* obj)
+{
+    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_SOUND)
+        return static_cast<API::CNWSSoundObject*>(obj);
+    return nullptr;
+}
+API::CNWSStore* AsNWSStore(API::CGameObject* obj)
+{
+    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_STORE)
+        return static_cast<API::CNWSStore*>(obj);
+    return nullptr;
+}
+API::CNWSTrigger* AsNWSTrigger(API::CGameObject* obj)
+{
+    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_TRIGGER)
+        return static_cast<API::CNWSTrigger*>(obj);
+    return nullptr;
+}
+API::CNWSWaypoint* AsNWSWaypoint(API::CGameObject* obj)
+{
+    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_WAYPOINT)
+        return static_cast<API::CNWSWaypoint*>(obj);
+    return nullptr;
+}
+
 
 }
 }

--- a/NWNXLib/Utils.hpp
+++ b/NWNXLib/Utils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "API/Types.hpp"
+#include "API/CGameObject.hpp"
 #include <string>
 
 
@@ -11,6 +12,22 @@ std::string ObjectIDToString(const API::Types::ObjectID id);
 
 std::string GetCurrentScript();
 void ExecuteScript(const std::string& script, API::Types::ObjectID oidOwner);
+
+// Since there's no RTTI, and NWN's dynamic casts don't work in NWNX.
+// These return nullptr if the object type isn't right.
+API::CNWSArea*               AsNWSArea(API::CGameObject* obj);
+API::CNWSAreaOfEffectObject* AsNWSAreaOfEffectObject(API::CGameObject* obj);
+API::CNWSCreature*           AsNWSCreature(API::CGameObject* obj);
+API::CNWSDoor*               AsNWSDoor(API::CGameObject* obj);
+API::CNWSEncounter*          AsNWSEncounter(API::CGameObject* obj);
+API::CNWSItem*               AsNWSItem(API::CGameObject* obj);
+API::CNWSModule*             AsNWSModule(API::CGameObject* obj);
+API::CNWSObject*             AsNWSObject(API::CGameObject* obj);
+API::CNWSPlaceable*          AsNWSPlaceable(API::CGameObject* obj);
+API::CNWSSoundObject*        AsNWSSoundObject(API::CGameObject* obj);
+API::CNWSStore*              AsNWSStore(API::CGameObject* obj);
+API::CNWSTrigger*            AsNWSTrigger(API::CGameObject* obj);
+API::CNWSWaypoint*           AsNWSWaypoint(API::CGameObject* obj);
 
 }
 

--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_plugin(Tweaks
     "Tweaks.cpp"
-    "Tweaks/HideClassesOnCharList.cpp")
+    "Tweaks/HideClassesOnCharList.cpp"
+    "Tweaks/PlayerDyingHitPointLimit.cpp")

--- a/Plugins/Tweaks/Tweaks.cpp
+++ b/Plugins/Tweaks/Tweaks.cpp
@@ -1,5 +1,6 @@
 #include "Tweaks.hpp"
 #include "Tweaks/HideClassesOnCharList.hpp"
+#include "Tweaks/PlayerDyingHitPointLimit.hpp"
 
 #include "Services/Config/Config.hpp"
 
@@ -35,6 +36,13 @@ Tweaks::Tweaks(const Plugin::CreateParams& params)
     {
         LOG_INFO("Hiding the display of classes on the character list.");
         m_HideClassesOnCharlist = std::make_unique<HideClassesOnCharList>(GetServices()->m_hooks.get());
+    }
+
+    int32_t hplimit = GetServices()->m_config->Get<int32_t>("PLAYER_DYING_HP_LIMIT", -10);
+    if (hplimit != -10)
+    {
+        LOG_INFO("Setting the player dying HP limit to %d", hplimit);
+        m_PlayerDyingHitPointLimit = std::make_unique<PlayerDyingHitPointLimit>(GetServices()->m_hooks.get(), hplimit);
     }
 }
 

--- a/Plugins/Tweaks/Tweaks.hpp
+++ b/Plugins/Tweaks/Tweaks.hpp
@@ -5,6 +5,7 @@
 namespace Tweaks {
 
 class HideClassesOnCharList;
+class PlayerDyingHitPointLimit;
 
 class Tweaks : public NWNXLib::Plugin
 {
@@ -14,6 +15,7 @@ public:
 
 private:
     std::unique_ptr<HideClassesOnCharList> m_HideClassesOnCharlist;
+    std::unique_ptr<PlayerDyingHitPointLimit> m_PlayerDyingHitPointLimit;
 };
 
 }

--- a/Plugins/Tweaks/Tweaks/PlayerDyingHitPointLimit.cpp
+++ b/Plugins/Tweaks/Tweaks/PlayerDyingHitPointLimit.cpp
@@ -15,6 +15,7 @@ namespace Tweaks {
 using namespace NWNXLib;
 using namespace NWNXLib::API;
 
+int16_t PlayerDyingHitPointLimit::m_hplimit;
 PlayerDyingHitPointLimit::PlayerDyingHitPointLimit(ViewPtr<Services::HooksProxy> hooker, int16_t hplimit)
 {
     m_hplimit = hplimit;

--- a/Plugins/Tweaks/Tweaks/PlayerDyingHitPointLimit.cpp
+++ b/Plugins/Tweaks/Tweaks/PlayerDyingHitPointLimit.cpp
@@ -1,0 +1,40 @@
+#include "Tweaks/PlayerDyingHitPointLimit.hpp"
+
+#include "Services/Hooks/Hooks.hpp"
+#include "Utils.hpp"
+
+#include "API/CAppManager.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/CNWSMessage.hpp"
+#include "API/CServerExoApp.hpp"
+#include "API/Functions.hpp"
+#include "API/Globals.hpp"
+
+namespace Tweaks {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+PlayerDyingHitPointLimit::PlayerDyingHitPointLimit(ViewPtr<Services::HooksProxy> hooker, int16_t hplimit)
+{
+    m_hplimit = hplimit;
+
+    hooker->RequestExclusiveHook<API::Functions::CNWSObject__GetIsPCDying>
+        (&CNWSObject__GetIsPCDying_Hook);
+}
+
+int32_t PlayerDyingHitPointLimit::CNWSObject__GetIsPCDying_Hook(CNWSObject* thisPtr)
+{
+    if (auto *pCreature = Utils::AsNWSCreature(thisPtr))
+    {
+        if (pCreature->m_bPlayerCharacter || pCreature->GetIsPossessedFamiliar())
+        {
+            int16_t hp = pCreature->GetCurrentHitPoints(false);
+            return (hp < 0) && (hp > m_hplimit);
+        }
+    }
+
+    return false;
+}
+
+}

--- a/Plugins/Tweaks/Tweaks/PlayerDyingHitPointLimit.hpp
+++ b/Plugins/Tweaks/Tweaks/PlayerDyingHitPointLimit.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "Common.hpp"
+#include "ViewPtr.hpp"
+
+namespace Tweaks {
+
+class PlayerDyingHitPointLimit
+{
+public:
+    PlayerDyingHitPointLimit(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker, int16_t hplimit);
+
+    
+private:
+    static int32_t CNWSObject__GetIsPCDying_Hook(NWNXLib::API::CNWSObject*);
+    static int16_t m_hplimit;
+};
+
+}

--- a/Plugins/Tweaks/Tweaks/PlayerDyingHitPointLimit.hpp
+++ b/Plugins/Tweaks/Tweaks/PlayerDyingHitPointLimit.hpp
@@ -14,6 +14,7 @@ public:
     
 private:
     static int32_t CNWSObject__GetIsPCDying_Hook(NWNXLib::API::CNWSObject*);
+    static int32_t CNWSObject__GetDead_Hook(NWNXLib::API::CNWSObject*);
     static int16_t m_hplimit;
 };
 


### PR DESCRIPTION
`export NWNX_TWEAKS_PLAYER_DYING_HP_LIMIT=-30` to change the default -10 limit. Requested in #115 

Also includes a set of dynamic cast functions in Utils, since we can't use the default NWN ones, nor `dynamic_cast<>`.
