### PR TITLE
Damage: Allow specifying the damage script per-object

### DIFF
--- a/Plugins/Damage/Damage.cpp
+++ b/Plugins/Damage/Damage.cpp
@@ -138,9 +138,9 @@ int32_t Damage::OnApplyDamage(NWNXLib::API::CNWSEffectListHandler *pThis, NWNXLi
       {
          // Prepare the data for the nwscript
          plugin.m_DamageData.oidDamager = pEffect->m_oidCreator;
-         
+
          std::memcpy(plugin.m_DamageData.vDamage, pEffect->m_nParamInteger, sizeof(plugin.m_DamageData.vDamage));
-         Utils::ExecuteScript(plugin.m_DamageScript, pObject->m_idSelf);
+         Utils::ExecuteScript(script, pObject->m_idSelf);
          std::memcpy(pEffect->m_nParamInteger, plugin.m_DamageData.vDamage, sizeof(plugin.m_DamageData.vDamage));
       }
    }

--- a/Plugins/Damage/NWScript/nwnx_damage.nss
+++ b/Plugins/Damage/NWScript/nwnx_damage.nss
@@ -21,7 +21,9 @@ struct NWNX_Damage_DamageEventData // Damage event data
 };
 
 // Set Damage Event Script
-void NWNX_Damage_SetDamageEventScript(string sScript);
+// If oOwner is OBJECT_INVALID, this sets the script globally for all creatures
+// If oOwner is valid, it will set it only for that creature.
+void NWNX_Damage_SetDamageEventScript(string sScript, object oOwner=OBJECT_INVALID);
 
 // Get Damage Event Data (to use only on Damage Event Script)
 struct NWNX_Damage_DamageEventData NWNX_Weapon_GetDamageEventData();
@@ -30,10 +32,11 @@ struct NWNX_Damage_DamageEventData NWNX_Weapon_GetDamageEventData();
 void NWNX_Damage_SetDamageEventData(struct NWNX_Damage_DamageEventData data);
 
 
-void NWNX_Weapon_SetDamageEventScript(string sScript)
+void NWNX_Weapon_SetDamageEventScript(string sScript, object oOwner=OBJECT_INVALID)
 {
     string sFunc = "SetDamageEventScript";
 
+    NWNX_PushArgumentObject(NWNX_Damage, sFunc, oOwner);
     NWNX_PushArgumentString(NWNX_Damage, sFunc, sScript);
 
     NWNX_CallFunction(NWNX_Damage, sFunc);

--- a/Plugins/Damage/NWScript/nwnx_damage.nss
+++ b/Plugins/Damage/NWScript/nwnx_damage.nss
@@ -32,7 +32,7 @@ struct NWNX_Damage_DamageEventData NWNX_Weapon_GetDamageEventData();
 void NWNX_Damage_SetDamageEventData(struct NWNX_Damage_DamageEventData data);
 
 
-void NWNX_Weapon_SetDamageEventScript(string sScript, object oOwner=OBJECT_INVALID)
+void NWNX_Damage_SetDamageEventScript(string sScript, object oOwner=OBJECT_INVALID)
 {
     string sFunc = "SetDamageEventScript";
 


### PR DESCRIPTION
Preserving the nwscript interface, so old code will still work (though you will get a warning if you didn't recompile), but you can specify a per-object script that takes priority over the global one.

Plus a bugfix in the NSS.

@BhaalM please review :)