### PR TITLE
Weapon plugin update

### DIFF
--- a/Plugins/Weapon/Documentation/README.md
+++ b/Plugins/Weapon/Documentation/README.md
@@ -38,6 +38,6 @@ NWNX_Weapon_SetWeaponOfChoiceFeat | Associate a weapon of choice feat to a weapo
 NWNX_Weapon_SetGreaterWeaponFocusFeat | Associate a greater weapon focus feat (default: +1 attack bonus) to a weapon
 NWNX_Weapon_SetGreaterWeaponSpecializationFeat | Associate a greater weapon specialization feat (default: +2 damage bonus) to a weapon
 NWNX_Weapon_SetWeaponIsMonkWeapon | Set the weapon to be considered a monk weapon
-NWNX_Weapon_SetOption | Set different options of the plugin.
+NWNX_Weapon_SetOption | Set different options of the plugin
 
-The NWNX_Weapon_SetOption function can be used to define the attack and damage bonus of the GreaterWeaponFocusFeat and GreaterWeaponSpecializationFeat respectively. 
+The NWNX_Weapon_SetOption function can be used to define the attack and damage bonusses of the Greater Weapon Focus Feats and Greater Weapon Specialization Feats respectively. 

--- a/Plugins/Weapon/Documentation/README.md
+++ b/Plugins/Weapon/Documentation/README.md
@@ -35,5 +35,9 @@ NWNX_Weapon_SetEpicWeaponSpecializationFeat | Associate an epic weapon specializ
 NWNX_Weapon_SetEpicWeaponOverwhelmingCriticalFeat | Associate an epic weapon overwhelming critical feat to a weapon 
 NWNX_Weapon_SetEpicWeaponDevastatingCriticalFeat | Associate an epic weapon devastating critical feat to a weapon 
 NWNX_Weapon_SetWeaponOfChoiceFeat | Associate a weapon of choice feat to a weapon 
-NWNX_Weapon_SetGreaterWeaponFocusFeat | Associate a greater weapon focus feat (+1 attack bonus) to a weapon
-NWNX_Weapon_SetGreaterWeaponSpecializationFeat | Associate a greater weapon specialization feat (+2 damage bonus) to a weapon
+NWNX_Weapon_SetGreaterWeaponFocusFeat | Associate a greater weapon focus feat (default: +1 attack bonus) to a weapon
+NWNX_Weapon_SetGreaterWeaponSpecializationFeat | Associate a greater weapon specialization feat (default: +2 damage bonus) to a weapon
+NWNX_Weapon_SetWeaponIsMonkWeapon | Set the weapon to be considered a monk weapon
+NWNX_Weapon_SetOption | Set different options of the plugin.
+
+The NWNX_Weapon_SetOption function can be used to define the attack and damage bonus of the GreaterWeaponFocusFeat and GreaterWeaponSpecializationFeat respectively. 

--- a/Plugins/Weapon/NWScript/nwnx_weapon.nss
+++ b/Plugins/Weapon/NWScript/nwnx_weapon.nss
@@ -2,6 +2,10 @@
 
 const string NWNX_Weapon = "NWNX_Weapon";
 
+// Otpions constants to be used with NWNX_Weapon_SetOption function
+const int NWNX_WEAPON_OPT_GRTFOCUS_AB_BONUS = 0; // Greater Focus AB bonus
+const int NWNX_WEAPON_OPT_GRTSPEC_DAM_BONUS = 1; // Greater Spec. DAM bonus
+
 // Set nFeat as weapon focus feat for nBaseItem
 void NWNX_Weapon_SetWeaponFocusFeat(int nBaseItem, int nFeat);
 
@@ -37,6 +41,13 @@ void NWNX_Weapon_SetGreaterWeaponSpecializationFeat(int nBaseItem, int nFeat);
 
 // Set nFeat as greater weapon focus feat for nBaseItem
 void NWNX_Weapon_SetGreaterWeaponFocusFeat(int nBaseItem, int nFeat);
+
+// Set nBaseItem as monk weapon
+void NWNX_Weapon_SetWeaponIsMonkWeapon(int nBaseItem);
+
+// Set plugin options
+void NWNX_Weapon_SetOption(int nOption, int nVal);
+
 
 void NWNX_Weapon_SetWeaponFocusFeat(int nBaseItem, int nFeat)
 {
@@ -81,6 +92,15 @@ void NWNX_Weapon_SetWeaponFinesseSize(int nBaseItem, int nSize)
 void NWNX_Weapon_SetWeaponUnarmed(int nBaseItem)
 {
     string sFunc = "SetWeaponUnarmed";
+
+    NWNX_PushArgumentInt(NWNX_Weapon, sFunc, nBaseItem);
+
+    NWNX_CallFunction(NWNX_Weapon, sFunc);
+}
+
+void NWNX_Weapon_SetWeaponIsMonkWeapon(int nBaseItem)
+{
+    string sFunc = "SetWeaponIsMonkWeapon";
 
     NWNX_PushArgumentInt(NWNX_Weapon, sFunc, nBaseItem);
 
@@ -157,4 +177,12 @@ void NWNX_Weapon_SetWeaponOfChoiceFeat(int nBaseItem, int nFeat)
     NWNX_CallFunction(NWNX_Weapon, sFunc);
 }
 
+void NWNX_Weapon_SetOption(int nOption, int nVal)
+{
+    string sFunc = "SetOption";
 
+    NWNX_PushArgumentInt(NWNX_Weapon, sFunc, nVal);
+    NWNX_PushArgumentInt(NWNX_Weapon, sFunc, nOption);
+
+    NWNX_CallFunction(NWNX_Weapon, sFunc);
+}

--- a/Plugins/Weapon/Weapon.hpp
+++ b/Plugins/Weapon/Weapon.hpp
@@ -10,6 +10,8 @@
 #include "API/CNWSCreatureStats.hpp"
 #include "API/CNWSItem.hpp"
 
+#define NWNX_WEAPON_OPT_GRTFOCUS_AB_BONUS 0
+#define NWNX_WEAPON_OPT_GRTSPEC_DAM_BONUS 1
 
 using ArgumentStack = NWNXLib::Services::Events::ArgumentStack;
 
@@ -34,6 +36,8 @@ class Weapon : public NWNXLib::Plugin
       ArgumentStack SetWeaponOfChoiceFeat                (ArgumentStack&& args);
       ArgumentStack SetGreaterWeaponSpecializationFeat   (ArgumentStack&& args);
       ArgumentStack SetGreaterWeaponFocusFeat            (ArgumentStack&& args);
+      ArgumentStack SetWeaponIsMonkWeapon                (ArgumentStack&& args);
+      ArgumentStack SetOption                            (ArgumentStack&& args);
       
       NWNXLib::Hooking::FunctionHook* m_GetWeaponFocusHook;
       NWNXLib::Hooking::FunctionHook* m_GetEpicWeaponFocusHook;
@@ -50,7 +54,6 @@ class Weapon : public NWNXLib::Plugin
       NWNXLib::Hooking::FunctionHook* m_GetRangedAttackBonusHook;
       NWNXLib::Hooking::FunctionHook* m_GetAttackModifierVersusHook;
 
-
       static int32_t GetWeaponFocus                   (NWNXLib::API::CNWSCreatureStats *pStats, NWNXLib::API::CNWSItem *pItem);
       static int32_t GetEpicWeaponFocus               (NWNXLib::API::CNWSCreatureStats *pStats, NWNXLib::API::CNWSItem *pItem);
       static int32_t GetWeaponFinesse                 (NWNXLib::API::CNWSCreatureStats *pStats, NWNXLib::API::CNWSItem *pItem);
@@ -65,7 +68,8 @@ class Weapon : public NWNXLib::Plugin
       static int32_t GetDamageBonus                   (NWNXLib::API::CNWSCreatureStats *pStats, NWNXLib::API::CNWSCreature *pCreature, int32_t bOffHand);
       static int32_t GetMeleeAttackBonus              (NWNXLib::API::CNWSCreatureStats *pStats, bool bOffHand, bool bIncludeBase, bool bTouchAttack);
       static int32_t GetRangedAttackBonus             (NWNXLib::API::CNWSCreatureStats *pStats, bool bIncludeBase, bool bTouchAttack);
-      static int32_t GetAttackModifierVersus          (NWNXLib::API::CNWSCreatureStats* pStats, NWNXLib::API::CNWSCreature* pCreature);
+      static int32_t GetAttackModifierVersus          (NWNXLib::API::CNWSCreatureStats *pStats, NWNXLib::API::CNWSCreature* pCreature);
+      static int32_t GetUseMonkAttackTables           (NWNXLib::API::CNWSCreatureStats *pStats, bool bForceUnarmed);
       
       std::map<std::uint32_t, std::uint32_t> m_WeaponFocusMap;
       std::map<std::uint32_t, std::uint32_t> m_EpicWeaponFocusMap;
@@ -80,9 +84,11 @@ class Weapon : public NWNXLib::Plugin
       std::map<std::uint32_t, std::uint32_t> m_GreaterWeaponFocusMap;
 
       std::set<std::uint32_t>  m_WeaponUnarmedSet;
+      std::set<std::uint32_t>  m_MonkWeaponSet;
 
       bool GetIsWeaponLight  (NWNXLib::API::CNWSCreatureStats* pInfo, NWNXLib::API::CNWSItem* pWeapon, bool bFinesse);
       bool GetIsUnarmedWeapon(NWNXLib::API::CNWSItem* pWeapon);
+      int  GetLevelByClass   (NWNXLib::API::CNWSCreatureStats* pStats, uint32_t nClassType);
 
       int m_GreaterFocusAttackBonus=1;
       int m_GreaterWeaponSpecializationDamageBonus=2;


### PR DESCRIPTION
Added the following functions:
```
// Set nBaseItem as monk weapon
void NWNX_Weapon_SetWeaponIsMonkWeapon(int nBaseItem);

// Set plugin options
void NWNX_Weapon_SetOption(int nOption, int nVal);
```

The NWNX_Weapon_SetOption function can be used to define the attack and damage bonusses of the Greater Weapon Focus Feats and Greater Weapon Specialization Feats respectively.