### PR TITLE
tweaks: Add PreserveDepletedItems tweak

### DIFF
--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -5,4 +5,5 @@ add_plugin(Tweaks
     "Tweaks/DisablePause.cpp"
     "Tweaks/CompareVarsForMerge.cpp"
     "Tweaks/ParryAllAttacks.cpp"
-    "Tweaks/SneakAttackCritImmunity.cpp")
+    "Tweaks/SneakAttackCritImmunity.cpp"
+    "Tweaks/PreserveDepletedItems.cpp")

--- a/Plugins/Tweaks/Tweaks.cpp
+++ b/Plugins/Tweaks/Tweaks.cpp
@@ -5,6 +5,7 @@
 #include "Tweaks/CompareVarsForMerge.hpp"
 #include "Tweaks/ParryAllAttacks.hpp"
 #include "Tweaks/SneakAttackCritImmunity.hpp"
+#include "Tweaks/PreserveDepletedItems.hpp"
 
 #include "Services/Config/Config.hpp"
 
@@ -75,6 +76,12 @@ Tweaks::Tweaks(const Plugin::CreateParams& params)
     {
         LOG_INFO("Sneak attacks will now be possible on creatures with immunity to critical hits");
         m_SneakAttackCritImmunity = std::make_unique<SneakAttackCritImmunity>(GetServices()->m_hooks.get());
+    }
+
+    if (GetServices()->m_config->Get<bool>("PRESERVE_DEPLETED_ITEMS", false))
+    {
+        LOG_INFO("Items will no longer be destroyed when they run out of charges");
+        m_PreserveDepletedItems = std::make_unique<PreserveDepletedItems>(GetServices()->m_hooks.get());
     }
 
     if (GetServices()->m_config->Get<bool>("DISABLE_SHADOWS", false))

--- a/Plugins/Tweaks/Tweaks.hpp
+++ b/Plugins/Tweaks/Tweaks.hpp
@@ -11,6 +11,7 @@ class FixMasterServerDNS;
 class CompareVarsForMerge;
 class ParryAllAttacks;
 class SneakAttackCritImmunity;
+class PreserveDepletedItems;
 
 class Tweaks : public NWNXLib::Plugin
 {
@@ -25,6 +26,7 @@ private:
     std::unique_ptr<CompareVarsForMerge> m_CompareVarsForMerge;
     std::unique_ptr<ParryAllAttacks> m_ParryAllAttacks;
     std::unique_ptr<SneakAttackCritImmunity> m_SneakAttackCritImmunity;
+    std::unique_ptr<PreserveDepletedItems> m_PreserveDepletedItems;
 };
 
 }

--- a/Plugins/Tweaks/Tweaks/PreserveDepletedItems.cpp
+++ b/Plugins/Tweaks/Tweaks/PreserveDepletedItems.cpp
@@ -1,0 +1,44 @@
+#include "Tweaks/PreserveDepletedItems.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/CNWSItem.hpp"
+#include "API/CNWSObjectActionNode.hpp"
+#include "API/Functions.hpp"
+#include "API/Globals.hpp"
+#include "API/Version.hpp"
+
+#include "Services/Hooks/Hooks.hpp"
+#include "Utils.hpp"
+
+
+namespace Tweaks {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+NWNXLib::Hooking::FunctionHook* PreserveDepletedItems::pAIActionItemCastSpell_hook;
+PreserveDepletedItems::PreserveDepletedItems(ViewPtr<Services::HooksProxy> hooker)
+{
+    hooker->RequestExclusiveHook<Functions::CNWSCreature__AIActionItemCastSpell>
+                                    (&CNWSCreature__AIActionItemCastSpell_hook);
+
+    pAIActionItemCastSpell_hook = hooker->FindHookByAddress(Functions::CNWSCreature__AIActionItemCastSpell);
+}
+
+
+uint32_t PreserveDepletedItems::CNWSCreature__AIActionItemCastSpell_hook(CNWSCreature *pThis, CNWSObjectActionNode *pNode)
+{
+    // If at risk of destroying the item, inflate charge count temporarily to bypass the destroy
+    // event, then set it back to mark the spells as unusable.
+    auto *pItem = Utils::AsNWSItem(Utils::GetGameObject((Types::ObjectID)pNode->m_pParameter[0]));
+    if (pItem && pItem->m_nNumCharges <= 5)
+    {
+        pItem->m_nNumCharges += 10;
+        int32_t ret = pAIActionItemCastSpell_hook->CallOriginal<uint32_t>(pThis, pNode);
+        pItem->SetNumCharges(pItem->m_nNumCharges - 10, 1 /* update which properties are usable */);
+        return ret;
+    }
+    return pAIActionItemCastSpell_hook->CallOriginal<uint32_t>(pThis, pNode);
+}
+
+
+}

--- a/Plugins/Tweaks/Tweaks/PreserveDepletedItems.hpp
+++ b/Plugins/Tweaks/Tweaks/PreserveDepletedItems.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "Common.hpp"
+#include "ViewPtr.hpp"
+#include "Services/Hooks/Hooks.hpp"
+
+namespace Tweaks {
+
+class PreserveDepletedItems
+{
+public:
+    PreserveDepletedItems(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
+
+private:
+    static uint32_t CNWSCreature__AIActionItemCastSpell_hook(NWNXLib::API::CNWSCreature*, NWNXLib::API::CNWSObjectActionNode*);
+    static NWNXLib::Hooking::FunctionHook* pAIActionItemCastSpell_hook;
+};
+
+}


### PR DESCRIPTION
As requested in #201 , running out of charges no longer destroys the item if tweak is activated.

Had to do this trick as AIActionItemCastSpell() is an absolute monster of a function and there's no way it would get done properly.

Only did a basic test that it works in the expected case and that it didn't break anything. Counting on @1d3s and whoever else wants to use this to give it a more thorough testing and report bugs.