### PR TITLE
player: fix return type for shared hook

### DIFF
--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -65,7 +65,7 @@ Player::Player(const Plugin::CreateParams& params)
 
     GetServices()->m_hooks->RequestSharedHook
         <Functions::CNWSMessage__HandlePlayerToServerInputCancelGuiTimingEvent,
-            void, CNWSMessage*, CNWSPlayer*>(&HandlePlayerToServerInputCancelGuiTimingEventHook);
+            int32_t, CNWSMessage*, CNWSPlayer*>(&HandlePlayerToServerInputCancelGuiTimingEventHook);
 
 }
 


### PR DESCRIPTION
Tiny bugfix for #95 

I verified the hook still fires.