### PR TITLE
Two fixes to Mono stuff; Handle empty string in StackPopString() and handle character encoding. Mono assumes UTF-8, while NWN strings are in CP-1252 aka ANSI. (Also sneakily added an extra path to FindMySQL)

### DIFF
--- a/Build/CMakeModules/FindMySQL.cmake
+++ b/Build/CMakeModules/FindMySQL.cmake
@@ -19,7 +19,7 @@ FIND_PATH(MYSQL_INCLUDE_DIR mysql.h
 SET(MYSQL_NAMES mysqlclient mysqlclient_r)
 FIND_LIBRARY(MYSQL_LIBRARY
   NAMES ${MYSQL_NAMES}
-  PATHS /usr/lib /usr/local/lib
+  PATHS /usr/lib /usr/local/lib /usr/lib/i386-linux-gnu/
   PATH_SUFFIXES mysql
 )
 

--- a/Plugins/Mono/Mono_Handlers.cpp
+++ b/Plugins/Mono/Mono_Handlers.cpp
@@ -245,10 +245,7 @@ MonoString* StackPopString()
 
     LOG_DEBUG("Popped string '%s'.", value.m_sString);
 
-    if (value.m_sString != nullptr)
-        return mono_string_new(g_Domain, ISO88959ToUTF8(value.m_sString).c_str());
-    else
-        return mono_string_new(g_Domain, "");
+    return mono_string_new(g_Domain, ISO88959ToUTF8(value.CStr()).c_str());
 }
 
 uint32_t StackPopObject()
@@ -405,10 +402,13 @@ std::string ISO88959ToUTF8(const char *str)
     std::string utf8("");
     utf8.reserve(2*strlen(str) + 1);
 
-    for (; *str; ++str) {
-        if (!(*str & 0x80)) {
+    for (; *str; ++str)
+    {
+        if (!(*str & 0x80))
+        {
             utf8.push_back(*str);
-        } else {
+        } else
+        {
             utf8.push_back(0xc2 | ((unsigned char)(*str) >> 6));
             utf8.push_back(0x3f & *str);
         }

--- a/Plugins/Mono/Mono_Handlers.cpp
+++ b/Plugins/Mono/Mono_Handlers.cpp
@@ -246,7 +246,7 @@ MonoString* StackPopString()
     LOG_DEBUG("Popped string '%s'.", value.m_sString);
 
     if (value.m_sString != nullptr)
-        return mono_string_new(g_Domain, ISO88959ToUTF8(value.m_sString).get());
+        return mono_string_new(g_Domain, ISO88959ToUTF8(value.m_sString).c_str());
     else
         return mono_string_new(g_Domain, "");
 }
@@ -400,31 +400,20 @@ int32_t ClosureActionDoCommand(uint32_t oid, uint64_t eventId)
     return 0;
 }
 
-std::shared_ptr<char> ISO88959ToUTF8(const char *str)
+std::string ISO88959ToUTF8(const char *str)
 {
-    char* utf8 = new char[1 + (2 * strlen(str))];
+    std::string utf8("");
+    utf8.reserve(2*strlen(str) + 1);
 
-    int len = 0;
-
-    if (utf8) {
-        char *c = utf8;
-        for (; *str; ++str) {
-            if (!(*str & 0x80)) {
-                *c++ = *str;
-                len++;
-            } else {
-                *c++ = (char) (0xc2 | ((unsigned char)(*str) >> 6));
-
-                *c++ = (char) (0x3f & *str);
-                len += 2;
-            }
+    for (; *str; ++str) {
+        if (!(*str & 0x80)) {
+            utf8.push_back(*str);
+        } else {
+            utf8.push_back(0xc2 | ((unsigned char)(*str) >> 6));
+            utf8.push_back(0x3f & *str);
         }
-        *c++ = '\0';
     }
-
-    realloc(utf8, len);
-
-    return std::shared_ptr<char> (utf8);
+    return utf8;
 }
 
 }

--- a/Plugins/Mono/Mono_Handlers.hpp
+++ b/Plugins/Mono/Mono_Handlers.hpp
@@ -6,6 +6,8 @@
 #include <unordered_map>
 #include <stack>
 #include <vector>
+#include <cstring>
+#include <memory>
 
 #include <mono/jit/jit.h>
 
@@ -51,5 +53,7 @@ void BeginClosure(uint32_t value);
 int32_t ClosureAssignCommand(uint32_t oid, uint64_t eventId);
 int32_t ClosureDelayCommand(uint32_t oid, float duration, uint64_t eventId);
 int32_t ClosureActionDoCommand(uint32_t oid, uint64_t eventId);
+
+std::shared_ptr<char> ISO88959ToUTF8(const char *str);
 
 }

--- a/Plugins/Mono/Mono_Handlers.hpp
+++ b/Plugins/Mono/Mono_Handlers.hpp
@@ -54,6 +54,6 @@ int32_t ClosureAssignCommand(uint32_t oid, uint64_t eventId);
 int32_t ClosureDelayCommand(uint32_t oid, float duration, uint64_t eventId);
 int32_t ClosureActionDoCommand(uint32_t oid, uint64_t eventId);
 
-std::shared_ptr<char> ISO88959ToUTF8(const char *str);
+std::string ISO88959ToUTF8(const char *str);
 
 }


### PR DESCRIPTION
The function added, ISO88959ToUTF8, is defined in the bottom of Mono_Handlers.cpp.

I could use a sanity check for it.

To convert to UTF-8 from ISO-88959, we take a character array in 88959 and create an array twice its size, as that's the maximum size the converted array could have in theory.

When a character code is at or above 0x80, we need to split the character to two bytes. The first byte is c2 is for characters from 0x80 to 0xc0. For characters between 0xc0 and 0xff, the byte is c3. The second byte goes from 0x80 to 0xbf for both quarters. This byte layout is easily seen here: http://www.utf8-chartable.de/

This seems to have fixed my issues and now I can use "¦" as a data separator.

..Also, I added a path to FindMySQL.