### PR TITLE
Add buildtime plugin filtering and out-of-tree plugin support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,8 +97,19 @@ add_subdirectory(Core)
 # Detect every plugin and store it in plugins . . .
 file(GLOB plugins Plugins/*/CMakeLists.txt)
 
+# Allow skipping certain plugins by putting their names in env. variable
+foreach(skipped $ENV{NWNX_SKIP_PLUGINS})
+    file(GLOB skip Plugins/${skipped}/CMakeLists.txt)
+    list(REMOVE_ITEM plugins ${skip} )
+endforeach(skipped)
+
 # . . . Then iterate over it.
 foreach(plugin ${plugins})
     get_filename_component(pluginPath ${plugin} PATH)
     add_subdirectory(${pluginPath})
 endforeach(plugin)
+
+# Allow specifying out of tree plugins by putting their paths in env. variable
+foreach(addplugin $ENV{NWNX_ADDITIONAL_PLUGINS})
+    add_subdirectory(${addplugin} ${CMAKE_CURRENT_SOURCE_DIR}/Binaries)
+endforeach(addplugin)


### PR DESCRIPTION
Allow some more control for the build by setting a few environment variables:

```
export NWNX_SKIP_PLUGINS="WebHook;Chat;Weapon;SQL;Mono"
```

Will cause those plugins not to be built. Additionally, you could do:
```
export NWNX_ADDITIONAL_PLUGINS="/path/to/private/Plugin;/path/to/other/Plugin2"
```

which will pick up plugins that live outside of the `unified/Plugins` directory. This is useful for plugins that might not be wanted by most people, or that don't play well with others. Or just for organization, so you keep server-specific plugins in the server code, and keep the nwnx folder clean.

Note that this is the first time I've ever worked with cmake, so if this is horrible for some reason, please let me know.

This implements #46 