### PR TITLE
object: Fix SetDialogResref to not push return values

### DIFF
--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -274,7 +274,6 @@ ArgumentStack Object::GetDialogResref(ArgumentStack&& args)
 ArgumentStack Object::SetDialogResref(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    std::string retval = "";
     if (auto *pObject = object(args))
     {
         const auto dialog = Services::Events::ExtractArgument<std::string>(args);
@@ -288,7 +287,6 @@ ArgumentStack Object::SetDialogResref(ArgumentStack&& args)
             pDoor->m_cDialog = resref;
     }
 
-    Services::Events::InsertArgument(stack, retval);
     return stack;
 }
 


### PR DESCRIPTION
@BhaalM on discord:
```
BhaalM Today at 12:41 AM
@sherincall I think there is an error in the SetDialogResref function, it should not return a value, see line 291: Services::Events::InsertArgument(stack, retval);
It only works the first time you use it
after that: 

E [00:33:41] [NWNXLib] [Events.cpp:80] SetLocalString encountered error 'Tried to operate on an event without first retrieving all the return values.' for input 'PUSH_ARGUMENT!NWNX_Object!SetDialogResref' and value '3 g_rq_deliver'.
```

Sure enough. Silly copy/paste error.