### PR TITLE
Add two env vars for mono: BASE_DIRECTORY and APP_CONFIG. 

### DIFF
--- a/Plugins/Mono/Documentation/README.md
+++ b/Plugins/Mono/Documentation/README.md
@@ -66,4 +66,7 @@ SCRIPT_METRICS [optional]: Whether metrics are exported for script execution tim
 CLOSURE_METRICS [optional]: Whether metrics are exported for closure timings.
 MAIN_LOOP_METRICS [optional]: Whether metrics are exported for main loop tick timings.
 CONFIG_PATH [optional]: The path to the Mono config file. Advanced users only.
+BASE_DIRECTORY [optional]: The path to the directory where your code lives. This is necessary if you need to access App.config files. Used in conjunction with the APP_CONFIG environment variable. Both must be set to use App.config files.
+APP_CONFIG [optional]: The path to the App.config file used for your project. Used in conjunction with the BASE_DIRECTORY environment variable. Both must be set to use App.config files.
+
 ```

--- a/Plugins/Mono/Mono.cpp
+++ b/Plugins/Mono/Mono.cpp
@@ -55,6 +55,14 @@ Mono::Mono(const Plugin::CreateParams& params)
 
     g_Domain = mono_jit_init("nwnx");
 
+    Maybe<std::string> baseDirectory = GetServices()->m_config->Get<std::string>("BASE_DIRECTORY");
+    Maybe<std::string> appConfig = GetServices()->m_config->Get<std::string>("APP_CONFIG");
+    
+    if(baseDirectory && appConfig)
+    {
+        mono_domain_set_config(g_Domain, baseDirectory->c_str(), appConfig->c_str());
+    }
+
     m_ScriptMetrics = GetServices()->m_config->Get<bool>("SCRIPT_METRICS", true);
     m_ClosureMetrics = GetServices()->m_config->Get<bool>("CLOSURE_METRICS", true);
     m_MainLoopMetrics = GetServices()->m_config->Get<bool>("MAIN_LOOP_METRICS", true);


### PR DESCRIPTION
This allows App.config files to load when mono is embedded.