### PR TITLE
Refactor object deserialization, fix a few issues

### DIFF
--- a/NWNXLib/Serialize.cpp
+++ b/NWNXLib/Serialize.cpp
@@ -146,7 +146,7 @@ API::CGameObject *DeserializeGameObject(const std::vector<uint8_t>& serialized)
     API::CExoString sFileType, sFileVersion;
     resGff.GetGFFFileInfo(&sFileType, &sFileVersion);
 
-    if (sFileType == "BIC " || sFileType == "GFF ")
+    if (sFileType == "BIC " || sFileType == "GFF " || sFileType == "UTC ")
     {
         API::CNWSCreature *pCreature = new API::CNWSCreature(API::Constants::OBJECT_INVALID, 0, 1);
 
@@ -200,43 +200,5 @@ API::CGameObject *DeserializeGameObjectB64(const std::string& serializedB64)
 {
     return DeserializeGameObject(base64_decode(serializedB64));
 }
-
-bool AcquireDeserializedItem(API::CNWSItem *pItem, API::CGameObject *pOwner, float x, float y, float z)
-{
-    if (!pOwner || !pItem)
-        return false;
-
-    using namespace API::Constants;
-    switch (pOwner->m_nObjectType)
-    {
-        case OBJECT_TYPE_CREATURE:
-        {
-            auto pCreature = static_cast<API::CNWSCreature*>(pOwner);
-            return pCreature->AcquireItem(&pItem, OBJECT_INVALID, OBJECT_INVALID, 0xFF, 0xFF, true, true);
-        }
-        case OBJECT_TYPE_PLACEABLE:
-        {
-            auto pPlaceable = static_cast<API::CNWSPlaceable*>(pOwner);
-            return pPlaceable->AcquireItem(&pItem, OBJECT_INVALID, 0xFF, 0xFF, true);
-        }
-        case OBJECT_TYPE_STORE:
-        {
-            auto pStore = static_cast<API::CNWSStore*>(pOwner);
-            return pStore->AcquireItem(pItem, true, 0xFF, 0xFF);
-        }
-        case OBJECT_TYPE_ITEM:
-        {
-            auto pItemOwner = static_cast<API::CNWSItem*>(pOwner);
-            return pItemOwner->AcquireItem(&pItem, OBJECT_INVALID, 0xFF, 0xFF, true);
-        }
-        case OBJECT_TYPE_AREA:
-        {
-            pItem->AddToArea(static_cast<API::CNWSArea*>(pOwner), x, y, z, true);
-            return true;
-        }
-    }
-    return false;
-}
-
 
 } // NWNXLib

--- a/NWNXLib/Serialize.hpp
+++ b/NWNXLib/Serialize.hpp
@@ -24,6 +24,4 @@ std::string SerializeGameObjectB64(API::CGameObject *pObject, bool bStripPCFlags
 API::CGameObject *DeserializeGameObject(const std::vector<uint8_t>& serialized);
 API::CGameObject *DeserializeGameObjectB64(const std::string& serializedB64);
 
-bool AcquireDeserializedItem(API::CNWSItem *pItem, API::CGameObject *pOwner, float x, float y, float z);
-
 } // NWNXLib

--- a/NWNXLib/Utils.cpp
+++ b/NWNXLib/Utils.cpp
@@ -23,6 +23,7 @@
 namespace NWNXLib {
 namespace Utils {
 
+using namespace API::Constants;
 
 std::string ObjectIDToString(const API::Types::ObjectID id)
 {
@@ -52,94 +53,159 @@ void ExecuteScript(const std::string& script, API::Types::ObjectID oidOwner)
 
 API::CNWSArea* AsNWSArea(API::CGameObject* obj)
 {
-    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_AREA)
+    if (obj && obj->m_nObjectType == OBJECT_TYPE_AREA)
         return static_cast<API::CNWSArea*>(obj);
     return nullptr;
 }
 API::CNWSAreaOfEffectObject* AsNWSAreaOfEffectObject(API::CGameObject* obj)
 {
-    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_AREA_OF_EFFECT)
+    if (obj && obj->m_nObjectType == OBJECT_TYPE_AREA_OF_EFFECT)
         return static_cast<API::CNWSAreaOfEffectObject*>(obj);
     return nullptr;
 }
 API::CNWSCreature* AsNWSCreature(API::CGameObject* obj)
 {
-    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_CREATURE)
+    if (obj && obj->m_nObjectType == OBJECT_TYPE_CREATURE)
         return static_cast<API::CNWSCreature*>(obj);
     return nullptr;
 }
 API::CNWSDoor* AsNWSDoor(API::CGameObject* obj)
 {
-    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_DOOR)
+    if (obj && obj->m_nObjectType == OBJECT_TYPE_DOOR)
         return static_cast<API::CNWSDoor*>(obj);
     return nullptr;
 }
 API::CNWSEncounter* AsNWSEncounter(API::CGameObject* obj)
 {
-    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_ENCOUNTER)
+    if (obj && obj->m_nObjectType == OBJECT_TYPE_ENCOUNTER)
         return static_cast<API::CNWSEncounter*>(obj);
     return nullptr;
 }
 API::CNWSItem* AsNWSItem(API::CGameObject* obj)
 {
-    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_ITEM)
+    if (obj && obj->m_nObjectType == OBJECT_TYPE_ITEM)
         return static_cast<API::CNWSItem*>(obj);
     return nullptr;
 }
 API::CNWSModule* AsNWSModule(API::CGameObject* obj)
 {
-    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_MODULE)
+    if (obj && obj->m_nObjectType == OBJECT_TYPE_MODULE)
         return static_cast<API::CNWSModule*>(obj);
     return nullptr;
 }
 API::CNWSObject* AsNWSObject(API::CGameObject* obj)
 {
+    if (!obj)
+        return nullptr;
+
     switch (obj->m_nObjectType)
     {
-        case API::Constants::OBJECT_TYPE_AREA_OF_EFFECT:
-        case API::Constants::OBJECT_TYPE_CREATURE:
-        case API::Constants::OBJECT_TYPE_DOOR:
-        case API::Constants::OBJECT_TYPE_ENCOUNTER:
-        case API::Constants::OBJECT_TYPE_ITEM:
-        case API::Constants::OBJECT_TYPE_PLACEABLE:
-        case API::Constants::OBJECT_TYPE_SOUND:
-        case API::Constants::OBJECT_TYPE_STORE:
-        case API::Constants::OBJECT_TYPE_TRIGGER:
-        case API::Constants::OBJECT_TYPE_WAYPOINT:
+        case OBJECT_TYPE_AREA_OF_EFFECT:
+        case OBJECT_TYPE_CREATURE:
+        case OBJECT_TYPE_DOOR:
+        case OBJECT_TYPE_ENCOUNTER:
+        case OBJECT_TYPE_ITEM:
+        case OBJECT_TYPE_PLACEABLE:
+        case OBJECT_TYPE_SOUND:
+        case OBJECT_TYPE_STORE:
+        case OBJECT_TYPE_TRIGGER:
+        case OBJECT_TYPE_WAYPOINT:
             return static_cast<API::CNWSObject*>(obj);
     }
     return nullptr;
 }
 API::CNWSPlaceable* AsNWSPlaceable(API::CGameObject* obj)
 {
-    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_PLACEABLE)
+    if (obj && obj->m_nObjectType == OBJECT_TYPE_PLACEABLE)
         return static_cast<API::CNWSPlaceable*>(obj);
     return nullptr;
 }
 API::CNWSSoundObject* AsNWSSoundObject(API::CGameObject* obj)
 {
-    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_SOUND)
+    if (obj && obj->m_nObjectType == OBJECT_TYPE_SOUND)
         return static_cast<API::CNWSSoundObject*>(obj);
     return nullptr;
 }
 API::CNWSStore* AsNWSStore(API::CGameObject* obj)
 {
-    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_STORE)
+    if (obj && obj->m_nObjectType == OBJECT_TYPE_STORE)
         return static_cast<API::CNWSStore*>(obj);
     return nullptr;
 }
 API::CNWSTrigger* AsNWSTrigger(API::CGameObject* obj)
 {
-    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_TRIGGER)
+    if (obj && obj->m_nObjectType == OBJECT_TYPE_TRIGGER)
         return static_cast<API::CNWSTrigger*>(obj);
     return nullptr;
 }
 API::CNWSWaypoint* AsNWSWaypoint(API::CGameObject* obj)
 {
-    if (obj->m_nObjectType == API::Constants::OBJECT_TYPE_WAYPOINT)
+    if (obj && obj->m_nObjectType == OBJECT_TYPE_WAYPOINT)
         return static_cast<API::CNWSWaypoint*>(obj);
     return nullptr;
 }
+
+bool AcquireItem(API::CNWSItem *pItem, API::CGameObject *pOwner)
+{
+    if (!pOwner || !pItem)
+        return false;
+
+    switch (pOwner->m_nObjectType)
+    {
+        case OBJECT_TYPE_CREATURE:
+            return AsNWSCreature(pOwner)->AcquireItem(&pItem, OBJECT_INVALID, OBJECT_INVALID, 0xFF, 0xFF, true, true);
+        case OBJECT_TYPE_PLACEABLE:
+            return AsNWSPlaceable(pOwner)->AcquireItem(&pItem, OBJECT_INVALID, 0xFF, 0xFF, true);
+        case OBJECT_TYPE_STORE:
+            return AsNWSStore(pOwner)->AcquireItem(pItem, true, 0xFF, 0xFF);
+        case OBJECT_TYPE_ITEM:
+            return AsNWSItem(pOwner)->AcquireItem(&pItem, OBJECT_INVALID, 0xFF, 0xFF, true);
+    }
+    return false;
+}
+
+bool AddToArea(API::CGameObject *pObject, API::CNWSArea *pArea, float x, float y, float z)
+{
+    if (!pObject || !pArea)
+        return false;
+
+    switch (pObject->m_nObjectType)
+    {
+        case OBJECT_TYPE_CREATURE:
+            AsNWSCreature(pObject)->AddToArea(pArea, x, y, z, false); // bForceAdd, not bRunScripts
+            return true;
+        case OBJECT_TYPE_PLACEABLE:
+            AsNWSPlaceable(pObject)->AddToArea(pArea, x, y, z, true);
+            return true;
+        case OBJECT_TYPE_WAYPOINT:
+            AsNWSWaypoint(pObject)->AddToArea(pArea, x, y, z, true);
+            return true;
+        case OBJECT_TYPE_DOOR:
+            AsNWSDoor(pObject)->AddToArea(pArea, x, y, z, true);
+            return true;
+        case OBJECT_TYPE_STORE:
+            AsNWSStore(pObject)->AddToArea(pArea, x, y, z, true);
+            return true;
+        case OBJECT_TYPE_TRIGGER:
+            AsNWSTrigger(pObject)->AddToArea(pArea, x, y, z, true);
+            return true;
+        case OBJECT_TYPE_ENCOUNTER:
+            AsNWSEncounter(pObject)->AddToArea(pArea, x, y, z, true);
+            return true;
+        case OBJECT_TYPE_ITEM:
+            AsNWSItem(pObject)->AddToArea(pArea, x, y, z, true);
+            return true;
+        case OBJECT_TYPE_AREA_OF_EFFECT:
+            AsNWSAreaOfEffectObject(pObject)->AddToArea(pArea, x, y, z, true);
+            return true;
+        case OBJECT_TYPE_SOUND:
+            AsNWSSoundObject(pObject)->AddToArea(pArea, true);
+            return true;
+        default:
+            return false;
+    }
+}
+
 
 
 }

--- a/NWNXLib/Utils.cpp
+++ b/NWNXLib/Utils.cpp
@@ -172,7 +172,7 @@ bool AddToArea(API::CGameObject *pObject, API::CNWSArea *pArea, float x, float y
     switch (pObject->m_nObjectType)
     {
         case OBJECT_TYPE_CREATURE:
-            AsNWSCreature(pObject)->AddToArea(pArea, x, y, z, false); // bForceAdd, not bRunScripts
+            AsNWSCreature(pObject)->AddToArea(pArea, x, y, z, true);
             return true;
         case OBJECT_TYPE_PLACEABLE:
             AsNWSPlaceable(pObject)->AddToArea(pArea, x, y, z, true);

--- a/NWNXLib/Utils.hpp
+++ b/NWNXLib/Utils.hpp
@@ -29,6 +29,10 @@ API::CNWSStore*              AsNWSStore(API::CGameObject* obj);
 API::CNWSTrigger*            AsNWSTrigger(API::CGameObject* obj);
 API::CNWSWaypoint*           AsNWSWaypoint(API::CGameObject* obj);
 
+// Wrappers around non-virtual methods repeated for all NWS types
+bool AcquireItem(API::CNWSItem *pItem, API::CGameObject *pOwner);
+bool AddToArea(API::CGameObject *pObject, API::CNWSArea *pArea, float x, float y, float z);
+
 }
 
 }

--- a/Plugins/SQL/NWScript/nwnx_sql.nss
+++ b/Plugins/SQL/NWScript/nwnx_sql.nss
@@ -36,9 +36,10 @@ void NWNX_SQL_PreparedObjectFull(int position, object value);
 
 // Like NWNX_SQL_ReadDataInActiveRow, but for full serialized objects.
 // The object will be deserialized and created in the game. New object ID is returned.
-// If the deserialized object is an item, owner object must be specified:
-//    - If the owner is a placeable, creature or container, the item will be created in its inventory
-//    - If the owner is an area, the item will be created on the ground at Vector(x,y,z);
+// The exact behavior depends on type of deserialized object and owner object:
+//    - If object is an item, and owner if placeable, creature or container, the item will be created in its inventory
+//    - If owner is an area, the object will be created on the ground at Vector(x,y,z)
+//    - Otherwise, the object will be created outside the world and needs to be ported manually.
 object NWNX_SQL_ReadFullObjectInActiveRow(int column = 0, object owner = OBJECT_INVALID, float x = 0.0, float y = 0.0, float z = 0.0);
 
 // Return number of rows affected by SQL statement (for non-row-based statements like INSERT, UPDATE, DELETE, etc.);

--- a/Plugins/SQL/NWScript/nwnx_sql_t.nss
+++ b/Plugins/SQL/NWScript/nwnx_sql_t.nss
@@ -60,6 +60,8 @@ void main()
         return;
     }
 
+    vector v = Vector(5.0, 5.0, 0.0); // slightly different location.
+
     b = NWNX_SQL_PrepareQuery(sInsert);
     report("Complex PrepareQuery", b);
     report("GetPreparedQueryParamCount", NWNX_SQL_GetPreparedQueryParamCount() == 5);
@@ -92,12 +94,13 @@ void main()
             object o2 = NWNX_Object_StringToObject(IntToHexString(StringToInt(sObjId)));
             report("ReadObjectId", o == o2);
 
-            object o3 = NWNX_SQL_ReadFullObjectInActiveRow(4);
+            object o3 = NWNX_SQL_ReadFullObjectInActiveRow(4, GetArea(o), v.x, v.y, v.z);
             report("ReadFullObject", GetIsObjectValid(o3));
             // Alternatively:
             // object o3 = NWNX_Object_Deserialize(NWNX_SQL_ReadDataInActiveRow(4));
         }
     }
+
 
     object oPlc = CreateObject(OBJECT_TYPE_PLACEABLE, "nw_plc_chestburd", GetStartingLocation());
     object oItem = CreateObject(OBJECT_TYPE_ITEM, "x0_it_mring013", GetStartingLocation());
@@ -143,7 +146,7 @@ void main()
             report("Deserialized to placeable's inventory", oItem2 == GetFirstItemInInventory(oPlc));
             report("Deserialized to placeable's inventory - possessor", GetItemPossessor(oItem2) == oPlc);
 
-            object oItem3 = NWNX_SQL_ReadFullObjectInActiveRow(0, GetArea(oPlc));
+            object oItem3 = NWNX_SQL_ReadFullObjectInActiveRow(0, GetArea(oPlc), v.x, v.y, v.z);
             report("Deserialized to area", GetArea(oItem3) == GetArea(oPlc));
 
             object oItem4 = NWNX_SQL_ReadFullObjectInActiveRow(0, o);


### PR DESCRIPTION
 - Allow caller to specify owner area and x/y/z for all deserialized object types
 - Move AddToArea() and AcquireItems() to utils, they are useful otherwise
 - Use the new utils AsNWSXxx for cleaner/less code
 - Add a null check to the utils
 - Support deserializing UTC files as well (RCO doesn't do this)
 - Small unit test update
 - Clarification in the function docs