### PR TITLE
creature: Add LevelUp and LevelDown functions

### DIFF
--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -117,6 +117,7 @@ Creature::Creature(const Plugin::CreateParams& params)
     REGISTER(SetBaseSavingThrow);
     REGISTER(LevelUp);
     REGISTER(LevelDown);
+    REGISTER(SetChallengeRating);
 
 #undef REGISTER
 }
@@ -1515,6 +1516,17 @@ ArgumentStack Creature::LevelDown(ArgumentStack&& args)
                 }
             }
         }
+    }
+    return stack;
+}
+
+ArgumentStack Creature::SetChallengeRating(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pCreature = creature(args))
+    {
+        const auto fCR = Services::Events::ExtractArgument<float>(args); ASSERT(fCR >= 0.0);
+        pCreature->m_pStats->m_fChallengeRating = fCR;
     }
     return stack;
 }

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -1473,8 +1473,28 @@ ArgumentStack Creature::LevelDown(ArgumentStack&& args)
             }
             else
             {
-                LOG_WARNING("Creature does not have the LeveLStats?");
-                break;
+                //
+                // Creature wasn't leveled up properly, so just decrement the level count.
+                // Assume that it first got all levels in first class, then second, then third.
+                //
+                if (pCreature->m_pStats->m_ClassInfo[2].m_nClass != 0xFF)
+                {
+                    if (--pCreature->m_pStats->m_ClassInfo[2].m_nLevel == 0)
+                        pCreature->m_pStats->m_ClassInfo[2].m_nClass = 0xFF;
+                }
+                else if (pCreature->m_pStats->m_ClassInfo[1].m_nClass != 0xFF)
+                {
+                    if (--pCreature->m_pStats->m_ClassInfo[1].m_nLevel == 0)
+                        pCreature->m_pStats->m_ClassInfo[1].m_nClass = 0xFF;
+                }
+                else
+                {
+                    if (--pCreature->m_pStats->m_ClassInfo[0].m_nLevel == 0)
+                    {
+                        LOG_WARNING("Creature out of levels to level down.");
+                        pCreature->m_pStats->m_ClassInfo[0].m_nLevel = 1;
+                    }
+                }
             }
         }
     }

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -97,6 +97,7 @@ Creature::Creature(const Plugin::CreateParams& params)
     REGISTER(SetSoundset);
     REGISTER(SetSkillRank);
     REGISTER(SetClassByPosition);
+    REGISTER(SetLevelByPosition);
     REGISTER(SetBaseAttackBonus);
     REGISTER(GetAttacksPerRound);
     REGISTER(SetGender);
@@ -1084,6 +1085,23 @@ ArgumentStack Creature::SetClassByPosition(ArgumentStack&& args)
         ASSERT(classID <= 255);
 
         pCreature->m_pStats->SetClass(static_cast<uint8_t>(position), static_cast<uint8_t>(classID));
+    }
+    return stack;
+}
+
+ArgumentStack Creature::SetLevelByPosition(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pCreature = creature(args))
+    {
+        const auto position = Services::Events::ExtractArgument<int32_t>(args);
+        const auto level = Services::Events::ExtractArgument<int32_t>(args);
+        ASSERT(position >= 0);
+        ASSERT(position <= 2);
+        ASSERT(level >= 0);
+        ASSERT(level <= 60);
+
+        pCreature->m_pStats->SetClassLevel(static_cast<uint8_t>(position), static_cast<uint8_t>(level));
     }
     return stack;
 }

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -61,6 +61,7 @@ private:
     ArgumentStack SetSoundset                   (ArgumentStack&& args);
     ArgumentStack SetSkillRank                  (ArgumentStack&& args);
     ArgumentStack SetClassByPosition            (ArgumentStack&& args);
+    ArgumentStack SetLevelByPosition            (ArgumentStack&& args);
     ArgumentStack SetBaseAttackBonus            (ArgumentStack&& args);
     ArgumentStack GetAttacksPerRound            (ArgumentStack&& args);
     ArgumentStack SetGender                     (ArgumentStack&& args);

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -81,6 +81,8 @@ private:
     ArgumentStack SetBaseSavingThrow            (ArgumentStack&& args);
     ArgumentStack LevelUp                       (ArgumentStack&& args);
     ArgumentStack LevelDown                     (ArgumentStack&& args);
+    ArgumentStack SetChallengeRating            (ArgumentStack&& args);
+
     NWNXLib::API::CNWSCreature *creature(ArgumentStack& args);
 
 };

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -78,6 +78,8 @@ private:
     ArgumentStack SetCorpseDecayTime            (ArgumentStack&& args);
     ArgumentStack GetBaseSavingThrow            (ArgumentStack&& args);
     ArgumentStack SetBaseSavingThrow            (ArgumentStack&& args);
+    ArgumentStack LevelUp                       (ArgumentStack&& args);
+    ArgumentStack LevelDown                     (ArgumentStack&& args);
     NWNXLib::API::CNWSCreature *creature(ArgumentStack& args);
 
 };

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -199,6 +199,11 @@ void NWNX_Creature_SetSkillRank(object creature, int skill, int rank);
 // ClassID should be a valid ID number in classes.2da and be between 0 and 255.
 void NWNX_Creature_SetClassByPosition(object creature, int position, int classID);
 
+// Set the level at the given position for a creature. A creature should already
+// have a class in that position.
+// Position should be 0, 1, or 2.
+void NWNX_Creature_SetLevelByPosition(object creature, int position, int level);
+
 // Set creature's base attack bonus (BAB)
 // Modifying the BAB will also affect the creature's attacks per round and its
 // eligability for feats, prestige classes, etc.
@@ -787,6 +792,16 @@ void NWNX_Creature_SetClassByPosition(object creature, int position, int classID
 {
     string sFunc = "SetClassByPosition";
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, classID);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, position);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_SetLevelByPosition(object creature, int position, int level)
+{
+    string sFunc = "SetLevelByPosition";
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, level);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, position);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -277,6 +277,9 @@ void NWNX_Creature_LevelUp(object creature, int class, int count=1);
 // This will not work on player characters
 void NWNX_Creature_LevelDown(object creature, int count=1);
 
+// Sets corpse decay time in milliseconds
+void NWNX_Creature_SetChallengeRating(object creature, float fCR);
+
 const string NWNX_Creature = "NWNX_Creature";
 
 
@@ -981,3 +984,13 @@ void NWNX_Creature_LevelDown(object creature, int count=1)
 
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
+
+void NWNX_Creature_SetChallengeRating(object creature, float fCR)
+{
+    string sFunc = "SetChallengeRating";
+    NWNX_PushArgumentFloat(NWNX_Creature, sFunc, fCR);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -264,7 +264,7 @@ int NWNX_Creature_GetBaseSavingThrow(object creature, int which);
 // Sets the base saving throw of the creature
 void NWNX_Creature_SetBaseSavingThrow(object creature, int which, int value);
 
-// Add count levels of class to the creature
+// Add count levels of class to the creature, bypassing all validation
 // This will not work on player characters
 void NWNX_Creature_LevelUp(object creature, int class, int count=1);
 

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -264,6 +264,14 @@ int NWNX_Creature_GetBaseSavingThrow(object creature, int which);
 // Sets the base saving throw of the creature
 void NWNX_Creature_SetBaseSavingThrow(object creature, int which, int value);
 
+// Add count levels of class to the creature
+// This will not work on player characters
+void NWNX_Creature_LevelUp(object creature, int class, int count=1);
+
+// Remove last count levels from a creature
+// This will not work on player characters
+void NWNX_Creature_LevelDown(object creature, int count=1);
+
 const string NWNX_Creature = "NWNX_Creature";
 
 
@@ -935,6 +943,25 @@ void NWNX_Creature_SetBaseSavingThrow(object creature, int which, int value)
     string sFunc = "SetBaseSavingThrow";
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, value);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, which);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_LevelUp(object creature, int class, int count=1)
+{
+    string sFunc = "LevelUp";
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, count);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, class);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_LevelDown(object creature, int count=1)
+{
+    string sFunc = "LevelDown";
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, count);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 
     NWNX_CallFunction(NWNX_Creature, sFunc);

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -132,5 +132,16 @@ void main()
     NWNX_Creature_SetBaseSavingThrow(oCreature, SAVING_THROW_WILL, nSave + 10);
     report("{S,G}etBaseSavingThrow", NWNX_Creature_GetBaseSavingThrow(oCreature, SAVING_THROW_WILL) == nSave+10);
 
+
+    int cls = NWNX_Creature_GetClassByLevel(oCreature, 1);
+    NWNX_Creature_LevelUp(oCreature, cls, 10);
+    report("LevelUp", GetLevelByPosition(1, oCreature) == 11);
+    NWNX_Creature_LevelDown(oCreature, 10);
+    report("LevelDown", GetLevelByPosition(1, oCreature) == 1);
+    NWNX_Creature_LevelUp(oCreature, CLASS_TYPE_ROGUE, 20);
+    NWNX_Creature_LevelUp(oCreature, CLASS_TYPE_ROGUE, 20);
+    NWNX_Creature_LevelUp(oCreature, CLASS_TYPE_ROGUE, 20);
+    NWNX_Creature_LevelUp(oCreature, CLASS_TYPE_ROGUE, 20);
+
     WriteTimestampedLogEntry("NWNX_Creature unit test end.");
 }

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -138,10 +138,19 @@ void main()
     report("LevelUp", GetLevelByPosition(1, oCreature) == 11);
     NWNX_Creature_LevelDown(oCreature, 10);
     report("LevelDown", GetLevelByPosition(1, oCreature) == 1);
+    NWNX_Creature_SetClassByPosition(oCreature, 0, CLASS_TYPE_ROGUE);
     NWNX_Creature_LevelUp(oCreature, CLASS_TYPE_ROGUE, 20);
     NWNX_Creature_LevelUp(oCreature, CLASS_TYPE_ROGUE, 20);
     NWNX_Creature_LevelUp(oCreature, CLASS_TYPE_ROGUE, 20);
     NWNX_Creature_LevelUp(oCreature, CLASS_TYPE_ROGUE, 20);
+    report("LevelUp+SetLevelByPosition", GetLevelByPosition(1, oCreature) == 60);
+
+    NWNX_Creature_SetLevelByPosition(oCreature, 0, 1); // Ugh, game uses 1-based indexing here..
+    report("SetLevelByPosition", GetLevelByPosition(1, oCreature) == 1);
+
+    float fCR = GetChallengeRating(oCreature);
+    NWNX_Creature_SetChallengeRating(oCreature, fCR + 1.0);
+    report("SetChallengeRating", GetChallengeRating(oCreature) == (fCR + 1.0));
 
     WriteTimestampedLogEntry("NWNX_Creature unit test end.");
 }


### PR DESCRIPTION
LevelUp() is similar to LevelUpHenchman except it does not do any validation at all, so you can do things like change the class at level 1, then add more levels of that class, etc. Also does not care about the creature experience, server level settings and the like.

LevelDown() is a simple way to permanently strip levels from a creature. For PCs, you're better off taking the XP instead.