### PR TITLE
Tweaks comparevars

### DIFF
--- a/NWNXLib/Utils.hpp
+++ b/NWNXLib/Utils.hpp
@@ -2,6 +2,8 @@
 
 #include "API/Types.hpp"
 #include "API/CGameObject.hpp"
+#include "API/CNWSScriptVarTable.hpp"
+#include "API/Vector.hpp"
 #include <string>
 
 
@@ -33,6 +35,11 @@ API::CNWSWaypoint*           AsNWSWaypoint(API::CGameObject* obj);
 bool AcquireItem(API::CNWSItem *pItem, API::CGameObject *pOwner);
 bool AddToArea(API::CGameObject *pObject, API::CNWSArea *pArea, float x, float y, float z);
 
+bool operator==(API::Vector& v1, API::Vector& v2);
+bool operator!=(API::Vector& v1, API::Vector& v2);
+
+// Returns TRUE if the var tables have the same variables with same values
+bool CompareVariables(API::CNWSScriptVarTable *pVars1, API::CNWSScriptVarTable *pVars2);
 }
 
 }

--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -3,4 +3,5 @@ add_plugin(Tweaks
     "Tweaks/HideClassesOnCharList.cpp"
     "Tweaks/PlayerDyingHitPointLimit.cpp"
     "Tweaks/DisablePause.cpp"
-    "Tweaks/FixMasterServerDNS.cpp")
+    "Tweaks/FixMasterServerDNS.cpp"
+    "Tweaks/CompareVarsForMerge.cpp")

--- a/Plugins/Tweaks/Tweaks.cpp
+++ b/Plugins/Tweaks/Tweaks.cpp
@@ -3,6 +3,7 @@
 #include "Tweaks/PlayerDyingHitPointLimit.hpp"
 #include "Tweaks/DisablePause.hpp"
 #include "Tweaks/FixMasterServerDNS.hpp"
+#include "Tweaks/CompareVarsForMerge.hpp"
 
 #include "Services/Config/Config.hpp"
 
@@ -57,6 +58,12 @@ Tweaks::Tweaks(const Plugin::CreateParams& params)
     {
         LOG_INFO("Fixing master server DNS fallback.");
         m_FixMasterServerDNS = std::make_unique<FixMasterServerDNS>(GetServices()->m_hooks.get());
+    }
+
+    if (GetServices()->m_config->Get<bool>("COMPARE_VARIABLES_WHEN_MERGING", false))
+    {
+        LOG_INFO("Will compare local variables when merging item stacks");
+        m_CompareVarsForMerge = std::make_unique<CompareVarsForMerge>(GetServices()->m_hooks.get());
     }
 }
 

--- a/Plugins/Tweaks/Tweaks.hpp
+++ b/Plugins/Tweaks/Tweaks.hpp
@@ -8,6 +8,7 @@ class HideClassesOnCharList;
 class PlayerDyingHitPointLimit;
 class DisablePause;
 class FixMasterServerDNS;
+class CompareVarsForMerge;
 
 class Tweaks : public NWNXLib::Plugin
 {
@@ -20,6 +21,7 @@ private:
     std::unique_ptr<PlayerDyingHitPointLimit> m_PlayerDyingHitPointLimit;
     std::unique_ptr<DisablePause> m_DisablePause;
     std::unique_ptr<FixMasterServerDNS> m_FixMasterServerDNS;
+    std::unique_ptr<CompareVarsForMerge> m_CompareVarsForMerge;
 };
 
 }

--- a/Plugins/Tweaks/Tweaks/CompareVarsForMerge.cpp
+++ b/Plugins/Tweaks/Tweaks/CompareVarsForMerge.cpp
@@ -1,0 +1,35 @@
+#include "Tweaks/CompareVarsForMerge.hpp"
+#include "API/CNWSItem.hpp"
+#include "API/Functions.hpp"
+#include "API/Globals.hpp"
+#include "API/Version.hpp"
+
+#include "Services/Hooks/Hooks.hpp"
+#include "Utils.hpp"
+
+
+namespace Tweaks {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+NWNXLib::Hooking::FunctionHook* CompareVarsForMerge::pCompareItem_hook;
+CompareVarsForMerge::CompareVarsForMerge(ViewPtr<Services::HooksProxy> hooker)
+{
+    hooker->RequestExclusiveHook<Functions::CNWSItem__CompareItem>
+                                    (&CNWSItem__CompareItem_hook);
+
+    pCompareItem_hook = hooker->FindHookByAddress(Functions::CNWSItem__CompareItem);
+}
+
+int32_t CompareVarsForMerge::CNWSItem__CompareItem_hook(CNWSItem* thisPtr, CNWSItem* pOtherItem)
+{
+    int32_t bCompare = pCompareItem_hook->CallOriginal<int32_t>(thisPtr, pOtherItem);
+    if (bCompare)
+    {
+        bCompare = Utils::CompareVariables(&thisPtr->m_ScriptVars, &pOtherItem->m_ScriptVars);
+    }
+    return bCompare;
+}
+
+}

--- a/Plugins/Tweaks/Tweaks/CompareVarsForMerge.hpp
+++ b/Plugins/Tweaks/Tweaks/CompareVarsForMerge.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "Common.hpp"
+#include "ViewPtr.hpp"
+#include "Services/Hooks/Hooks.hpp"
+
+namespace Tweaks {
+
+class CompareVarsForMerge
+{
+public:
+    CompareVarsForMerge(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
+
+private:
+    static int32_t CNWSItem__CompareItem_hook(NWNXLib::API::CNWSItem*, NWNXLib::API::CNWSItem*);
+    static NWNXLib::Hooking::FunctionHook* pCompareItem_hook;
+
+};
+
+}


### PR DESCRIPTION
Addresses #112 , and also useful elsewhere.

Logic is simple: If items have different local variables, they will not stack. If you want to prevent stacking on a certain item, you can use:
```C
SetLocalString(oItem, "_nostack", ObjectToString(oItem));
```

That will guarantee it has a unique variable and it won't be merged because other item objects will have different object IDs.