### PR TITLE
Exposed a function to get the name of the bic resource associated with the player

### DIFF
--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -39,6 +39,9 @@ struct NWNX_Player_QuickBarSlot NWNX_Player_GetQuickBarSlot(object player, int s
 // Sets a player's quickbar slot
 void NWNX_Player_SetQuickBarSlot(object player, int slot, struct NWNX_Player_QuickBarSlot qbs);
 
+// Get the name of the .bic file associated with the player's character.
+string NWNX_Player_GetBicFileName(object player);
+
 const string NWNX_Player = "NWNX_Player";
 
 void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable)
@@ -153,4 +156,12 @@ void NWNX_Player_SetQuickBarSlot(object player, int slot, struct NWNX_Player_Qui
     NWNX_PushArgumentInt(NWNX_Player, sFunc, slot);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
     NWNX_CallFunction(NWNX_Player, sFunc);
+}
+
+string NWNX_Player_GetBicFileName(object player)
+{
+    string sFunc = "GetBicFileName";
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
+    NWNX_CallFunction(NWNX_Player, sFunc);
+    return NWNX_GetReturnValueString(NWNX_Player, sFunc);
 }

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -307,7 +307,7 @@ ArgumentStack Player::GetBicFileName(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pPlayer = player(args))
     {
-        Services::Events::InsertArgument(stack, std::string(pPlayer->m_resFileName.GetResRef()));
+        Services::Events::InsertArgument(stack, std::string(pPlayer->m_resFileName.GetResRef(), pPlayer->m_resFileName.GetLength()));
     }
     return stack;
 }

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -61,6 +61,7 @@ Player::Player(const Plugin::CreateParams& params)
     REGISTER(SetAlwaysWalk);
     REGISTER(GetQuickBarSlot);
     REGISTER(SetQuickBarSlot);
+    REGISTER(GetBicFileName);
 
 #undef REGISTER
 
@@ -297,6 +298,16 @@ ArgumentStack Player::SetQuickBarSlot(ArgumentStack&& args)
 
         auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
         pMessage->SendServerToPlayerGuiQuickbar_SetButton(pPlayer, slot, 0);
+    }
+    return stack;
+}
+
+ArgumentStack Player::GetBicFileName(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pPlayer = player(args))
+    {
+        Services::Events::InsertArgument(stack, std::string(pPlayer->m_resFileName.GetResRef()));
     }
     return stack;
 }

--- a/Plugins/Player/Player.hpp
+++ b/Plugins/Player/Player.hpp
@@ -26,6 +26,7 @@ private:
     ArgumentStack SetAlwaysWalk                 (ArgumentStack&& args);
     ArgumentStack GetQuickBarSlot               (ArgumentStack&& args);
     ArgumentStack SetQuickBarSlot               (ArgumentStack&& args);
+    ArgumentStack GetBicFileName                (ArgumentStack&& args);
 
     NWNXLib::API::CNWSPlayer *player(ArgumentStack& args);
 


### PR DESCRIPTION
The BIC filename is useful for e.g. moving character files.