### PR TITLE
mono: Add utf8->iso8859 conversion too, not just the other way.

### DIFF
--- a/Plugins/Mono/Mono_Handlers.cpp
+++ b/Plugins/Mono/Mono_Handlers.cpp
@@ -428,7 +428,7 @@ std::string UTF8ToISO8859(const char *str)
     std::string iso8859("");
     iso8859.reserve(strlen(str) + 1);
 
-    uint32_t codepoint;
+    uint32_t codepoint = 0;
     for (; *str; ++str)
     {
         uint8_t ch = static_cast<uint8_t>(*str);

--- a/Plugins/Mono/Mono_Handlers.cpp
+++ b/Plugins/Mono/Mono_Handlers.cpp
@@ -131,7 +131,7 @@ void StackPushString(MonoString* value)
 
     char* valueAsCStr = mono_string_to_utf8(value);
     LOG_DEBUG("Pushing string '%s'.", valueAsCStr);
-    CExoString str(valueAsCStr);
+    CExoString str(UTF8ToISO8859(valueAsCStr).c_str());
     mono_free(valueAsCStr);
 
     if (GetVm()->StackPushString(str))
@@ -245,7 +245,7 @@ MonoString* StackPopString()
 
     LOG_DEBUG("Popped string '%s'.", value.m_sString);
 
-    return mono_string_new(g_Domain, ISO88959ToUTF8(value.CStr()).c_str());
+    return mono_string_new(g_Domain, ISO8859ToUTF8(value.CStr()).c_str());
 }
 
 uint32_t StackPopObject()
@@ -397,8 +397,11 @@ int32_t ClosureActionDoCommand(uint32_t oid, uint64_t eventId)
     return 0;
 }
 
-std::string ISO88959ToUTF8(const char *str)
+std::string ISO8859ToUTF8(const char *str)
 {
+    if (str == nullptr || *str == 0)
+        return std::string("");
+
     std::string utf8("");
     utf8.reserve(2*strlen(str) + 1);
 
@@ -414,6 +417,38 @@ std::string ISO88959ToUTF8(const char *str)
         }
     }
     return utf8;
+}
+
+// Adapted from https://stackoverflow.com/a/23690194/2771245
+std::string UTF8ToISO8859(const char *str)
+{
+    if (str == nullptr || *str == 0)
+        return std::string("");
+
+    std::string iso8859("");
+    iso8859.reserve(strlen(str) + 1);
+
+    uint32_t codepoint;
+    for (; *str; ++str)
+    {
+        uint8_t ch = static_cast<uint8_t>(*str);
+        if (ch <= 0x7f)
+            codepoint = ch;
+        else if (ch <= 0xbf)
+            codepoint = (codepoint << 6) | (ch & 0x3f);
+        else if (ch <= 0xdf)
+            codepoint = ch & 0x1f;
+        else if (ch <= 0xef)
+            codepoint = ch & 0x0f;
+        else
+            codepoint = ch & 0x07;
+
+        if (((str[1] & 0xc0) != 0x80) && (codepoint <= 0x10ffff))
+        {
+            iso8859.push_back(codepoint <= 0xFF ? static_cast<char>(codepoint) : '?');
+        }
+    }
+    return iso8859;
 }
 
 }

--- a/Plugins/Mono/Mono_Handlers.hpp
+++ b/Plugins/Mono/Mono_Handlers.hpp
@@ -54,6 +54,7 @@ int32_t ClosureAssignCommand(uint32_t oid, uint64_t eventId);
 int32_t ClosureDelayCommand(uint32_t oid, float duration, uint64_t eventId);
 int32_t ClosureActionDoCommand(uint32_t oid, uint64_t eventId);
 
-std::string ISO88959ToUTF8(const char *str);
+std::string ISO8859ToUTF8(const char *str);
+std::string UTF8ToISO8859(const char *str);
 
 }


### PR DESCRIPTION
This fixes issues with >127 character points needed for color tokens.

Relying on C# to do the encoding doesn't _quite_ work:
![Encoding.ASCII](https://cdn.discordapp.com/attachments/395917181474439168/486806425431965697/unknown.png)

With this change, passing direct C# utf8 strings:
![direct string push](https://cdn.discordapp.com/attachments/395917181474439168/486813204803092480/unknown.png)

Also fix typo in standard name in previous function