### PR TITLE
pos: Use c++ casts like a normal person

### DIFF
--- a/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
+++ b/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
@@ -1,5 +1,7 @@
 #include "Services/PerObjectStorage/PerObjectStorage.hpp"
 #include "API/CGameObject.hpp"
+#include "API/CNWSArea.hpp"
+#include "API/CNWSObject.hpp"
 #include "API/Constants.hpp"
 
 namespace NWNXLib {
@@ -216,12 +218,12 @@ void PerObjectStorage::DestroyObjectStorage(API::CGameObject *pGameObject)
 void PerObjectStorage::CNWSObject__CNWSObjectDtor__0_hook(Services::Hooks::CallType type, API::CNWSObject* pThis)
 {
     if (type == Services::Hooks::CallType::AFTER_ORIGINAL)
-        DestroyObjectStorage((API::CGameObject*)pThis);
+        DestroyObjectStorage(dynamic_cast<API::CGameObject*>(pThis));
 }
 void PerObjectStorage::CNWSArea__CNWSAreaDtor__0_hook(Services::Hooks::CallType type, API::CNWSArea* pThis)
 {
     if (type == Services::Hooks::CallType::AFTER_ORIGINAL)
-        DestroyObjectStorage((API::CGameObject*)pThis);
+        DestroyObjectStorage(dynamic_cast<API::CGameObject*>(pThis));
 }
 
 

--- a/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
+++ b/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
@@ -218,12 +218,12 @@ void PerObjectStorage::DestroyObjectStorage(API::CGameObject *pGameObject)
 void PerObjectStorage::CNWSObject__CNWSObjectDtor__0_hook(Services::Hooks::CallType type, API::CNWSObject* pThis)
 {
     if (type == Services::Hooks::CallType::AFTER_ORIGINAL)
-        DestroyObjectStorage(dynamic_cast<API::CGameObject*>(pThis));
+        DestroyObjectStorage(static_cast<API::CGameObject*>(pThis));
 }
 void PerObjectStorage::CNWSArea__CNWSAreaDtor__0_hook(Services::Hooks::CallType type, API::CNWSArea* pThis)
 {
     if (type == Services::Hooks::CallType::AFTER_ORIGINAL)
-        DestroyObjectStorage(dynamic_cast<API::CGameObject*>(pThis));
+        DestroyObjectStorage(static_cast<API::CGameObject*>(pThis));
 }
 
 


### PR DESCRIPTION
CNWSArea uses multiple inheritance so a C style cast is bad. Not sure why I used those in the first place, maybe trying to cut down on the includes?

Anyway, this fixes a crash when destroying areas. Testing:

```c
DestroyArea(CopyArea(GetFirstArea()));
```