### PR TITLE
Profiler perf scopes via messaging and nwscript

### DIFF
--- a/Plugins/Profiler/NWScript/nwnx_profiler.nss
+++ b/Plugins/Profiler/NWScript/nwnx_profiler.nss
@@ -1,0 +1,43 @@
+#include "nwnx"
+
+// These functions are for advanced users to instrument their nwscript code.
+
+// Push a timing metric scope - note that every push must be matched by a corresponding pop.
+// A timing metric contains the following information.
+//
+//  {
+//    metricName: [name], // Mandatory, from user code
+//    metricFields: { time, nanoseconds }, // Automatically captured by the push/pop pair
+//    metricTags: { [tag0_tag], [tag0_value] } // Optional, from user code, can be used to
+//                                                filter metrics based on some category or,
+//                                                constant e.g. objectType or area
+//  }
+//
+// If you don't understand how this works and you wish to use it, you should research
+// the Metrics system (see Metrics.hpp) as well as googling about how InfluxDB stores metrics.
+//
+// NOTE - it's possible to have more than one tag pair per metric, I've just limited
+// it to one arbitrarily here. You can edit the prototype to include more and the C++
+// code will cope with it correctly.
+void NWNX_Profiler_PushPerfScope(string name, string tag0_tag = "", string tag0_value = "");
+
+// Pops a timing metric - one must already be pushed.
+void NWNX_Profiler_PopPerfScope();
+
+void NWNX_Profiler_PushPerfScope(string name, string tag0_tag = "", string tag0_value = "")
+{
+    NWNX_PushArgumentString("NWNX_Profiler", "PUSH_PERF_SCOPE", name);
+
+    if (tag0_value != "" && tag0_tag != "")
+    {
+        NWNX_PushArgumentString("NWNX_Profiler", "PUSH_PERF_SCOPE", tag0_value);
+        NWNX_PushArgumentString("NWNX_Profiler", "PUSH_PERF_SCOPE", tag0_tag);
+    }
+
+    NWNX_CallFunction("NWNX_Profiler", "PUSH_PERF_SCOPE");
+}
+
+string NWNX_Profiler_PopPerfScope()
+{
+    NWNX_CallFunction("NWNX_Profiler", "POP_PERF_SCOPE");
+}

--- a/Plugins/Profiler/Profiler.hpp
+++ b/Plugins/Profiler/Profiler.hpp
@@ -2,6 +2,7 @@
 
 #include "Plugin.hpp"
 #include "Services/Hooks/Hooks.hpp"
+#include "Services/Metrics/Metrics.hpp"
 #include <chrono>
 #include <memory>
 
@@ -36,6 +37,10 @@ private:
     static void HandleRecalibration(const std::chrono::time_point<std::chrono::high_resolution_clock>& now);
 
     static void MainLoopUpdate(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CServerExoAppInternal* thisPtr);
+
+    void SetPerfScopeResampler(std::string&& name);
+    void PushPerfScope(std::string&& name, NWNXLib::Services::MetricData::Tags&& tags);
+    void PopPerfScope();
 };
 
 }


### PR DESCRIPTION
This adds instrumentation that can be used cross-plugin via messaging (it was mostly broken before, it crashed with nested perf scopes) and also in nwscript. I also updated Mono to use this system rather than directly use metrics.

This doesn't support setting the resampler via nwscript yet, so users will need to resample via Grafana rules or however else they are visualising their data. This can be improved in the future, though I suspect only advanced users will ever use this and can therefore improve it themselves if they need to.

I haven't tested this in nwscript. I have tested it with C# bindings that do the same thing, though.