### PR TITLE
New service: Commands

### DIFF
--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -15,6 +15,7 @@
 #include "Services/Tasks/Tasks.hpp"
 #include "Services/Messaging/Messaging.hpp"
 #include "Services/PerObjectStorage/PerObjectStorage.hpp"
+#include "Services/Commands/Commands.hpp"
 #include "Utils.hpp"
 
 #include <cstring>

--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -136,6 +136,7 @@ std::unique_ptr<Services::ServiceList> NWNXCore::ConstructCoreServices()
     services->m_config = std::make_unique<Config>();
     services->m_messaging = std::make_unique<Messaging>();
     services->m_perObjectStorage = std::make_unique<PerObjectStorage>();
+    services->m_commands = std::make_unique<Commands>();
 
     return services;
 }
@@ -153,6 +154,7 @@ std::unique_ptr<Services::ProxyServiceList> NWNXCore::ConstructProxyServices(con
     proxyServices->m_config = std::make_unique<Services::ConfigProxy>(*m_services->m_config, plugin);
     proxyServices->m_messaging = std::make_unique<Services::MessagingProxy>(*m_services->m_messaging);
     proxyServices->m_perObjectStorage = std::make_unique<Services::PerObjectStorageProxy>(*m_services->m_perObjectStorage, plugin);
+    proxyServices->m_commands = std::make_unique<Services::CommandsProxy>(*m_services->m_commands);
 
     ConfigureLogLevel(plugin, *proxyServices->m_config);
 
@@ -429,6 +431,7 @@ void NWNXCore::MainLoopInternalHandler(Services::Hooks::CallType type, API::CSer
 
     g_core->m_services->m_metrics->Update(g_core->m_services->m_tasks);
     g_core->m_services->m_tasks->ProcessWorkOnMainThread();
+    g_core->m_services->m_commands->RunScheduledCommands();
 }
 
 }

--- a/NWNXLib/Common.hpp
+++ b/NWNXLib/Common.hpp
@@ -17,6 +17,7 @@ class Patching;
 class Config;
 class Messaging;
 class PerObjectStorage;
+class Commands;
 
 class EventsProxy;
 class HooksProxy;
@@ -27,6 +28,7 @@ class PatchingProxy;
 class ConfigProxy;
 class MessagingProxy;
 class PerObjectStorageProxy;
+class CommandsProxy;
 
 }
 

--- a/NWNXLib/Services/CMakeLists.txt
+++ b/NWNXLib/Services/CMakeLists.txt
@@ -7,5 +7,6 @@ add_subdirectory(Plugins)
 add_subdirectory(Tasks)
 add_subdirectory(Messaging)
 add_subdirectory(PerObjectStorage)
+add_subdirectory(Commands)
 
 nwnxlib_scope()

--- a/NWNXLib/Services/Commands/CMakeLists.txt
+++ b/NWNXLib/Services/Commands/CMakeLists.txt
@@ -1,0 +1,2 @@
+nwnxlib_add(
+    "Commands.cpp")

--- a/NWNXLib/Services/Commands/Commands.cpp
+++ b/NWNXLib/Services/Commands/Commands.cpp
@@ -1,14 +1,88 @@
 #include "Services/Commands/Commands.hpp"
+#include <stdio.h>
+#include <dlfcn.h>
 
 namespace NWNXLib {
 namespace Services {
 
+static Commands *g_commands;
+
 Commands::Commands()
 {
+    g_commands = this;
+    RegisterCommand("nwnx_commands_test", [](std::string& s){ LOG_NOTICE("Selftest command. Args: '%s'", s.c_str()); });
 }
 
 Commands::~Commands()
 {
+    g_commands = nullptr;
+
+}
+
+bool Commands::RegisterCommand(const std::string& cmd, CommandFunc func)
+{
+    auto it = m_commandMap.find(cmd);
+    if (it == m_commandMap.end())
+    {
+        m_commandMap[cmd] = func;
+        LOG_INFO("Registering command '%s'", cmd.c_str());
+        return true;
+    }
+    else
+    {
+        LOG_WARNING("Command '%s' already registered", cmd.c_str());
+        return false;
+    }
+}
+
+void Commands::UnregisterCommand(const std::string& cmd)
+{
+    LOG_INFO("Unregistering command '%s'", cmd.c_str());
+    m_commandMap.erase(cmd);
+}
+
+bool Commands::ScheduleCommand(const std::string& cmdline)
+{
+    std::string cmd, args;
+    size_t space = cmdline.find(' ');
+
+    if (space == std::string::npos) // No args
+    {
+        cmd = cmdline.substr(0, cmdline.length() - 1);
+        args = "";
+    }
+    else
+    {
+        cmd = cmdline.substr(0, space);
+        args = cmdline.substr(space+1, cmdline.length()-space-2);
+    }
+
+    auto it = m_commandMap.find(cmd);
+    if (it != m_commandMap.end())
+    {
+        std::lock_guard<std::mutex> guard(m_queueLock);
+        m_commandQueue.push_back(std::make_pair(cmd, args));
+        LOG_DEBUG("Scheduled command '%s' with args '%s'", cmd.c_str(), args.c_str());
+        return true;
+    }
+
+    return false;
+}
+
+void Commands::RunScheduledCommands()
+{
+    std::lock_guard<std::mutex> guard(m_queueLock);
+    for (auto item: m_commandQueue)
+    {
+        LOG_DEBUG("Running command '%s', args: '%s'", item.first.c_str(), item.second.c_str());
+        auto it = m_commandMap.find(item.first);
+        if (it != m_commandMap.end())
+        {
+            auto func = it->second;
+            func(item.second);
+        }
+    }
+    m_commandQueue.clear();
 }
 
 
@@ -16,12 +90,39 @@ CommandsProxy::CommandsProxy(Commands& commands)
     : ServiceProxy<Commands>(commands)
 {
 }
-
 CommandsProxy::~CommandsProxy()
 {
 }
 
 
+bool CommandsProxy::RegisterCommand(const std::string& cmd, Commands::CommandFunc func)
+{
+    return m_proxyBase.RegisterCommand(cmd, func);
+}
+void CommandsProxy::UnregisterCommand(const std::string& cmd)
+{
+    m_proxyBase.UnregisterCommand(cmd);
+}
 
 }
+}
+
+
+extern "C" char *fgets(char * str, int num, FILE *stream)
+{
+    using Type = char*(*)(char*,int,FILE*);
+    static Type real;
+    if (!real)
+        real = (Type)dlsym(RTLD_NEXT, "fgets");
+
+    char *ret = real(str, num, stream);
+    if (ret && stream == stdin && num == 1024 && NWNXLib::Services::g_commands)
+    {
+        if (NWNXLib::Services::g_commands->ScheduleCommand(std::string(str)))
+        {
+            // Clear command line so server doesn't run it.
+            str[0] = '\0';
+        }
+    }
+    return ret;
 }

--- a/NWNXLib/Services/Commands/Commands.cpp
+++ b/NWNXLib/Services/Commands/Commands.cpp
@@ -59,10 +59,10 @@ bool Commands::ScheduleCommand(std::string cmdline)
 
     trim(cmd); trim(args);
 
+    std::lock_guard<std::mutex> guard(m_queueLock);
     auto it = m_commandMap.find(cmd);
     if (it != m_commandMap.end())
     {
-        std::lock_guard<std::mutex> guard(m_queueLock);
         m_commandQueue.emplace_back(cmd, args);
         LOG_DEBUG("Scheduled command '%s' with args '%s'", cmd.c_str(), args.c_str());
         return true;

--- a/NWNXLib/Services/Commands/Commands.cpp
+++ b/NWNXLib/Services/Commands/Commands.cpp
@@ -1,0 +1,27 @@
+#include "Services/Commands/Commands.hpp"
+
+namespace NWNXLib {
+namespace Services {
+
+Commands::Commands()
+{
+}
+
+Commands::~Commands()
+{
+}
+
+
+CommandsProxy::CommandsProxy(Commands& commands)
+    : ServiceProxy<Commands>(commands)
+{
+}
+
+CommandsProxy::~CommandsProxy()
+{
+}
+
+
+
+}
+}

--- a/NWNXLib/Services/Commands/Commands.cpp
+++ b/NWNXLib/Services/Commands/Commands.cpp
@@ -92,16 +92,30 @@ CommandsProxy::CommandsProxy(Commands& commands)
 }
 CommandsProxy::~CommandsProxy()
 {
+    for (auto cmd: m_RegisteredCommands)
+    {
+        m_proxyBase.UnregisterCommand(cmd);
+    }
+    m_RegisteredCommands.clear();
 }
 
 
 bool CommandsProxy::RegisterCommand(const std::string& cmd, Commands::CommandFunc func)
 {
-    return m_proxyBase.RegisterCommand(cmd, func);
+    if (m_proxyBase.RegisterCommand(cmd, func))
+    {
+        m_RegisteredCommands.emplace(cmd);
+        return true;
+    }
+    return false;
 }
 void CommandsProxy::UnregisterCommand(const std::string& cmd)
 {
-    m_proxyBase.UnregisterCommand(cmd);
+    if (m_RegisteredCommands.find(cmd) != m_RegisteredCommands.end())
+    {
+        m_proxyBase.UnregisterCommand(cmd);
+        m_RegisteredCommands.erase(cmd);
+    }
 }
 
 }

--- a/NWNXLib/Services/Commands/Commands.hpp
+++ b/NWNXLib/Services/Commands/Commands.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Services/Services.hpp"
+
+namespace NWNXLib {
+namespace Services {
+
+class Commands : public ServiceBase
+{
+public:
+    Commands();
+    ~Commands();
+};
+
+class CommandsProxy : public ServiceProxy<Commands>
+{
+public:
+    CommandsProxy(Commands&);
+    ~CommandsProxy();
+};
+
+}
+}

--- a/NWNXLib/Services/Commands/Commands.hpp
+++ b/NWNXLib/Services/Commands/Commands.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <unordered_map>
 #include <deque>
+#include <set>
 #include <mutex>
 
 namespace NWNXLib {
@@ -37,6 +38,9 @@ public:
 
     bool RegisterCommand(const std::string& cmd, Commands::CommandFunc func);
     void UnregisterCommand(const std::string& cmd);
+
+private:
+    std::set<std::string> m_RegisteredCommands;
 };
 
 }

--- a/NWNXLib/Services/Commands/Commands.hpp
+++ b/NWNXLib/Services/Commands/Commands.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
 #include "Services/Services.hpp"
+#include <string>
+#include <unordered_map>
+#include <deque>
+#include <mutex>
 
 namespace NWNXLib {
 namespace Services {
@@ -8,8 +12,21 @@ namespace Services {
 class Commands : public ServiceBase
 {
 public:
+    using CommandFunc = void (*)(std::string&);
+
     Commands();
     ~Commands();
+
+    bool RegisterCommand(const std::string& cmd, CommandFunc func);
+    void UnregisterCommand(const std::string& cmd);
+
+    bool ScheduleCommand(const std::string& cmdline);
+    void RunScheduledCommands();
+
+private:
+    std::unordered_map<std::string, CommandFunc> m_commandMap;
+    std::deque<std::pair<std::string,std::string>> m_commandQueue;
+    std::mutex m_queueLock;
 };
 
 class CommandsProxy : public ServiceProxy<Commands>
@@ -17,6 +34,9 @@ class CommandsProxy : public ServiceProxy<Commands>
 public:
     CommandsProxy(Commands&);
     ~CommandsProxy();
+
+    bool RegisterCommand(const std::string& cmd, Commands::CommandFunc func);
+    void UnregisterCommand(const std::string& cmd);
 };
 
 }

--- a/NWNXLib/Services/Commands/Commands.hpp
+++ b/NWNXLib/Services/Commands/Commands.hpp
@@ -21,7 +21,7 @@ public:
     bool RegisterCommand(const std::string& cmd, CommandFunc func);
     void UnregisterCommand(const std::string& cmd);
 
-    bool ScheduleCommand(const std::string& cmdline);
+    bool ScheduleCommand(std::string cmdline);
     void RunScheduledCommands();
 
 private:

--- a/NWNXLib/Services/Services.hpp
+++ b/NWNXLib/Services/Services.hpp
@@ -22,6 +22,7 @@ struct ServiceList
     std::unique_ptr<Config> m_config;
     std::unique_ptr<Messaging> m_messaging;
     std::unique_ptr<PerObjectStorage> m_perObjectStorage;
+    std::unique_ptr<Commands> m_commands;
 };
 
 // Contains proxies through which the services should be accessed.
@@ -36,6 +37,7 @@ struct ProxyServiceList
     std::unique_ptr<ConfigProxy> m_config;
     std::unique_ptr<MessagingProxy> m_messaging;
     std::unique_ptr<PerObjectStorageProxy> m_perObjectStorage;
+    std::unique_ptr<CommandsProxy> m_commands;
 };
 
 struct ServiceBase


### PR DESCRIPTION
As mentioned in #6 , this allows plugins (and core) to register console commands on the server. It works by overriding `fgets` when the server tries to read stdin, and checks NWNX commands first. Some notes:

- The input is handled on a side thread, so commands must be scheduled into a queue and then run on the main thread.
- No (useful) commands currently. We can try doing config changes and plugin load/unload in a follow up change
- nwnx commands can shadow nwserver ones - If a command is registered for nwnx, a command of the same name can't be run on nwserver. This might be an issue if we want to use load/unload/reload for plugins, since `load` is already a nwserver command to load a savegame. Might need to prefix them explicitly
- Plugin commands are in the global namespace, so plugins can conflict over the command names. It will print a warning in this case, and only use the first one.
- Original implementation done on a phone via ssh. Not recommended for replication.