### PR TITLE
Update tweaks plugin README

### DIFF
--- a/Plugins/Tweaks/Documentation/README.md
+++ b/Plugins/Tweaks/Documentation/README.md
@@ -6,6 +6,6 @@ Tweaks stuff. See below.
 
 ## Environment Variables
 
-HIDE_CLASSES_ON_CHAR_LIST: true or false
-PLAYER_DYING_HP_LIMIT: Between 0 and -127
-DISABLE_PAUSE: true or false
+* `NWNX_TWEAKS_HIDE_CLASSES_ON_CHAR_LIST`: true or false
+* `NWNX_TWEAKS_PLAYER_DYING_HP_LIMIT`: Between 0 and -127
+* `NWNX_TWEAKS_DISABLE_PAUSE`: true or false


### PR DESCRIPTION
The environment variables in the tweaks plugin README seem to be incomplete. At least in build 8166-1 they require a `NWNX_TWEAKS_` prefix to work.