### PR TITLE
tweaks: Add fix for per-part coloring until 8180 drops

### DIFF
--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -4,4 +4,5 @@ add_plugin(Tweaks
     "Tweaks/PlayerDyingHitPointLimit.cpp"
     "Tweaks/DisablePause.cpp"
     "Tweaks/CompareVarsForMerge.cpp"
-    "Tweaks/ParryAllAttacks.cpp")
+    "Tweaks/ParryAllAttacks.cpp"
+    "Tweaks/FixPerPartColoring.cpp")

--- a/Plugins/Tweaks/Tweaks.cpp
+++ b/Plugins/Tweaks/Tweaks.cpp
@@ -4,6 +4,7 @@
 #include "Tweaks/DisablePause.hpp"
 #include "Tweaks/CompareVarsForMerge.hpp"
 #include "Tweaks/ParryAllAttacks.hpp"
+#include "Tweaks/FixPerPartColoring.hpp"
 
 #include "Services/Config/Config.hpp"
 
@@ -64,6 +65,12 @@ Tweaks::Tweaks(const Plugin::CreateParams& params)
     {
         LOG_INFO("Parry will no longer be limited to one attack per flurry");
         m_ParryAllAttacks = std::make_unique<ParryAllAttacks>(GetServices()->m_hooks.get());
+    }
+
+    if (GetServices()->m_config->Get<bool>("FIX_PER_PART_COLORING", true))
+    {
+        LOG_INFO("Per part coloring in CopyItemAndModify crash fixed");
+        m_FixPerPartColoring = std::make_unique<FixPerPartColoring>(GetServices()->m_hooks.get());
     }
 }
 

--- a/Plugins/Tweaks/Tweaks.hpp
+++ b/Plugins/Tweaks/Tweaks.hpp
@@ -10,6 +10,7 @@ class DisablePause;
 class FixMasterServerDNS;
 class CompareVarsForMerge;
 class ParryAllAttacks;
+class FixPerPartColoring;
 
 class Tweaks : public NWNXLib::Plugin
 {
@@ -23,6 +24,7 @@ private:
     std::unique_ptr<DisablePause> m_DisablePause;
     std::unique_ptr<CompareVarsForMerge> m_CompareVarsForMerge;
     std::unique_ptr<ParryAllAttacks> m_ParryAllAttacks;
+    std::unique_ptr<FixPerPartColoring> m_FixPerPartColoring;
 };
 
 }

--- a/Plugins/Tweaks/Tweaks/FixPerPartColoring.cpp
+++ b/Plugins/Tweaks/Tweaks/FixPerPartColoring.cpp
@@ -1,0 +1,55 @@
+#include "Tweaks/FixPerPartColoring.hpp"
+#include "API/CNWSItem.hpp"
+#include "API/Functions.hpp"
+#include "API/Globals.hpp"
+#include "API/Version.hpp"
+
+#include "Services/Hooks/Hooks.hpp"
+#include "Utils.hpp"
+#include <cstring>
+
+NWNX_EXPECT_VERSION(8179); // Only needed for 8179, remove with API update.
+
+namespace Tweaks {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+Hooking::FunctionHook* FixPerPartColoring::pSetLayeredTextureColorPerPart_hook;
+Hooking::FunctionHook* FixPerPartColoring::pGetLayeredTextureColorPerPart_hook;
+FixPerPartColoring::FixPerPartColoring(ViewPtr<Services::HooksProxy> hooker)
+{
+    hooker->RequestExclusiveHook<Functions::CNWItem__SetLayeredTextureColorPerPart>
+                                    (&CNWItem__SetLayeredTextureColorPerPart_hook);
+    hooker->RequestExclusiveHook<Functions::CNWItem__GetLayeredTextureColorPerPart>
+                                    (&CNWItem__GetLayeredTextureColorPerPart_hook);
+
+    pSetLayeredTextureColorPerPart_hook = hooker->FindHookByAddress(Functions::CNWItem__SetLayeredTextureColorPerPart);
+    pGetLayeredTextureColorPerPart_hook = hooker->FindHookByAddress(Functions::CNWItem__GetLayeredTextureColorPerPart);
+}
+
+void FixPerPartColoring::CNWItem__SetLayeredTextureColorPerPart_hook(CNWItem *pThis, uint8_t nTexture, uint8_t nPart, uint8_t nColor)
+{
+    if (pThis->m_pLayeredTextureColorsPerPart[nTexture] == 0)
+    {
+        if (nColor == 0xFF)
+        {
+            return;
+        }
+
+        pThis->m_pLayeredTextureColorsPerPart[nTexture] = new uint8_t[19];
+        std::memset(pThis->m_pLayeredTextureColorsPerPart[nTexture], 0xFF, 19);
+    }
+    pThis->m_pLayeredTextureColorsPerPart[nTexture][nPart] = nColor;
+}
+
+uint8_t FixPerPartColoring::CNWItem__GetLayeredTextureColorPerPart_hook(CNWItem *pThis, uint8_t nTexture, uint8_t nPart)
+{
+    if (nTexture < 6 && nPart < 19 && pThis->m_pLayeredTextureColorsPerPart[nTexture])
+        return pThis->m_pLayeredTextureColorsPerPart[nTexture][nPart];
+    else
+        return 0xFF;
+}
+
+
+}

--- a/Plugins/Tweaks/Tweaks/FixPerPartColoring.hpp
+++ b/Plugins/Tweaks/Tweaks/FixPerPartColoring.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "Common.hpp"
+#include "ViewPtr.hpp"
+#include "Services/Hooks/Hooks.hpp"
+
+namespace Tweaks {
+
+class FixPerPartColoring
+{
+public:
+    FixPerPartColoring(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
+
+private:
+    static void    CNWItem__SetLayeredTextureColorPerPart_hook(NWNXLib::API::CNWItem*, uint8_t, uint8_t, uint8_t);
+    static uint8_t CNWItem__GetLayeredTextureColorPerPart_hook(NWNXLib::API::CNWItem*, uint8_t, uint8_t);
+    static NWNXLib::Hooking::FunctionHook* pSetLayeredTextureColorPerPart_hook;
+    static NWNXLib::Hooking::FunctionHook* pGetLayeredTextureColorPerPart_hook;
+
+};
+
+}


### PR DESCRIPTION
Temporary plug&play fix for servers (*cough* Netheril *cough*) experiencing crashes with the per-part coloring. Should be reverted with 8180 API.

Also a good test to see if the 8180 changes fix all the known crashes.