### PR TITLE
Tweaks: Add option to disable pausing

### DIFF
--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_plugin(Tweaks
     "Tweaks.cpp"
     "Tweaks/HideClassesOnCharList.cpp"
-    "Tweaks/PlayerDyingHitPointLimit.cpp")
+    "Tweaks/PlayerDyingHitPointLimit.cpp"
+    "Tweaks/DisablePause.cpp")

--- a/Plugins/Tweaks/Documentation/README.md
+++ b/Plugins/Tweaks/Documentation/README.md
@@ -7,3 +7,5 @@ Tweaks stuff. See below.
 ## Environment Variables
 
 HIDE_CLASSES_ON_CHAR_LIST: true or false
+PLAYER_DYING_HP_LIMIT: Between 0 and -127
+DISABLE_PAUSE: true or false

--- a/Plugins/Tweaks/Tweaks.cpp
+++ b/Plugins/Tweaks/Tweaks.cpp
@@ -1,6 +1,7 @@
 #include "Tweaks.hpp"
 #include "Tweaks/HideClassesOnCharList.hpp"
 #include "Tweaks/PlayerDyingHitPointLimit.hpp"
+#include "Tweaks/DisablePause.hpp"
 
 #include "Services/Config/Config.hpp"
 
@@ -43,6 +44,12 @@ Tweaks::Tweaks(const Plugin::CreateParams& params)
     {
         LOG_INFO("Setting the player dying HP limit to %d", hplimit);
         m_PlayerDyingHitPointLimit = std::make_unique<PlayerDyingHitPointLimit>(GetServices()->m_hooks.get(), hplimit);
+    }
+
+    if (GetServices()->m_config->Get<bool>("DISABLE_PAUSE", false))
+    {
+        LOG_INFO("Disabling pausing of the server");
+        m_DisablePause = std::make_unique<DisablePause>(GetServices()->m_hooks.get());
     }
 }
 

--- a/Plugins/Tweaks/Tweaks.hpp
+++ b/Plugins/Tweaks/Tweaks.hpp
@@ -6,6 +6,7 @@ namespace Tweaks {
 
 class HideClassesOnCharList;
 class PlayerDyingHitPointLimit;
+class DisablePause;
 
 class Tweaks : public NWNXLib::Plugin
 {
@@ -16,6 +17,7 @@ public:
 private:
     std::unique_ptr<HideClassesOnCharList> m_HideClassesOnCharlist;
     std::unique_ptr<PlayerDyingHitPointLimit> m_PlayerDyingHitPointLimit;
+    std::unique_ptr<DisablePause> m_DisablePause;
 };
 
 }

--- a/Plugins/Tweaks/Tweaks/DisablePause.cpp
+++ b/Plugins/Tweaks/Tweaks/DisablePause.cpp
@@ -1,0 +1,34 @@
+#include "Tweaks/DisablePause.hpp"
+
+#include "Services/Hooks/Hooks.hpp"
+#include "Utils.hpp"
+
+#include "API/CAppManager.hpp"
+#include "API/CServerExoAppInternal.hpp"
+#include "API/CServerExoApp.hpp"
+#include "API/Functions.hpp"
+#include "API/Globals.hpp"
+
+namespace Tweaks {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+NWNXLib::Hooking::FunctionHook* DisablePause::pSetPauseState_hook;
+DisablePause::DisablePause(ViewPtr<Services::HooksProxy> hooker)
+{
+    hooker->RequestExclusiveHook<Functions::CServerExoAppInternal__SetPauseState>
+                                    (&CServerExoAppInternal__SetPauseState_hook);
+
+    pSetPauseState_hook = hooker->FindHookByAddress(Functions::CServerExoAppInternal__SetPauseState);
+}
+
+void DisablePause::CServerExoAppInternal__SetPauseState_hook(CServerExoAppInternal* thisPtr, uint8_t nState, int32_t bPause)
+{
+    // nState=1 - timestop
+    // nState=2 - DM pause
+    if (nState != 2)
+        pSetPauseState_hook->CallOriginal<void>(thisPtr, nState, bPause);
+}
+
+}

--- a/Plugins/Tweaks/Tweaks/DisablePause.hpp
+++ b/Plugins/Tweaks/Tweaks/DisablePause.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "Common.hpp"
+#include "ViewPtr.hpp"
+#include "Services/Hooks/Hooks.hpp"
+
+namespace Tweaks {
+
+class DisablePause
+{
+public:
+    DisablePause(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
+
+private:
+    static void CServerExoAppInternal__SetPauseState_hook(NWNXLib::API::CServerExoAppInternal*, uint8_t, int32_t);
+    static NWNXLib::Hooking::FunctionHook* pSetPauseState_hook;
+};
+
+}


### PR DESCRIPTION
Requested by @zunath on discord and in #32 . Disables DM pause, but leaves timestop available.