### PR TITLE
Plugin SQL: At startup try multiple times to connect to the database

### DIFF
--- a/Plugins/SQL/SQL.cpp
+++ b/Plugins/SQL/SQL.cpp
@@ -101,7 +101,7 @@ SQL::SQL(const Plugin::CreateParams& params)
         throw std::runtime_error("Invalid database type selected.");
     }
 
-    m_target->Connect(GetServices()->m_config);
+    Reconnect(19);
 }
 
 SQL::~SQL()


### PR DESCRIPTION
This is intended to improve working with docker-compose and depends_on. So that the server waits until the db has been initialized and is ready.

19 attempts means the last sleep beeing called with i = 17, which leads to about 2 minutes (1 << 17 ms).