### PR TITLE
plugins/jvm: don't memleak popped CGameEffects and ScriptLocations

### DIFF
--- a/Plugins/JVM/Internal.cpp
+++ b/Plugins/JVM/Internal.cpp
@@ -8,6 +8,7 @@
 
 #include "API/Functions.hpp"
 #include "API/CNWVirtualMachineCommands.hpp"
+#include "API/CGameEffect.hpp"
 
 using namespace NWNXLib;
 using namespace NWNXLib::API;
@@ -165,6 +166,11 @@ ArgumentStack Internal::EntryPoint(jmethodID method, ArgumentStack& args)
 
     // reset event mappings
     if (m_contextDepth == 0) {
+        for (const CGameEffect* eff : m_touchedEffects)
+        {
+            delete eff;
+        }
+
         m_touchedEffects.clear();
     }
 

--- a/Plugins/JVM/NWScript.cpp
+++ b/Plugins/JVM/NWScript.cpp
@@ -138,6 +138,9 @@ jobject JNIEXPORT JNICALL Internal::NWScriptPopLocation(JNIEnv* env, jobject obj
     auto r = JNICHECKED(env, CallStaticObjectMethod(g_internal->m_jclassNWLocation,
         g_internal->m_jmethodNWLocationCreate,
         ret_area, pRetVal->m_vPosition.x, pRetVal->m_vPosition.y, pRetVal->m_vPosition.z, facing));
+
+    delete pRetVal;
+
     return r;
 }
 


### PR DESCRIPTION
Something I noticed while browsing the new nwnxee codebase.

Caveat: I haven't actually tried running this patch.

CScriptLocation and CGameEffect (and any other engine structures) are allocated on the nwn core side. NWNX_JVM would not free them again. This means that every script call touching these variable types would leak a small amount of memory.

Pretty sure all other language plugins suffer the same issue. I had a quick browse on the Mono plugin and I didn't find where it would release the allocated CGameEffects, for example. JVM would solve this by tracking all requested CGameEffect instances and then, with this patch, free them after we drop out of the script context. An alternative would be to store all CGameEffect internal data in a JVM/Mono class and let those VMs handle it, but that seems needlessly interlinked.

Maybe someone using this plugin (or Mono, I guess) can have a look.