### PR TITLE
Tweak the log output format.

### DIFF
--- a/NWNXLib/Log.cpp
+++ b/NWNXLib/Log.cpp
@@ -38,10 +38,10 @@ void InternalTrace(Channel::Enum channel, Channel::Enum allowedChannel, const ch
     }
 
     char buffer[2048];
-    std::sprintf(buffer, "%s [%02d:%02d:%02d] [%s:%d] %s: ",
+    std::sprintf(buffer, "%s [%02d:%02d:%02d] [%s] [%s:%d] ",
             SEVERITY_NAMES[static_cast<size_t>(channel)],
             date.m_hour, date.m_minute, date.m_second,
-            filename, line, plugin);
+            plugin, filename, line);
 
     std::printf("%s%s\n", buffer, message);
 


### PR DESCRIPTION
This changes the format from:

```
I [15:02:52] [Mono.cpp:307] NWNX_Mono: Resolved NWN.Scripts.m_hb::Main.
D [15:02:52] [Mono.cpp:215] NWNX_Mono: Invoking NWN.Scripts.m_hb::Main on OID 0x0.
D [15:02:52] [Mono.cpp:264] NWNX_Mono: Run took 27.688568 ms.
D [15:02:54] [Mono.cpp:299] NWNX_Mono: Failed to find class x2_def_heartbeat.
D [15:02:54] [Mono.cpp:299] NWNX_Mono: Failed to find class nw_c2_default1.
```
to

```
I [15:02:52] [NWNX_Mono] [Mono.cpp:307] Resolved NWN.Scripts.m_hb::Main.
D [15:02:52] [NWNX_Mono] [Mono.cpp:215] Invoking NWN.Scripts.m_hb::Main on OID 0x0.
D [15:02:52] [NWNX_Mono] [Mono.cpp:264] Run took 27.688568 ms.
D [15:02:54] [NWNX_Mono] [Mono.cpp:299] Failed to find class x2_def_heartbeat.
D [15:02:54] [NWNX_Mono] [Mono.cpp:299] Failed to find class nw_c2_default1.
```

For me, this makes it much easier to visually parse which plugin is emitting which log messages. Let me know if anyone disagrees or agrees that the old format was difficult to visually parse but still dislikes the new format.