### PR TITLE
PerObjectStorage update to use pNwnxData

### DIFF
--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -184,7 +184,8 @@ void NWNXCore::InitialSetupHooks()
     m_services->m_hooks->RequestExclusiveHook<API::Functions::CAppManager__DestroyServer>(&DestroyServerHandler);
     m_services->m_hooks->RequestSharedHook<API::Functions::CServerExoAppInternal__MainLoop, int32_t>(&MainLoopInternalHandler);
 
-    m_services->m_hooks->RequestSharedHook<API::Functions::CGameObjectArray__Delete__1, void>(&Services::PerObjectStorage::CGameObjectArray__Delete__1_hook);
+    m_services->m_hooks->RequestSharedHook<API::Functions::CNWSObject__CNWSObjectDtor__0, void>(&Services::PerObjectStorage::CNWSObject__CNWSObjectDtor__0_hook);
+    m_services->m_hooks->RequestSharedHook<API::Functions::CNWSArea__CNWSAreaDtor__0, void>(&Services::PerObjectStorage::CNWSArea__CNWSAreaDtor__0_hook);
 
     g_setStringHook = m_services->m_hooks->FindHookByAddress(API::Functions::CNWSScriptVarTable__SetString);
     g_getStringHook = m_services->m_hooks->FindHookByAddress(API::Functions::CNWSScriptVarTable__GetString);

--- a/NWNXLib/Utils.cpp
+++ b/NWNXLib/Utils.cpp
@@ -149,6 +149,11 @@ API::CNWSWaypoint* AsNWSWaypoint(API::CGameObject* obj)
     return nullptr;
 }
 
+API::CGameObject* GetGameObject(API::Types::ObjectID objectId)
+{
+    return API::Globals::AppManager()->m_pServerExoApp->GetGameObject(objectId);
+}
+
 bool AcquireItem(API::CNWSItem *pItem, API::CGameObject *pOwner)
 {
     if (!pOwner || !pItem)

--- a/NWNXLib/Utils.hpp
+++ b/NWNXLib/Utils.hpp
@@ -31,6 +31,8 @@ API::CNWSStore*              AsNWSStore(API::CGameObject* obj);
 API::CNWSTrigger*            AsNWSTrigger(API::CGameObject* obj);
 API::CNWSWaypoint*           AsNWSWaypoint(API::CGameObject* obj);
 
+API::CGameObject* GetGameObject(API::Types::ObjectID objectId);
+
 // Wrappers around non-virtual methods repeated for all NWS types
 bool AcquireItem(API::CNWSItem *pItem, API::CGameObject *pOwner);
 bool AddToArea(API::CGameObject *pObject, API::CNWSArea *pArea, float x, float y, float z);


### PR DESCRIPTION
We got a neat little pointer in `CGameObject` for this, but I never got around to updating the code.

 - We now use `CGameObject::m_pNwnxData` for the POS, rather than a `map<ObjectID, POS>`
 - Switched the preferred interface to be the `CGameObject*` one, with `ObjectID` as fallback that performs the lookup
 - Switched from hooking the removal from object array to destructors for `CNWSObject` and `CNWSArea`. `CGameObject` does not have a destructor NWNX can use, unfortunately.