### PR TITLE
Revised ClearMemorisedSpell()

### DIFF
--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -80,6 +80,7 @@ Creature::Creature(const Plugin::CreateParams& params)
     REGISTER(GetKnownSpellCount);
     REGISTER(RemoveKnownSpell);
     REGISTER(AddKnownSpell);
+    REGISTER(ClearMemorisedSpell);
     REGISTER(GetMaxHitPointsByLevel);
     REGISTER(SetMaxHitPointsByLevel);
     REGISTER(SetMovementRate);
@@ -803,6 +804,30 @@ ArgumentStack Creature::AddKnownSpell(ArgumentStack&& args)
             if (classInfo.m_nClass == classId)
             {
                 classInfo.AddKnownSpell(static_cast<unsigned char>(level), static_cast<uint32_t>(spellId));
+                break;
+            }
+        }
+    }
+    return stack;
+}
+
+ArgumentStack Creature::ClearMemorisedSpell(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pCreature = creature(args))
+    {
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT(classId >= 0 && classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT(level < 10);
+        const auto index   = Services::Events::ExtractArgument<int32_t>(args);
+
+        for (int32_t i = 0; i < 3; i++)
+        {
+            auto& classInfo = pCreature->m_pStats->m_ClassInfo[i];
+            if (classInfo.m_nClass == classId)
+            {
+                classInfo.ClearMemorizedSpellSlot(static_cast<unsigned char>(level),
+                                                  static_cast<unsigned char>(index));
+
                 break;
             }
         }

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -46,6 +46,7 @@ private:
     ArgumentStack GetKnownSpellCount            (ArgumentStack&& args);
     ArgumentStack RemoveKnownSpell              (ArgumentStack&& args);
     ArgumentStack AddKnownSpell                 (ArgumentStack&& args);
+    ArgumentStack ClearMemorisedSpell           (ArgumentStack&& args);
     ArgumentStack GetMaxHitPointsByLevel        (ArgumentStack&& args);
     ArgumentStack SetMaxHitPointsByLevel        (ArgumentStack&& args);
     ArgumentStack SetMovementRate               (ArgumentStack&& args);

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -131,10 +131,6 @@ int NWNX_Creature_GetMemorisedSpellCountByLevel(object creature, int class, int 
 // Index bounds: 0 <= index < NWNX_Creature_GetMemorisedSpellCountByLevel(creature, class, level).
 void NWNX_Creature_SetMemorisedSpell(object creature, int class, int level, int index, struct NWNX_Creature_MemorisedSpell spell);
 
-// Clear the memorised spell of the provided creature for the provided class, level and index. */
-// Index bounds: 0 <= index < NWNX_Creature_GetMemorisedSpellCountByLevel(creature, class, level).
-void NWNX_Creature_ClearMemorisedSpell(object creature, int class, int level, int index);
-
 // Gets the remaining spell slots (innate casting) for the provided creature for the provided class and level.
 int NWNX_Creature_GetRemainingSpellSlots(object creature, int class, int level);
 
@@ -154,6 +150,10 @@ void NWNX_Creature_RemoveKnownSpell(object creature, int class, int level, int s
 
 // Add a new spell to creature's spellbook for class.
 void NWNX_Creature_AddKnownSpell(object creature, int class, int level, int spellId);
+
+// Clear the memorised spell of the provided creature for the provided class, level and index. */
+// Index bounds: 0 <= index < NWNX_Creature_GetMemorisedSpellCountByLevel(creature, class, level).
+void NWNX_Creature_ClearMemorisedSpell(object creature, int class, int level, int index);
 
 // Gets the maximum hit points for creature for level.
 int NWNX_Creature_GetMaxHitPointsByLevel(object creature, int level);
@@ -528,14 +528,6 @@ void NWNX_Creature_SetMemorisedSpell(object creature, int class, int level, int 
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
 
-void NWNX_Creature_ClearMemorisedSpell(object creature, int class, int level, int index)
-{
-    struct NWNX_Creature_MemorisedSpell spell;
-    spell.id = -1;
-
-    NWNX_Creature_SetMemorisedSpell(creature, class, level, index, spell);
-}
-
 int NWNX_Creature_GetRemainingSpellSlots(object creature, int class, int level)
 {
     string sFunc = "GetRemainingSpellSlots";
@@ -602,6 +594,18 @@ void NWNX_Creature_AddKnownSpell(object creature, int class, int level, int spel
     string sFunc = "AddKnownSpell";
 
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, spellId);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, level);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, class);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_ClearMemorisedSpell(object creature, int class, int level, int index)
+{
+    string sFunc = "ClearMemorisedSpell";
+
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, index);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, level);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, class);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);


### PR DESCRIPTION
Last implemention called SetMemorisedSpell() with a
struct NWNX_Creature_MemorisedSpell spell parameter
whose id field was set to -1.  That implementation was
based off of legacy nwnx implentation. It seemed to
work, but was hacky.  This implemenation should use
internals correctly.