### PR TITLE
plugins/redis: auto-coerce all return types to string instead of raising error to core

### DIFF
--- a/Plugins/Redis/Connection.cpp
+++ b/Plugins/Redis/Connection.cpp
@@ -17,18 +17,6 @@ using namespace NWNXLib;
 using namespace NWNXLib::Services;
 using namespace std::chrono;
 
-std::string RedisReplyTypeToString(const cpp_redis::reply::type& t)
-{
-    switch (t) {
-        case cpp_redis::reply::type::array: return "Array";
-        case cpp_redis::reply::type::bulk_string: return "BulkString";
-        case cpp_redis::reply::type::error: return "Error";
-        case cpp_redis::reply::type::integer: return "Integer";
-        case cpp_redis::reply::type::simple_string: return "String";
-        case cpp_redis::reply::type::null: return "Null";
-    }
-    return "Unknown";
-}
 
 void Redis::LogQuery(const std::vector<std::string>& v, const cpp_redis::reply& r,
                      const uint64_t ns)
@@ -76,7 +64,7 @@ void Redis::LogQuery(const std::vector<std::string>& v, const cpp_redis::reply& 
         std::move(tags));
 
     auto qstr = str_implode(v);
-    auto rstr = r.as_string();
+    auto rstr = RedisReplyAsString(r);
 
     if (r.is_error())
     {
@@ -129,7 +117,7 @@ cpp_redis::reply Redis::RawSync(const std::vector<std::string>& v)
 
 std::string Redis::Sync(const std::vector<std::string>& v)
 {
-    return RawSync(v).as_string();
+    return RedisReplyAsString(RawSync(v));
 }
 
 std::vector<std::string> Redis::SyncList(const std::vector<std::string>& v)
@@ -137,7 +125,7 @@ std::vector<std::string> Redis::SyncList(const std::vector<std::string>& v)
     std::vector<std::string> r;
     auto p = RawSync(v).as_array();
     for (auto& k : p)
-        r.push_back(k.as_string());
+        r.push_back(RedisReplyAsString(k));
     return r;
 }
 

--- a/Plugins/Redis/Internal.hpp
+++ b/Plugins/Redis/Internal.hpp
@@ -4,6 +4,7 @@
 #include "Redis.hpp"
 #include "Pool.hpp"
 #include <mutex>
+#include <sstream>
 
 namespace Redis
 {
@@ -27,5 +28,39 @@ struct Internal {
     // Aaand the config
     Redis::Configuration m_config;
 };
+
+inline std::string RedisReplyTypeToString(const cpp_redis::reply::type& t)
+{
+    switch (t) {
+        case cpp_redis::reply::type::array: return "Array";
+        case cpp_redis::reply::type::bulk_string: return "BulkString";
+        case cpp_redis::reply::type::error: return "Error";
+        case cpp_redis::reply::type::integer: return "Integer";
+        case cpp_redis::reply::type::simple_string: return "String";
+        case cpp_redis::reply::type::null: return "Null";
+    }
+    return "Unknown";
+}
+
+inline int RedisReplyTypeToInt(const cpp_redis::reply::type& t)
+{
+    switch (t)
+    {
+        case cpp_redis::reply::type::array: return 1;
+        case cpp_redis::reply::type::bulk_string: return 2;
+        case cpp_redis::reply::type::error: return 3;
+        case cpp_redis::reply::type::integer: return 4;
+        case cpp_redis::reply::type::simple_string: return 5;
+        case cpp_redis::reply::type::null: return 6;
+    }
+    return 0;
+}
+
+inline std::string RedisReplyAsString(const cpp_redis::reply& r)
+{
+    std::stringstream ss;
+    ss << r;
+    return ss.str();
+}
 
 }

--- a/Plugins/Redis/NWScript.cpp
+++ b/Plugins/Redis/NWScript.cpp
@@ -11,20 +11,6 @@ namespace Redis
 using namespace NWNXLib;
 using namespace NWNXLib::Services;
 
-int RedisReplyTypeToInt(const cpp_redis::reply::type& t)
-{
-    switch (t)
-    {
-        case cpp_redis::reply::type::array: return 1;
-        case cpp_redis::reply::type::bulk_string: return 2;
-        case cpp_redis::reply::type::error: return 3;
-        case cpp_redis::reply::type::integer: return 4;
-        case cpp_redis::reply::type::simple_string: return 5;
-        case cpp_redis::reply::type::null: return 6;
-    }
-    return 0;
-}
-
 void Redis::RegisterWithNWScript()
 {
     // Full reply data of the last command executed for nwscript purposes.
@@ -51,7 +37,7 @@ void Redis::RegisterWithNWScript()
         Events::ArgumentStack st;
         // Return value: a simple string for now to cut down on call
         // count.
-        Events::InsertArgument(st, m_last_nwscript_reply.as_string());
+        Events::InsertArgument(st, RedisReplyAsString(m_last_nwscript_reply));
 
         // Events::InsertArgument(st, std::to_string(RedisReplyTypeToInt(
         // m_last_nwscript_reply.get_type())));
@@ -64,7 +50,7 @@ void Redis::RegisterWithNWScript()
     [&](Events::ArgumentStack &&)
     {
         Events::ArgumentStack st;
-        Events::InsertArgument(st, m_last_nwscript_reply.as_string());
+        Events::InsertArgument(st, RedisReplyAsString(m_last_nwscript_reply));
         return st;
     });
 


### PR DESCRIPTION
As reported by @Urothis in #193 

This fixes "what():  Reply is not a string", originally the result of - for example - doing "GET something" where something is null in redis (resulting in reply::nil). I think this was a regression resulting from updating cpp_redis, but I can't recall the specifics.

This isn't exactly great, as this will auto-cast errors to strings too. However, handling errors is not something nwnx_redis can do yet, so that will have to wait for another PR.

Example failure mode would be calling LLEN on a non-list type:
`E [18:08:26] [NWNX_Redis] [Connection.cpp:71] Query failed: 'LLEN test' -> 'WRONGTYPE Operation against a key holding the wrong kind of value'`

The error value is passed verbatim to NWScript as a string; in the case of LLEN, it'd parse to integer 0 of course, resulting in somewhat non-disastrous behaviour. Still, ugly.

Future changes could include:
* Exposing the last result type to nwscript
* Or maybe passing the result type as an additional return argument to nwscript