### PR TITLE
Player: Per-player object visibility

### DIFF
--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -18,6 +18,10 @@ struct NWNX_Player_QuickBarSlot
     object oAssociate;
 };
 
+const int NWNX_PLAYER_VISIBILITY_DEFAULT = 0;
+const int NWNX_PLAYER_VISIBILITY_HIDDEN  = 1;
+const int NWNX_PLAYER_VISIBILITY_VISIBLE = 2;
+
 // Force display placeable examine window for player
 void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable);
 
@@ -41,6 +45,17 @@ void NWNX_Player_SetQuickBarSlot(object player, int slot, struct NWNX_Player_Qui
 
 // Get the name of the .bic file associated with the player's character.
 string NWNX_Player_GetBicFileName(object player);
+
+// Overrides the default visibility rules about how player perceives the target object.
+// NWNX_PLAYER_VISIBILITY_DEFAULT - Restore normal behavior
+// NWNX_PLAYER_VISIBILITY_HIDDEN - Object is always hidden from the player
+// NWNX_PLAYER_VISIBILITY_VISIBLE - Object is always shown to the player
+void NWNX_Player_SetVisibilityOverride(object player, object target, int override);
+
+// Queries the existing visibility override for given (player, object) pair
+// Returns NWNX_PLAYER_VISIBILITY_DEFAULT if no override exists
+int NWNX_Player_GetVisibilityOverride(object player, object target);
+
 
 const string NWNX_Player = "NWNX_Player";
 
@@ -164,4 +179,24 @@ string NWNX_Player_GetBicFileName(object player)
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
     NWNX_CallFunction(NWNX_Player, sFunc);
     return NWNX_GetReturnValueString(NWNX_Player, sFunc);
+}
+
+void NWNX_Player_SetVisibilityOverride(object player, object target, int override)
+{
+    string sFunc = "SetVisibilityOverride";
+    NWNX_PushArgumentInt(NWNX_Player, sFunc, override);
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, target);
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
+
+    NWNX_CallFunction(NWNX_Player, sFunc);
+}
+
+int NWNX_Player_GetVisibilityOverride(object player, object target)
+{
+    string sFunc = "GetVisibilityOverride";
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, target);
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
+
+    NWNX_CallFunction(NWNX_Player, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Player, sFunc);
 }

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -62,6 +62,8 @@ Player::Player(const Plugin::CreateParams& params)
     REGISTER(GetQuickBarSlot);
     REGISTER(SetQuickBarSlot);
     REGISTER(GetBicFileName);
+    REGISTER(SetVisibilityOverride);
+    REGISTER(GetVisibilityOverride);
 
 #undef REGISTER
 
@@ -308,6 +310,42 @@ ArgumentStack Player::GetBicFileName(ArgumentStack&& args)
     if (auto *pPlayer = player(args))
     {
         Services::Events::InsertArgument(stack, std::string(pPlayer->m_resFileName.GetResRef(), pPlayer->m_resFileName.GetLength()));
+    }
+    return stack;
+}
+
+
+ArgumentStack Player::SetVisibilityOverride(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pPlayer = player(args))
+    {
+        const auto oidTarget = Services::Events::ExtractArgument<Types::ObjectID>(args);
+        const auto override = Services::Events::ExtractArgument<int32_t>(args);
+
+        std::string name = std::string("VISIBILITY_OVERRIDE:") + Utils::ObjectIDToString(oidTarget);
+        if (override > 0 && override <= 2) // valid values
+        {
+            g_plugin->GetServices()->m_perObjectStorage->Set(pPlayer->m_oidNWSObject, name, override);
+        }
+        else
+        {
+            g_plugin->GetServices()->m_perObjectStorage->Remove(pPlayer->m_oidNWSObject, name);
+        }
+    }
+    return stack;
+}
+
+ArgumentStack Player::GetVisibilityOverride(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pPlayer = player(args))
+    {
+        const auto oidTarget = Services::Events::ExtractArgument<Types::ObjectID>(args);
+        std::string name = std::string("VISIBILITY_OVERRIDE:") + Utils::ObjectIDToString(oidTarget);
+
+        int override = g_plugin->GetServices()->m_perObjectStorage->Get<int>(pPlayer->m_oidNWSObject, name);
+        Services::Events::InsertArgument(stack, override);
     }
     return stack;
 }

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -317,6 +317,28 @@ ArgumentStack Player::GetBicFileName(ArgumentStack&& args)
 
 ArgumentStack Player::SetVisibilityOverride(ArgumentStack&& args)
 {
+    static NWNXLib::Hooking::FunctionHook* pTestObjectVisible_hook;
+
+    if (!pTestObjectVisible_hook)
+    {
+        GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWSMessage__TestObjectVisible>(
+            +[](CNWSMessage *pThis, CNWSObject *pAreaObject, CNWSObject *pPlayerGameObject) -> int32_t
+            {
+                std::string name = std::string("VISIBILITY_OVERRIDE:") + Utils::ObjectIDToString(pAreaObject->m_idSelf);
+
+                // Don't remove the forced walk flag when various slowdown effects expire
+                auto override = g_plugin->GetServices()->m_perObjectStorage->Get<int>(pPlayerGameObject, name);
+                if (override && *override)
+                {
+                    ASSERT(*override == 1 || *override == 2);
+                    return *override == 2;
+                }
+
+                return pTestObjectVisible_hook->CallOriginal<int32_t>(pThis, pAreaObject, pPlayerGameObject);
+            });
+        pTestObjectVisible_hook = GetServices()->m_hooks->FindHookByAddress(Functions::CNWSMessage__TestObjectVisible);
+    }
+
     ArgumentStack stack;
     if (auto *pPlayer = player(args))
     {
@@ -328,9 +350,13 @@ ArgumentStack Player::SetVisibilityOverride(ArgumentStack&& args)
         {
             g_plugin->GetServices()->m_perObjectStorage->Set(pPlayer->m_oidNWSObject, name, override);
         }
-        else
+        else if (override == 0)
         {
             g_plugin->GetServices()->m_perObjectStorage->Remove(pPlayer->m_oidNWSObject, name);
+        }
+        else
+        {
+            LOG_WARNING("Invalid visibility override constant specified: %d", override);
         }
     }
     return stack;
@@ -344,8 +370,8 @@ ArgumentStack Player::GetVisibilityOverride(ArgumentStack&& args)
         const auto oidTarget = Services::Events::ExtractArgument<Types::ObjectID>(args);
         std::string name = std::string("VISIBILITY_OVERRIDE:") + Utils::ObjectIDToString(oidTarget);
 
-        int override = g_plugin->GetServices()->m_perObjectStorage->Get<int>(pPlayer->m_oidNWSObject, name);
-        Services::Events::InsertArgument(stack, override);
+        auto override = g_plugin->GetServices()->m_perObjectStorage->Get<int>(pPlayer->m_oidNWSObject, name);
+        Services::Events::InsertArgument(stack, override ? *override : 0);
     }
     return stack;
 }

--- a/Plugins/Player/Player.hpp
+++ b/Plugins/Player/Player.hpp
@@ -27,6 +27,8 @@ private:
     ArgumentStack GetQuickBarSlot               (ArgumentStack&& args);
     ArgumentStack SetQuickBarSlot               (ArgumentStack&& args);
     ArgumentStack GetBicFileName                (ArgumentStack&& args);
+    ArgumentStack SetVisibilityOverride         (ArgumentStack&& args);
+    ArgumentStack GetVisibilityOverride         (ArgumentStack&& args);
 
     NWNXLib::API::CNWSPlayer *player(ArgumentStack& args);
 


### PR DESCRIPTION
As requested in #176 , this should be the equivalent of the old nwnx_visibility plugin.

Can't really write automated tests for this, but I tested by manually toggling visibility of creatures a bit. Seems nice and stable.