### PR TITLE
player: add ForcePlaceableInventoryWindow()

### DIFF
--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -23,7 +23,18 @@ const int NWNX_PLAYER_VISIBILITY_HIDDEN  = 1;
 const int NWNX_PLAYER_VISIBILITY_VISIBLE = 2;
 
 // Force display placeable examine window for player
+// If used on a placeable in a different area than the player, the portait will not be shown.
 void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable);
+
+// Force opens the target object's inventory for the player.
+// A few notes about this function:
+// - If the placeable is in a different area than the player, the portrait will not be shown
+// - The placeable's open/close animations will be played
+// - Clicking the 'close' button will cause the player to walk to the placeable;
+//     If the placeable is in a different area, the player will just walk to the edge
+//     of the current area and stop. This action can be cancelled manually.
+// - Walking will close the placeable automatically.
+void NWNX_Player_ForcePlaceableInventoryWindow(object player, object placeable);
 
 // Starts displaying a timing bar.
 // Will run a script at the end of the timing bar, if specified.
@@ -62,6 +73,15 @@ const string NWNX_Player = "NWNX_Player";
 void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable)
 {
     string sFunc = "ForcePlaceableExamineWindow";
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, placeable);
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
+
+    NWNX_CallFunction(NWNX_Player, sFunc);
+}
+
+void NWNX_Player_ForcePlaceableInventoryWindow(object player, object placeable)
+{
+    string sFunc = "ForcePlaceableInventoryWindow";
     NWNX_PushArgumentObject(NWNX_Player, sFunc, placeable);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -12,6 +12,9 @@
 #include "API/CNWSCreature.hpp"
 #include "API/CNWSQuickbarButton.hpp"
 #include "API/CGameEffect.hpp"
+#include "API/CNWSPlayerInventoryGUI.hpp"
+#include "API/CNWSPlaceable.hpp"
+#include "API/CNWSItem.hpp"
 //#include "API/CNWSStats_Spell.hpp"
 //#include "API/CNWSStats_SpellLikeAbility.hpp"
 //#include "API/CExoArrayListTemplatedCNWSStats_SpellLikeAbility.hpp"
@@ -56,6 +59,7 @@ Player::Player(const Plugin::CreateParams& params)
     GetServices()->m_events->RegisterEvent(#func, std::bind(&Player::func, this, std::placeholders::_1))
 
     REGISTER(ForcePlaceableExamineWindow);
+    REGISTER(ForcePlaceableInventoryWindow);
     REGISTER(StartGuiTimingBar);
     REGISTER(StopGuiTimingBar);
     REGISTER(SetAlwaysWalk);
@@ -110,6 +114,24 @@ ArgumentStack Player::ForcePlaceableExamineWindow(ArgumentStack&& args)
         else
         {
             LOG_ERROR("Unable to get CNWSMessage");
+        }
+    }
+
+    return stack;
+}
+
+
+ArgumentStack Player::ForcePlaceableInventoryWindow(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pPlayer = player(args))
+    {
+        const auto oidTarget = Services::Events::ExtractArgument<Types::ObjectID>(args);
+        const auto oidPlayer = pPlayer->m_oidNWSObject;
+
+        if (auto *pPlaceable = Utils::AsNWSPlaceable(Utils::GetGameObject(oidTarget)))
+        {
+            pPlaceable->OpenInventory(oidPlayer);
         }
     }
 

--- a/Plugins/Player/Player.hpp
+++ b/Plugins/Player/Player.hpp
@@ -21,6 +21,7 @@ private:
         NWNXLib::API::CNWSMessage* pMessage, NWNXLib::API::CNWSPlayer* pPlayer);
 
     ArgumentStack ForcePlaceableExamineWindow   (ArgumentStack&& args);
+    ArgumentStack ForcePlaceableInventoryWindow (ArgumentStack&& args);
     ArgumentStack StartGuiTimingBar             (ArgumentStack&& args);
     ArgumentStack StopGuiTimingBar              (ArgumentStack&& args);
     ArgumentStack SetAlwaysWalk                 (ArgumentStack&& args);


### PR DESCRIPTION
As requested in #183 .

- Only works on placeables. 
    - For creatures, I couldn't get PCs to properly display random NPC inventories. And if you want to look at your henchmen, or if you're a DM, there's already the builtin `OpenInventory` that does it. Couldn't really add much value to that.
    - For items (boxes) I was getting weird behavior at times, so just ignoring it for now.
- Placeable's open/close animation will be played
- If the placeable is in a different area than the player, the portrait may not be shown
- Clicking the 'close' button will cause the player to walk to the placeable; or wander off to the edge of the area if placeable is in the different area
- Walking anywhere automatically closes the inventory

But generally works well, especially for usecase listed in #183.