### PR TITLE
New plugin: dialog

### DIFF
--- a/Plugins/Dialog/CMakeLists.txt
+++ b/Plugins/Dialog/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_plugin(Dialog
+    "Dialog.cpp")

--- a/Plugins/Dialog/Dialog.cpp
+++ b/Plugins/Dialog/Dialog.cpp
@@ -1,0 +1,350 @@
+#include "Dialog.hpp"
+
+#include "API/CAppManager.hpp"
+#include "API/CServerExoApp.hpp"
+#include "API/CNWSObject.hpp"
+#include "API/CNWSDialog.hpp"
+#include "API/CNWSDialogEntry.hpp"
+#include "API/CNWSDialogReply.hpp"
+#include "API/CNWSDialogLinkEntry.hpp"
+#include "API/CNWSDialogLinkReply.hpp"
+#include "API/CExoLocString.hpp"
+#include "API/CExoString.hpp"
+#include "API/CResRef.hpp"
+#include "API/Constants.hpp"
+#include "API/Globals.hpp"
+#include "API/Functions.hpp"
+#include "Services/Events/Events.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include "ViewPtr.hpp"
+#include "Utils.hpp"
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+static ViewPtr<Dialog::Dialog> g_plugin;
+
+NWNX_PLUGIN_ENTRY Plugin::Info* PluginInfo()
+{
+    return new Plugin::Info
+    {
+        "Dialog",
+        "Functions exposing additional dialog properties",
+        "sherincall",
+        "sherincall@gmail.com",
+        1,
+        true
+    };
+}
+
+NWNX_PLUGIN_ENTRY Plugin* PluginLoad(Plugin::CreateParams params)
+{
+    g_plugin = new Dialog::Dialog(params);
+    return g_plugin;
+}
+
+namespace Dialog {
+
+//
+// Constants mirrored from NSS
+const int32_t NODE_TYPE_INVALID       = -1;
+const int32_t NODE_TYPE_STARTING_NODE = 0;
+const int32_t NODE_TYPE_ENTRY_NODE    = 1;
+const int32_t NODE_TYPE_REPLY_NODE    = 2;
+
+const int32_t SCRIPT_TYPE_OTHER = 0;
+const int32_t SCRIPT_TYPE_STARTING_CONDITIONAL = 1;
+const int32_t SCRIPT_TYPE_ACTION_TAKEN = 2;
+
+//
+// Hooks to maintain the state stack
+//
+Dialog::State Dialog::statestack[16];
+int32_t Dialog::ssp;
+CNWSDialog *Dialog::pDialog;
+CNWSObject *Dialog::pOwner;
+uint32_t Dialog::idxEntry;
+uint32_t Dialog::idxReply;
+int32_t  Dialog::scriptType;
+int32_t  Dialog::loopCount;
+
+void Dialog::Hooks::GetStartEntry(Services::Hooks::CallType type, CNWSDialog *pThis, 
+    CNWSObject* pNWSObjectOwner)
+{
+    pDialog = pThis;
+    pOwner = pNWSObjectOwner;
+    loopCount = 0;
+    if (type == Services::Hooks::CallType::BEFORE_ORIGINAL)
+        statestack[++ssp] = DIALOG_STATE_START;
+    else ssp--;
+}
+
+void Dialog::Hooks::GetStartEntryOneLiner(Services::Hooks::CallType type, CNWSDialog *pThis, 
+    CNWSObject* pNWSObjectOwner, CExoLocString& sOneLiner, CResRef* sSound, CResRef* sScript)
+{
+    pDialog = pThis;
+    pOwner = pNWSObjectOwner;
+    loopCount = 0;
+    (void)sOneLiner; (void)sSound; (void)sScript;
+    if (type == Services::Hooks::CallType::BEFORE_ORIGINAL)
+        statestack[++ssp] = DIALOG_STATE_START;
+    else ssp--;
+}
+
+void Dialog::Hooks::SendDialogEntry(Services::Hooks::CallType type, CNWSDialog *pThis,
+    CNWSObject* pNWSObjectOwner, uint32_t nPlayerIdGUIOnly, uint32_t iEntry, int32_t bPlayHelloSound)
+{
+    pDialog = pThis;
+    pOwner = pNWSObjectOwner;
+    idxEntry = iEntry;
+    loopCount = 0;
+    (void)nPlayerIdGUIOnly; (void)bPlayHelloSound;
+    if (type == Services::Hooks::CallType::BEFORE_ORIGINAL)
+        statestack[++ssp] = DIALOG_STATE_SEND_ENTRY;
+    else ssp--;
+}
+
+void Dialog::Hooks::SendDialogReplies(Services::Hooks::CallType type, CNWSDialog *pThis,
+    CNWSObject* pNWSObjectOwner, uint32_t nPlayerIdGUIOnly)
+{
+    pDialog = pThis;
+    pOwner = pNWSObjectOwner;
+    loopCount = 0;
+    (void)nPlayerIdGUIOnly;
+    if (type == Services::Hooks::CallType::BEFORE_ORIGINAL)
+        statestack[++ssp] = DIALOG_STATE_SEND_REPLIES;
+    else ssp--;
+}
+
+void Dialog::Hooks::HandleReply(Services::Hooks::CallType type, CNWSDialog *pThis,
+    uint32_t nPlayerID, CNWSObject* pNWSObjectOwner, uint32_t nReplyIndex, int32_t bEscapeDialog, uint32_t currentEntryIndex)
+{
+    pDialog = pThis;
+    pOwner = pNWSObjectOwner;
+    idxEntry = currentEntryIndex;
+    idxReply = nReplyIndex;
+    loopCount = 0;
+    (void)bEscapeDialog; (void)nPlayerID;
+    if (type == Services::Hooks::CallType::BEFORE_ORIGINAL)
+        statestack[++ssp] = DIALOG_STATE_HANDLE_REPLY;
+    else ssp--;
+}
+
+void Dialog::Hooks::CheckScript(Services::Hooks::CallType type, CNWSDialog *pThis, 
+    CNWSObject* pNWSObjectOwner, const CResRef* sActive)
+{
+    pDialog = pThis;
+    pOwner = pNWSObjectOwner;
+    (void)sActive;
+    if (type == Services::Hooks::CallType::BEFORE_ORIGINAL)
+    {
+        scriptType = SCRIPT_TYPE_STARTING_CONDITIONAL;
+    }
+    else
+    {
+        loopCount++;
+        scriptType = SCRIPT_TYPE_OTHER;
+    }
+}
+
+void Dialog::Hooks::RunScript(Services::Hooks::CallType type, CNWSDialog *pThis, 
+    CNWSObject* pNWSObjectOwner, const CResRef* sScript)
+{
+    pDialog = pThis;
+    pOwner = pNWSObjectOwner;
+    (void)sScript;
+    if (type == Services::Hooks::CallType::BEFORE_ORIGINAL)
+        scriptType = SCRIPT_TYPE_ACTION_TAKEN;
+    else
+        scriptType = SCRIPT_TYPE_OTHER;
+}
+
+Dialog::Dialog(const Plugin::CreateParams& params)
+    : Plugin(params)
+{
+#define REGISTER(func) \
+    GetServices()->m_events->RegisterEvent(#func, std::bind(&Dialog::func, this, std::placeholders::_1))
+
+    REGISTER(GetCurrentNodeType);
+    REGISTER(GetCurrentScriptType);
+    REGISTER(GetCurrentNodeID);
+    REGISTER(GetCurrentNodeIndex);
+    REGISTER(GetCurrentNodeText);
+    REGISTER(SetCurrentNodeText);
+#undef REGISTER
+
+    GetServices()->m_hooks->RequestSharedHook
+        <Functions::CNWSDialog__GetStartEntry,
+            uint32_t, CNWSDialog*, CNWSObject*>(&Hooks::GetStartEntry);
+//    GetServices()->m_hooks->RequestSharedHook
+//        <Functions::CNWSDialog__GetStartEntryOneLiner,
+//            int32_t, CNWSDialog*, CNWSObject*, CExoLocString&, CResRef*, CResRef*>(&Hooks::GetStartEntryOneLiner);
+    GetServices()->m_hooks->RequestSharedHook
+        <Functions::CNWSDialog__SendDialogEntry,
+            int32_t, CNWSDialog*, CNWSObject*, uint32_t, uint32_t, int32_t>(&Hooks::SendDialogEntry);
+    GetServices()->m_hooks->RequestSharedHook
+        <Functions::CNWSDialog__SendDialogReplies,
+            int32_t, CNWSDialog*, CNWSObject*, uint32_t>(&Hooks::SendDialogReplies);
+    GetServices()->m_hooks->RequestSharedHook
+        <Functions::CNWSDialog__HandleReply,
+            int32_t, CNWSDialog*, uint32_t , CNWSObject*, uint32_t, int32_t, uint32_t>(&Hooks::HandleReply);
+    GetServices()->m_hooks->RequestSharedHook
+        <Functions::CNWSDialog__CheckScript,
+        int32_t, CNWSDialog *, CNWSObject*, const CResRef*>(&Hooks::CheckScript);
+    GetServices()->m_hooks->RequestSharedHook
+        <Functions::CNWSDialog__RunScript,
+        void, CNWSDialog *, CNWSObject*, const CResRef*>(&Hooks::RunScript);
+}
+
+Dialog::~Dialog()
+{
+}
+
+ArgumentStack Dialog::GetCurrentNodeType(ArgumentStack&& args)
+{
+    (void)args;
+    ArgumentStack stack;
+    int32_t retval;
+    switch (statestack[ssp])
+    {
+        case DIALOG_STATE_START:        retval = NODE_TYPE_STARTING_NODE; break;
+        case DIALOG_STATE_SEND_ENTRY:   retval = NODE_TYPE_ENTRY_NODE;    break;
+        case DIALOG_STATE_HANDLE_REPLY: retval = NODE_TYPE_REPLY_NODE;    break;
+        case DIALOG_STATE_SEND_REPLIES: retval = NODE_TYPE_REPLY_NODE;    break;
+        default: retval = NODE_TYPE_INVALID;                              break;
+    }
+
+    Services::Events::InsertArgument(stack, retval);
+    return stack;
+}
+
+ArgumentStack Dialog::GetCurrentScriptType(ArgumentStack&& args)
+{
+    (void)args;
+    ArgumentStack stack;
+    Services::Events::InsertArgument(stack, scriptType);
+    return stack;
+}
+
+ArgumentStack Dialog::GetCurrentNodeID(ArgumentStack&& args)
+{
+    (void)args;
+    ArgumentStack stack;
+    int32_t retval;
+
+    switch (statestack[ssp])
+    {
+        case DIALOG_STATE_START:
+            retval = pDialog->m_pStartingEntries[loopCount].m_nIndex;
+            break;
+        case DIALOG_STATE_SEND_ENTRY:
+            retval = idxEntry;
+            break;
+        case DIALOG_STATE_HANDLE_REPLY:
+            retval = idxReply;
+            break;
+        case DIALOG_STATE_SEND_REPLIES:
+            retval = pDialog->m_pEntries[pDialog->m_currentEntryIndex].m_pReplies[loopCount].m_nIndex;
+            break;
+        default: 
+            retval = -1;
+            break;
+    }
+
+    Services::Events::InsertArgument(stack, retval);
+    return stack;
+}
+
+ArgumentStack Dialog::GetCurrentNodeIndex(ArgumentStack&& args)
+{
+    (void)args;
+    ArgumentStack stack;
+    Services::Events::InsertArgument(stack, loopCount);
+    return stack;
+}
+
+ArgumentStack Dialog::GetCurrentNodeText(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    CExoString str;
+
+    auto language = Services::Events::ExtractArgument<int32_t>(args);
+    auto gender = Services::Events::ExtractArgument<int32_t>(args);
+    CExoLocString *pLocString;
+
+    switch (statestack[ssp])
+    {
+        case DIALOG_STATE_START:
+            pLocString = &pDialog->m_pEntries[pDialog->m_pStartingEntries[loopCount].m_nIndex].m_sText;
+            break;
+        case DIALOG_STATE_SEND_ENTRY:
+            pLocString = &pDialog->m_pEntries[idxEntry].m_sText;
+            break;
+        case DIALOG_STATE_HANDLE_REPLY:
+            pLocString = &pDialog->m_pReplies[idxReply].m_sText;
+            break;
+        case DIALOG_STATE_SEND_REPLIES:
+        {
+            auto idx = pDialog->m_pEntries[pDialog->m_currentEntryIndex].m_pReplies[loopCount].m_nIndex;
+            pLocString = &pDialog->m_pReplies[idx].m_sText;
+            break;
+        }
+        default: 
+            pLocString = nullptr;
+            break;
+    }
+
+    if (pLocString)
+    {
+        gender = !!gender; // Only male/female supported; CExoLocString is traditional that way.
+        pLocString->GetString(language, &str, gender, true);
+    }
+
+    Services::Events::InsertArgument(stack, std::string(str.CStr()));
+    return stack;
+}
+
+ArgumentStack Dialog::SetCurrentNodeText(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+
+    auto str = Services::Events::ExtractArgument<std::string>(args);
+    auto language = Services::Events::ExtractArgument<int32_t>(args);
+    auto gender = Services::Events::ExtractArgument<int32_t>(args);
+    CExoLocString *pLocString;
+
+    switch (statestack[ssp])
+    {
+        case DIALOG_STATE_START:
+            pLocString = &pDialog->m_pEntries[pDialog->m_pStartingEntries[loopCount].m_nIndex].m_sText;
+            break;
+        case DIALOG_STATE_SEND_ENTRY:
+            pLocString = &pDialog->m_pEntries[idxEntry].m_sText;
+            break;
+        case DIALOG_STATE_HANDLE_REPLY:
+            pLocString = &pDialog->m_pReplies[idxReply].m_sText;
+            break;
+        case DIALOG_STATE_SEND_REPLIES:
+        {
+            auto idx = pDialog->m_pEntries[pDialog->m_currentEntryIndex].m_pReplies[loopCount].m_nIndex;
+            pLocString = &pDialog->m_pReplies[idx].m_sText;
+            break;
+        }
+        default: 
+            pLocString = nullptr;
+            break;
+    }
+
+    if (pLocString)
+    {
+        CExoString cexostr = str.c_str();
+        gender = !!gender; // Only male/female supported; CExoLocString is traditional that way.
+        pLocString->AddString(language, cexostr, gender);
+    }
+
+    return stack;
+}
+
+
+
+}

--- a/Plugins/Dialog/Dialog.hpp
+++ b/Plugins/Dialog/Dialog.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "Plugin.hpp"
+#include "Services/Events/Events.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include "API/Types.hpp"
+
+using ArgumentStack = NWNXLib::Services::Events::ArgumentStack;
+
+namespace Dialog {
+
+class Dialog : public NWNXLib::Plugin
+{
+public:
+    Dialog(const Plugin::CreateParams& params);
+    virtual ~Dialog();
+
+private:
+    struct Hooks {
+        static void GetStartEntry(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSDialog *pThis,
+            NWNXLib::API::CNWSObject* pNWSObjectOwner);
+        static void GetStartEntryOneLiner(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSDialog *pThis,
+            NWNXLib::API::CNWSObject* pNWSObjectOwner, NWNXLib::API::CExoLocString& sOneLiner, NWNXLib::API::CResRef* sSound, NWNXLib::API::CResRef* sScript);
+        static void SendDialogEntry(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSDialog *pThis,
+            NWNXLib::API::CNWSObject* pNWSObjectOwner, uint32_t nPlayerIdGUIOnly, uint32_t iEntry, int32_t bPlayHelloSound);
+        static void SendDialogReplies(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSDialog *pThis,
+            NWNXLib::API::CNWSObject* pNWSObjectOwner, uint32_t nPlayerIdGUIOnly);
+        static void HandleReply(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSDialog *pThis,
+            uint32_t nPlayerID, NWNXLib::API::CNWSObject* pNWSObjectOwner, uint32_t nReplyIndex, int32_t bEscapeDialog, uint32_t currentEntryIndex);
+        static void CheckScript(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSDialog *pThis,
+            NWNXLib::API::CNWSObject*, const NWNXLib::API::CResRef*);
+        static void RunScript(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSDialog *pThis,
+            NWNXLib::API::CNWSObject*, const NWNXLib::API::CResRef*);
+    };
+    static enum State {
+        DIALOG_STATE_INVALID,
+        DIALOG_STATE_START,
+        DIALOG_STATE_SEND_ENTRY,
+        DIALOG_STATE_SEND_REPLIES,
+        DIALOG_STATE_HANDLE_REPLY
+    } statestack[16];
+    static int32_t ssp;
+    static NWNXLib::API::CNWSDialog *pDialog;
+    static NWNXLib::API::CNWSObject *pOwner;
+    static uint32_t idxEntry;
+    static uint32_t idxReply;
+    static int32_t  scriptType;
+    static int32_t  loopCount;
+
+    ArgumentStack GetCurrentNodeType   (ArgumentStack&& args);
+    ArgumentStack GetCurrentScriptType (ArgumentStack&& args);
+    ArgumentStack GetCurrentNodeID     (ArgumentStack&& args);
+    ArgumentStack GetCurrentNodeIndex  (ArgumentStack&& args);
+    ArgumentStack GetCurrentNodeText   (ArgumentStack&& args);
+    ArgumentStack SetCurrentNodeText   (ArgumentStack&& args);
+};
+
+}

--- a/Plugins/Dialog/Documentation/README.md
+++ b/Plugins/Dialog/Documentation/README.md
@@ -1,0 +1,7 @@
+# Dialog Plugin Reference
+
+## Description
+
+Functions exposing additional dialog properties
+
+## Environment Variables

--- a/Plugins/Dialog/NWScript/nwnx_dialog.nss
+++ b/Plugins/Dialog/NWScript/nwnx_dialog.nss
@@ -1,0 +1,94 @@
+#include "nwnx"
+
+const int NWNX_DIALOG_NODE_TYPE_INVALID                = -1;
+const int NWNX_DIALOG_NODE_TYPE_STARTING_NODE          = 0;
+const int NWNX_DIALOG_NODE_TYPE_ENTRY_NODE             = 1;
+const int NWNX_DIALOG_NODE_TYPE_REPLY_NODE             = 2;
+
+const int NWNX_DIALOG_SCRIPT_TYPE_OTHER                = 0;
+const int NWNX_DIALOG_SCRIPT_TYPE_STARTING_CONDITIONAL = 1;
+const int NWNX_DIALOG_SCRIPT_TYPE_ACTION_TAKEN         = 2;
+
+const int NWNX_DIALOG_LANGUAGE_ENGLISH                 = 0;
+const int NWNX_DIALOG_LANGUAGE_FRENCH                  = 1;
+const int NWNX_DIALOG_LANGUAGE_GERMAN                  = 2;
+const int NWNX_DIALOG_LANGUAGE_ITALIAN                 = 3;
+const int NWNX_DIALOG_LANGUAGE_SPANISH                 = 4;
+const int NWNX_DIALOG_LANGUAGE_POLISH                  = 5;
+const int NWNX_DIALOG_LANGUAGE_KOREAN                  = 128;
+const int NWNX_DIALOG_LANGUAGE_CHINESE_TRADITIONAL     = 129;
+const int NWNX_DIALOG_LANGUAGE_CHINESE_SIMPLIFIED      = 130;
+const int NWNX_DIALOG_LANGUAGE_JAPANESE                = 131;
+
+// Get the type (NWNX_DIALOG_NODE_TYPE_*) of the current text node
+// If called out of dialog, returns INVALID
+int NWNX_Dialog_GetCurrentNodeType();
+
+// Get the current script type (NWNX_DIALOG_SCRIPT_TYPE_*)
+// If called out of dialog, returns OTHER
+int NWNX_Dialog_GetCurrentScriptType();
+
+// Get the absolute ID of the current node in the conversation
+// ENTRY and REPLY nodes have different namespaces, so can have double IDs
+// If called out of dialog, returns -1
+int NWNX_Dialog_GetCurrentNodeID();
+
+// Get the index of the current node in the list of replies/entries.
+// The index is zero based, and counts items not displayed due StartingConditional
+int NWNX_Dialog_GetCurrentNodeIndex();
+
+// Get the text of the current node for given language/gender
+string NWNX_Dialog_GetCurrentNodeText(int language=NWNX_DIALOG_LANGUAGE_ENGLISH, int gender=GENDER_MALE);
+
+// Set the text of the current node for given language/gender
+// This will persist until server reset, for this dialog owner only
+void NWNX_Dialog_SetCurrentNodeText(string text, int language=NWNX_DIALOG_LANGUAGE_ENGLISH, int gender=GENDER_MALE);
+
+
+const string NWNX_Dialog = "NWNX_Dialog";
+
+int NWNX_Dialog_GetCurrentNodeType()
+{
+    string sFunc = "GetCurrentNodeType";
+    NWNX_CallFunction(NWNX_Dialog, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Dialog, sFunc);
+}
+
+int NWNX_Dialog_GetCurrentScriptType()
+{
+    string sFunc = "GetCurrentScriptType";
+    NWNX_CallFunction(NWNX_Dialog, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Dialog, sFunc);
+}
+
+int NWNX_Dialog_GetCurrentNodeID()
+{
+    string sFunc = "GetCurrentNodeID";
+    NWNX_CallFunction(NWNX_Dialog, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Dialog, sFunc);
+}
+
+int NWNX_Dialog_GetCurrentNodeIndex()
+{
+    string sFunc = "GetCurrentNodeIndex";
+    NWNX_CallFunction(NWNX_Dialog, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Dialog, sFunc);
+}
+
+string NWNX_Dialog_GetCurrentNodeText(int language=NWNX_DIALOG_LANGUAGE_ENGLISH, int gender=GENDER_MALE)
+{
+    string sFunc = "GetCurrentNodeText";
+    NWNX_PushArgumentInt(NWNX_Dialog, sFunc, gender);
+    NWNX_PushArgumentInt(NWNX_Dialog, sFunc, language);
+    NWNX_CallFunction(NWNX_Dialog, sFunc);
+    return NWNX_GetReturnValueString(NWNX_Dialog, sFunc);
+}
+
+void NWNX_Dialog_SetCurrentNodeText(string text, int language=NWNX_DIALOG_LANGUAGE_ENGLISH, int gender=GENDER_MALE)
+{
+    string sFunc = "SetCurrentNodeText";
+    NWNX_PushArgumentInt(NWNX_Dialog, sFunc, gender);
+    NWNX_PushArgumentInt(NWNX_Dialog, sFunc, language);
+    NWNX_PushArgumentString(NWNX_Dialog, sFunc, text);
+    NWNX_CallFunction(NWNX_Dialog, sFunc);
+}

--- a/Plugins/Dialog/NWScript/nwnx_dialog.nss
+++ b/Plugins/Dialog/NWScript/nwnx_dialog.nss
@@ -41,7 +41,7 @@ int NWNX_Dialog_GetCurrentNodeIndex();
 string NWNX_Dialog_GetCurrentNodeText(int language=NWNX_DIALOG_LANGUAGE_ENGLISH, int gender=GENDER_MALE);
 
 // Set the text of the current node for given language/gender
-// This will persist until server reset, for this dialog owner only
+// This will only work in a starting conditional script (action take comes after the text is displayed)
 void NWNX_Dialog_SetCurrentNodeText(string text, int language=NWNX_DIALOG_LANGUAGE_ENGLISH, int gender=GENDER_MALE);
 
 

--- a/Plugins/Dialog/NWScript/nwnx_dialog_t.nss
+++ b/Plugins/Dialog/NWScript/nwnx_dialog_t.nss
@@ -1,0 +1,37 @@
+#include "nwnx_dialog"
+
+void _report()
+{
+    string sMessage = "NWNX_Dialog debug:";
+    int id = NWNX_Dialog_GetCurrentNodeID();
+    sMessage = "\nNode ID = " + IntToString(id);
+
+    int type = NWNX_Dialog_GetCurrentNodeType();
+    sMessage += "\nCurrent node type = " + IntToString(type) + " (";
+    switch (type)
+    {
+        case NWNX_DIALOG_NODE_TYPE_INVALID: sMessage += "INVALID)"; break;
+        case NWNX_DIALOG_NODE_TYPE_STARTING_NODE: sMessage += "STARTING_NODE)"; break;
+        case NWNX_DIALOG_NODE_TYPE_ENTRY_NODE: sMessage += "ENTRY_NODE)"; break;
+        case NWNX_DIALOG_NODE_TYPE_REPLY_NODE: sMessage += "REPLY_NODE)"; break;
+    }
+
+    int scripttype = NWNX_Dialog_GetCurrentScriptType();
+    sMessage += "\nScript type = " + IntToString(scripttype) + " (";
+    switch (scripttype)
+    {
+        case NWNX_DIALOG_SCRIPT_TYPE_OTHER: sMessage += "OTHER)"; break;
+        case NWNX_DIALOG_SCRIPT_TYPE_STARTING_CONDITIONAL: sMessage += "STARTING_CONDITIONAL)"; break;
+        case NWNX_DIALOG_SCRIPT_TYPE_ACTION_TAKEN: sMessage += "ACTION_TAKEN)"; break;
+    }
+
+    int index = NWNX_Dialog_GetCurrentNodeIndex();
+    sMessage += "\nNode index = " + IntToString(index);
+
+    string text = NWNX_Dialog_GetCurrentNodeText();
+    sMessage += "\nText = '" + text + "'";
+
+    NWNX_Dialog_SetCurrentNodeText(text + " [ADDED]");
+
+    SendMessageToPC(GetFirstPC(), sMessage);
+}

--- a/Plugins/Dialog/NWScript/nwnx_dialog_t1.nss
+++ b/Plugins/Dialog/NWScript/nwnx_dialog_t1.nss
@@ -1,0 +1,7 @@
+#include "nwnx_dialog_t"
+
+int StartingConditional()
+{
+    _report();
+    return FALSE;
+}

--- a/Plugins/Dialog/NWScript/nwnx_dialog_t2.nss
+++ b/Plugins/Dialog/NWScript/nwnx_dialog_t2.nss
@@ -1,0 +1,7 @@
+#include "nwnx_dialog_t"
+
+int StartingConditional()
+{
+    _report();
+    return TRUE;
+}

--- a/Plugins/Dialog/NWScript/nwnx_dialog_t3.nss
+++ b/Plugins/Dialog/NWScript/nwnx_dialog_t3.nss
@@ -1,0 +1,6 @@
+#include "nwnx_dialog_t"
+
+void main()
+{
+    _report();
+}


### PR DESCRIPTION
Long standing request, see #26 . Also surprisingly hard to do without inline hooks.

```C

// Get the type (NWNX_DIALOG_NODE_TYPE_*) of the current text node
// If called out of dialog, returns INVALID
int NWNX_Dialog_GetCurrentNodeType();

// Get the current script type (NWNX_DIALOG_SCRIPT_TYPE_*)
// If called out of dialog, returns OTHER
int NWNX_Dialog_GetCurrentScriptType();

// Get the absolute ID of the current node in the conversation
// ENTRY and REPLY nodes have different namespaces, so can have double IDs
// If called out of dialog, returns -1
int NWNX_Dialog_GetCurrentNodeID();

// Get the index of the current node in the list of replies/entries.
// The index is zero based, and counts items not displayed due StartingConditional
int NWNX_Dialog_GetCurrentNodeIndex();

// Get the text of the current node for given language/gender
string NWNX_Dialog_GetCurrentNodeText(int language=NWNX_DIALOG_LANGUAGE_ENGLISH, int gender=GENDER_MALE);

// Set the text of the current node for given language/gender
// This will only work in a starting conditional script (action take comes after the text is displayed)
void NWNX_Dialog_SetCurrentNodeText(string text, int language=NWNX_DIALOG_LANGUAGE_ENGLISH, int gender=GENDER_MALE);
```

Pretty experimental currently, but not destructive, so should be good to merge.