### PR TITLE
creature: Add {G,S}etBaseSavingThrow functions

### DIFF
--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -76,6 +76,8 @@ private:
     ArgumentStack SetWalkRateCap                (ArgumentStack&& args);
     ArgumentStack SetGold                       (ArgumentStack&& args);
     ArgumentStack SetCorpseDecayTime            (ArgumentStack&& args);
+    ArgumentStack GetBaseSavingThrow            (ArgumentStack&& args);
+    ArgumentStack SetBaseSavingThrow            (ArgumentStack&& args);
     NWNXLib::API::CNWSCreature *creature(ArgumentStack& args);
 
 };

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -258,6 +258,12 @@ void NWNX_Creature_SetGold(object creature, int gold);
 // Sets corpse decay time in milliseconds
 void NWNX_Creature_SetCorpseDecayTime(object creature, int nDecayTime);
 
+// Returns the creature's base save and any modifiers set in the toolset
+int NWNX_Creature_GetBaseSavingThrow(object creature, int which);
+
+// Sets the base saving throw of the creature
+void NWNX_Creature_SetBaseSavingThrow(object creature, int which, int value);
+
 const string NWNX_Creature = "NWNX_Creature";
 
 
@@ -908,6 +914,27 @@ void NWNX_Creature_SetCorpseDecayTime(object creature, int nDecayTime)
 {
     string sFunc = "SetCorpseDecayTime";
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, nDecayTime);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+
+int NWNX_Creature_GetBaseSavingThrow(object creature, int which)
+{
+    string sFunc = "GetBaseSavingThrow";
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, which);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_SetBaseSavingThrow(object creature, int which, int value)
+{
+    string sFunc = "SetBaseSavingThrow";
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, value);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, which);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 
     NWNX_CallFunction(NWNX_Creature, sFunc);

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -128,5 +128,9 @@ void main()
     NWNX_Creature_SetGold(oCreature, nGold + 100);
     report("SetGold", GetGold(oCreature) == (nGold+100));
 
+    int nSave = NWNX_Creature_GetBaseSavingThrow(oCreature, SAVING_THROW_WILL);
+    NWNX_Creature_SetBaseSavingThrow(oCreature, SAVING_THROW_WILL, nSave + 10);
+    report("{S,G}etBaseSavingThrow", NWNX_Creature_GetBaseSavingThrow(oCreature, SAVING_THROW_WILL) == nSave+10);
+
     WriteTimestampedLogEntry("NWNX_Creature unit test end.");
 }


### PR DESCRIPTION
Requested in #120 

The old nwnx2 code was wrong, the fields are only used for overriding, and don't include the actual base save (which is calculated each time). This code considers base+misc to be base. Otherwise a straightforward implementation.