### PR TITLE
events: Add party events

### DIFF
--- a/Plugins/Events/CMakeLists.txt
+++ b/Plugins/Events/CMakeLists.txt
@@ -8,4 +8,5 @@ add_plugin(Events
     "Events/FeatEvents.cpp"
     "Events/ItemEvents.cpp"
     "Events/StealthEvents.cpp"
-    "Events/SpellEvents.cpp")
+    "Events/SpellEvents.cpp"
+    "Events/PartyEvents.cpp")

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -12,6 +12,7 @@
 #include "Events/ItemEvents.hpp"
 #include "Events/StealthEvents.hpp"
 #include "Events/SpellEvents.hpp"
+#include "Events/PartyEvents.hpp"
 #include "Services/Config/Config.hpp"
 #include "Services/Messaging/Messaging.hpp"
 #include "ViewPtr.hpp"
@@ -107,6 +108,11 @@ Events::Events(const Plugin::CreateParams& params)
     if (GetServices()->m_config->Get<bool>("ENABLE_SPELL_EVENTS", true))
     {
         m_spellEvents = std::make_unique<SpellEvents>(GetServices()->m_hooks);
+    }
+
+    if (GetServices()->m_config->Get<bool>("ENABLE_PARTY_EVENTS", true))
+    {
+        m_partyEvents = std::make_unique<PartyEvents>(GetServices()->m_hooks);
     }
 }
 

--- a/Plugins/Events/Events.hpp
+++ b/Plugins/Events/Events.hpp
@@ -19,6 +19,7 @@ class FeatEvents;
 class ItemEvents;
 class StealthEvents;
 class SpellEvents;
+class PartyEvents;
 
 class Events : public NWNXLib::Plugin
 {
@@ -56,6 +57,7 @@ private:
     std::unique_ptr<ItemEvents> m_itemEvents;
     std::unique_ptr<StealthEvents> m_stealthEvents;
     std::unique_ptr<SpellEvents> m_spellEvents;
+    std::unique_ptr<PartyEvents> m_partyEvents;
 };
 
 }

--- a/Plugins/Events/Events/PartyEvents.cpp
+++ b/Plugins/Events/Events/PartyEvents.cpp
@@ -1,0 +1,89 @@
+#include "Events/PartyEvents.hpp"
+#include "API/CNWSPlayer.hpp"
+#include "API/CNWSMessage.hpp"
+#include "API/Functions.hpp"
+#include "API/Constants.hpp"
+#include "Events.hpp"
+#include "Utils.hpp"
+#include <cstring>
+
+namespace Events {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+using namespace NWNXLib::Platform;
+
+PartyEvents::PartyEvents(ViewPtr<Services::HooksProxy> hooker)
+{
+    hooker->RequestSharedHook<Functions::CNWSMessage__HandlePlayerToServerParty, int32_t,
+        CNWSMessage*, CNWSPlayer*, uint8_t>(&HandlePartyMessageHook);
+}
+template <typename T>
+static T PeekMessage(CNWSMessage *pMessage, int32_t offset)
+{
+    static_assert(std::is_pod<T>::value);
+    T value;
+    uint8_t *ptr = pMessage->m_pnReadBuffer + pMessage->m_nReadBufferPtr + offset;
+    std::memcpy(&value, ptr, sizeof(T));
+    return value;
+}
+
+void PartyEvents::HandlePartyMessageHook(Services::Hooks::CallType type,
+    CNWSMessage *thisPtr, CNWSPlayer *pPlayer, uint8_t nMinor)
+{
+    const bool before = (type == Services::Hooks::CallType::BEFORE_ORIGINAL);
+    const char *suffix = before ? "_BEFORE" : "_AFTER";
+    std::string event = "NWNX_ON_PARTY_";
+
+    Types::ObjectID oidPlayer = pPlayer ? pPlayer->m_oidNWSObject : Constants::OBJECT_INVALID;
+
+    static std::string sOidOther;
+    if (before)
+        sOidOther = Utils::ObjectIDToString(PeekMessage<Types::ObjectID>(thisPtr, 0));
+
+    std::string argname;
+    switch (nMinor)
+    {
+        case 0x06:
+            event += "LEAVE";
+            argname = "LEAVING";
+            break;
+        case 0x07:
+            event += "KICK";
+            argname = "KICKED";
+            break;
+        case 0x08:
+            event += "TRANSFER_LEADERSHIP";
+            argname = "NEW_LEADER";
+            break;
+        case 0x09:
+            event += "INVITE";
+            argname = "INVITED";
+            break;
+        case 0x0a:
+            event += "IGNORE_INVITATION";
+            argname = "INVITED_BY";
+            break;
+        case 0x0b:
+            event += "ACCEPT_INVITATION";
+            argname = "INVITED_BY";
+            break;
+        case 0x0c:
+            event += "REJECT_INVITATION";
+            argname = "INVITED_BY";
+            break;
+        case 0x0d:
+            event += "KICK_HENCHMAN";
+            argname = "KICKED";
+            break;
+
+        default:
+            return;
+    }
+
+    Events::PushEventData(argname, sOidOther);
+    Events::SignalEvent(event + suffix, oidPlayer);
+}
+
+
+}

--- a/Plugins/Events/Events/PartyEvents.hpp
+++ b/Plugins/Events/Events/PartyEvents.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "Common.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include "ViewPtr.hpp"
+
+namespace Events {
+
+class PartyEvents
+{
+public:
+    PartyEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
+
+private:
+    static void HandlePartyMessageHook(NWNXLib::Services::Hooks::CallType, 
+        NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*, uint8_t);
+};
+
+}


### PR DESCRIPTION
Mostly straightforward stuff. No way to bypass the event, but you can always add/remove to the party in the _AFTER one to undo it.