### PR TITLE
./Scripts/buildnwnx.sh -l

### DIFF
--- a/Scripts/buildnwnx.sh
+++ b/Scripts/buildnwnx.sh
@@ -6,8 +6,9 @@ CLEAN=1
 JOBS=""
 BUILD_TYPE="RelWithDebInfo"
 SANITIZE=""
+TOOLCHAIN=""
 
-while getopts "hcj:ds" o; do
+while getopts "hcj:dst" o; do
     case "${o}" in
         c) # Clean build - remove Binaries and re-execute cmake
             CLEAN=0
@@ -20,6 +21,9 @@ while getopts "hcj:ds" o; do
             ;;
         s) # Enable the address and undefined behaviour sanitisers
             SANITIZE="-DSANITIZE_ADDRESS=On -DSANITIZE_UNDEFINED=On"
+            ;;
+        t) # Enable forcing  locating of 32-bit libraries on linux
+            TOOLCHAIN="-DCMAKE_TOOLCHAIN_FILE=../Toolchains/linux_i686.toolchain.cmake"
             ;;
         h | *) # Display help
             usage
@@ -47,7 +51,7 @@ fi
 mkdir ./build-nwnx
 pushd ./build-nwnx
 
-cmake -D CMAKE_BUILD_TYPE=$BUILD_TYPE $SANITIZE ..
+cmake -D CMAKE_BUILD_TYPE=$BUILD_TYPE $SANITIZE $TOOLCHAIN ..
 
 make ${JOBS} all
 

--- a/Toolchains/linux_i686.toolchain.cmake
+++ b/Toolchains/linux_i686.toolchain.cmake
@@ -1,0 +1,7 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR "i686")
+
+set(NWNX_STANDARD_FLAGS "-m32 -march=pentium4 -fdiagnostics-show-option -fno-omit-frame-pointer -fno-pic")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${NWNX_STANDARD_FLAGS}" CACHE STRING "c++ flags")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NWNX_STANDARD_FLAGS}" CACHE STRING "c flags")


### PR DESCRIPTION
The -l Flag will force cmake to locate 32-bit libraries/packages.
Allows the 64-bit versions of the libraries to be installed without confusion during the building process . For example the 64-bit library counting as the package even if the 32-bit library is required for the plugin.

Decided on a flag as obviously people have been being able to build fine without it.