### PR TITLE
Tweaks: Allow parry to parry more than one attack in a flurry

### DIFF
--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -4,4 +4,5 @@ add_plugin(Tweaks
     "Tweaks/PlayerDyingHitPointLimit.cpp"
     "Tweaks/DisablePause.cpp"
     "Tweaks/FixMasterServerDNS.cpp"
-    "Tweaks/CompareVarsForMerge.cpp")
+    "Tweaks/CompareVarsForMerge.cpp"
+    "Tweaks/ParryAllAttacks.cpp")

--- a/Plugins/Tweaks/Documentation/README.md
+++ b/Plugins/Tweaks/Documentation/README.md
@@ -9,3 +9,5 @@ Tweaks stuff. See below.
 * `NWNX_TWEAKS_HIDE_CLASSES_ON_CHAR_LIST`: true or false
 * `NWNX_TWEAKS_PLAYER_DYING_HP_LIMIT`: Between 0 and -127
 * `NWNX_TWEAKS_DISABLE_PAUSE`: true or false
+* `COMPARE_VARIABLES_WHEN_MERGING`: true or false
+* `PARRY_ALL_ATTACKS`: true or false

--- a/Plugins/Tweaks/Tweaks.cpp
+++ b/Plugins/Tweaks/Tweaks.cpp
@@ -4,6 +4,7 @@
 #include "Tweaks/DisablePause.hpp"
 #include "Tweaks/FixMasterServerDNS.hpp"
 #include "Tweaks/CompareVarsForMerge.hpp"
+#include "Tweaks/ParryAllAttacks.hpp"
 
 #include "Services/Config/Config.hpp"
 
@@ -64,6 +65,12 @@ Tweaks::Tweaks(const Plugin::CreateParams& params)
     {
         LOG_INFO("Will compare local variables when merging item stacks");
         m_CompareVarsForMerge = std::make_unique<CompareVarsForMerge>(GetServices()->m_hooks.get());
+    }
+
+    if (GetServices()->m_config->Get<bool>("PARRY_ALL_ATTACKS", false))
+    {
+        LOG_INFO("Parry will no longer be limited to one attack per flurry");
+        m_ParryAllAttacks = std::make_unique<ParryAllAttacks>(GetServices()->m_hooks.get());
     }
 }
 

--- a/Plugins/Tweaks/Tweaks.hpp
+++ b/Plugins/Tweaks/Tweaks.hpp
@@ -9,6 +9,7 @@ class PlayerDyingHitPointLimit;
 class DisablePause;
 class FixMasterServerDNS;
 class CompareVarsForMerge;
+class ParryAllAttacks;
 
 class Tweaks : public NWNXLib::Plugin
 {
@@ -22,6 +23,7 @@ private:
     std::unique_ptr<DisablePause> m_DisablePause;
     std::unique_ptr<FixMasterServerDNS> m_FixMasterServerDNS;
     std::unique_ptr<CompareVarsForMerge> m_CompareVarsForMerge;
+    std::unique_ptr<ParryAllAttacks> m_ParryAllAttacks;
 };
 
 }

--- a/Plugins/Tweaks/Tweaks/ParryAllAttacks.cpp
+++ b/Plugins/Tweaks/Tweaks/ParryAllAttacks.cpp
@@ -1,0 +1,46 @@
+#include "Tweaks/ParryAllAttacks.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/CNWSCombatRound.hpp"
+#include "API/Functions.hpp"
+#include "API/Globals.hpp"
+#include "API/Version.hpp"
+
+#include "Services/Hooks/Hooks.hpp"
+#include "Utils.hpp"
+
+
+namespace Tweaks {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+NWNXLib::Hooking::FunctionHook* ParryAllAttacks::pResolveAttackRoll_hook;
+ParryAllAttacks::ParryAllAttacks(ViewPtr<Services::HooksProxy> hooker)
+{
+    hooker->RequestExclusiveHook<Functions::CNWSCreature__ResolveAttackRoll>
+                                    (&CNWSCreature__ResolveAttackRoll_hook);
+
+    pResolveAttackRoll_hook = hooker->FindHookByAddress(Functions::CNWSCreature__ResolveAttackRoll);
+}
+
+
+void ParryAllAttacks::CNWSCreature__ResolveAttackRoll_hook(CNWSCreature *pThis, CNWSObject *pTarget)
+{
+    int32_t bRoundPaused = false;
+    if (auto *pCreature = Utils::AsNWSCreature(pTarget))
+    {
+        if (pCreature->m_nCombatMode == 1 /*parry*/ &&
+            pCreature->m_pcCombatRound->m_nParryActions > 0 &&
+            !pCreature->GetRangeWeaponEquipped())
+        {
+            bRoundPaused = pCreature->m_pcCombatRound->m_bRoundPaused;
+            pCreature->m_pcCombatRound->m_bRoundPaused = false;
+        }
+    }
+    pResolveAttackRoll_hook->CallOriginal<void>(pThis, pTarget);
+    if (bRoundPaused)
+        Utils::AsNWSCreature(pTarget)->m_pcCombatRound->m_bRoundPaused = true;
+}
+
+
+}

--- a/Plugins/Tweaks/Tweaks/ParryAllAttacks.hpp
+++ b/Plugins/Tweaks/Tweaks/ParryAllAttacks.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "Common.hpp"
+#include "ViewPtr.hpp"
+#include "Services/Hooks/Hooks.hpp"
+
+namespace Tweaks {
+
+class ParryAllAttacks
+{
+public:
+    ParryAllAttacks(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
+
+private:
+    static void CNWSCreature__ResolveAttackRoll_hook(NWNXLib::API::CNWSCreature*, NWNXLib::API::CNWSObject*);
+    static NWNXLib::Hooking::FunctionHook* pResolveAttackRoll_hook;
+};
+
+}


### PR DESCRIPTION
Here's a fun one. When this is enabled, a parrying character will not differentiate between flurries with regards to parry. This has a few consequences:
 - Attacks are now parried in order, not first in flurry. So in case of 4 attacks (+16/+11/+6/+1), the first three will be parried instead of +16/+6/+1 as it was previously.
 - This form of parry is seriously unbalanced in epic levels, as you can typically get +30 to the skill.
 - Animations to trigger two riposte attacks in a flurry don't exist. In these cases only a single animation will be played.

This wasn't really tested in too much detail, so it might possibly mess with some other combat sequences.