### PR TITLE
Fixed a possible issue for some compilers in Mono_Handler's converting ANSI to UTF-8

### DIFF
--- a/Plugins/Mono/Mono_Handlers.cpp
+++ b/Plugins/Mono/Mono_Handlers.cpp
@@ -410,7 +410,7 @@ std::string ISO88959ToUTF8(const char *str)
         } else
         {
             utf8.push_back(0xc2 | ((unsigned char)(*str) >> 6));
-            utf8.push_back(0x3f & *str);
+            utf8.push_back(0xbf & *str);
         }
     }
     return utf8;


### PR DESCRIPTION
Fixed an issue in setting the low bit to 2nd highest bit of a signed char. Under some compilers, result might not be what was expected.