### PR TITLE
Fix infinite recursion when signals are overwritten

### DIFF
--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -34,12 +34,15 @@ extern "C" void nwnx_signal_handler(int sig)
         default:       err = "Unknown error";            break;
     }
 
-    ASSERT_FAIL_MSG(" NWNX Signal Handler:\n"
+    std::fprintf(stderr, " NWNX Signal Handler:\n"
         "==============================================================\n"
         " NWNX has crashed. Fatal error: %s (%d).\n"
         " Please file a bug at https://github.com/nwnxee/unified/issues\n"
         "==============================================================\n",
         err, sig);
+
+    std::fflush(stderr);
+
     nwn_crash_handler(sig);
 }
 

--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -6,6 +6,7 @@
 #include "API/Functions.hpp"
 #include "API/Globals.hpp"
 #include "Platform/ASLR.hpp"
+#include "Platform/Debug.hpp"
 #include "Platform/FileSystem.hpp"
 #include "Services/Config/Config.hpp"
 #include "Services/Events/Events.hpp"
@@ -40,6 +41,8 @@ extern "C" void nwnx_signal_handler(int sig)
         " Please file a bug at https://github.com/nwnxee/unified/issues\n"
         "==============================================================\n",
         err, sig);
+
+    std::fputs(NWNXLib::Platform::Debug::GetStackTrace(20).c_str(), stderr);
 
     std::fflush(stderr);
 


### PR DESCRIPTION
- NWNX overwrites signals and chains
- Mono overwites signals and chains
- Crash happens
- Mono does its thing
- NWNX does its thing - ASSERT_FAIL_MSG causes `std::abort()`
- Mono does its thing ...
- NWNX does its thing ...

This fixes the above scenario by writing to stderr rather than asserting when we encounter a signal.