### PR TITLE
fix double free on resource deserialization

### DIFF
--- a/NWNXLib/Serialize.cpp
+++ b/NWNXLib/Serialize.cpp
@@ -136,7 +136,11 @@ API::CGameObject *DeserializeGameObject(const std::vector<uint8_t>& serialized)
     if (serialized.size() < 14*4) // GFF header size
         return nullptr;
 
-    if (!resGff.GetDataFromPointer((void*)serialized.data(), (int32_t)serialized.size()))
+    // resGff/resman will claim ownership of this pointer and free it in resGff destructor,
+    // so need a copy for them to play with since the vector can't relinquish its own.
+    uint8_t *data = new uint8_t[serialized.size()];
+    memcpy(data, serialized.data(), serialized.size());
+    if (!resGff.GetDataFromPointer((void*)data, (int32_t)serialized.size()))
         return nullptr;
 
     resGff.InitializeForWriting();


### PR DESCRIPTION
I couldn't figure out a nice way to avoid creating the copy. The only alternative would be to make `base64_decode()` return a `std::pair<uint8_t*,size_t>` and use that, but that change ends up being ugly because it also complicates `base64_decode()`.

Let me know if this is too hacky and I'll do the other thing instead.

Or, if there's a way to tell `std::vector` that they lost ownership of their data pointer :roll_eyes: 