### PR TITLE
New plugin: Visibility

### DIFF
--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -1,6 +1,5 @@
 #include "nwnx"
 
-
 struct NWNX_Player_QuickBarSlot
 {
     object oItem;
@@ -17,10 +16,6 @@ struct NWNX_Player_QuickBarSlot
     int    nAssociateType;
     object oAssociate;
 };
-
-const int NWNX_PLAYER_VISIBILITY_DEFAULT = 0;
-const int NWNX_PLAYER_VISIBILITY_HIDDEN  = 1;
-const int NWNX_PLAYER_VISIBILITY_VISIBLE = 2;
 
 // Force display placeable examine window for player
 // If used on a placeable in a different area than the player, the portait will not be shown.
@@ -56,16 +51,6 @@ void NWNX_Player_SetQuickBarSlot(object player, int slot, struct NWNX_Player_Qui
 
 // Get the name of the .bic file associated with the player's character.
 string NWNX_Player_GetBicFileName(object player);
-
-// Overrides the default visibility rules about how player perceives the target object.
-// NWNX_PLAYER_VISIBILITY_DEFAULT - Restore normal behavior
-// NWNX_PLAYER_VISIBILITY_HIDDEN - Object is always hidden from the player
-// NWNX_PLAYER_VISIBILITY_VISIBLE - Object is always shown to the player
-void NWNX_Player_SetVisibilityOverride(object player, object target, int override);
-
-// Queries the existing visibility override for given (player, object) pair
-// Returns NWNX_PLAYER_VISIBILITY_DEFAULT if no override exists
-int NWNX_Player_GetVisibilityOverride(object player, object target);
 
 // Plays the VFX at the target position in current area for the given player only
 void NWNX_Player_ShowVisualEffect(object player, int effectId, vector position);
@@ -230,26 +215,6 @@ string NWNX_Player_GetBicFileName(object player)
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
     NWNX_CallFunction(NWNX_Player, sFunc);
     return NWNX_GetReturnValueString(NWNX_Player, sFunc);
-}
-
-void NWNX_Player_SetVisibilityOverride(object player, object target, int override)
-{
-    string sFunc = "SetVisibilityOverride";
-    NWNX_PushArgumentInt(NWNX_Player, sFunc, override);
-    NWNX_PushArgumentObject(NWNX_Player, sFunc, target);
-    NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
-
-    NWNX_CallFunction(NWNX_Player, sFunc);
-}
-
-int NWNX_Player_GetVisibilityOverride(object player, object target)
-{
-    string sFunc = "GetVisibilityOverride";
-    NWNX_PushArgumentObject(NWNX_Player, sFunc, target);
-    NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
-
-    NWNX_CallFunction(NWNX_Player, sFunc);
-    return NWNX_GetReturnValueInt(NWNX_Player, sFunc);
 }
 
 void NWNX_Player_ShowVisualEffect(object player, int effectId, vector position)

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -17,6 +17,10 @@ struct NWNX_Player_QuickBarSlot
     object oAssociate;
 };
 
+const int NWNX_PLAYER_VISIBILITY_DEFAULT = 0;
+const int NWNX_PLAYER_VISIBILITY_HIDDEN  = 1;
+const int NWNX_PLAYER_VISIBILITY_VISIBLE = 2;
+
 // Force display placeable examine window for player
 // If used on a placeable in a different area than the player, the portait will not be shown.
 void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable);
@@ -52,6 +56,20 @@ void NWNX_Player_SetQuickBarSlot(object player, int slot, struct NWNX_Player_Qui
 // Get the name of the .bic file associated with the player's character.
 string NWNX_Player_GetBicFileName(object player);
 
+// Overrides the default visibility rules about how player perceives the target object.
+// NWNX_PLAYER_VISIBILITY_DEFAULT - Restore normal behavior
+// NWNX_PLAYER_VISIBILITY_HIDDEN - Object is always hidden from the player
+// NWNX_PLAYER_VISIBILITY_VISIBLE - Object is always shown to the player
+//
+// DEPRECATED - Use NWNX_Visibility_SetVisibilityOverride instead
+void NWNX_Player_SetVisibilityOverride(object player, object target, int override);
+
+// Queries the existing visibility override for given (player, object) pair
+// Returns NWNX_PLAYER_VISIBILITY_DEFAULT if no override exists
+//
+// DEPRECATED - Use NWNX_Visibility_GetVisibilityOverride instead
+int NWNX_Player_GetVisibilityOverride(object player, object target);
+
 // Plays the VFX at the target position in current area for the given player only
 void NWNX_Player_ShowVisualEffect(object player, int effectId, vector position);
 
@@ -85,6 +103,7 @@ void NWNX_Player_SetPlaceableUsable(object player, object placeable, int usable)
 
 
 const string NWNX_Player = "NWNX_Player";
+
 
 void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable)
 {
@@ -215,6 +234,67 @@ string NWNX_Player_GetBicFileName(object player)
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
     NWNX_CallFunction(NWNX_Player, sFunc);
     return NWNX_GetReturnValueString(NWNX_Player, sFunc);
+}
+
+void NWNX_Player_SetVisibilityOverride(object player, object target, int override)
+{
+    WriteTimestampedLogEntry("NWNX_Player: SetVisibilityOverride() is deprecated. Use NWNX_Visibility: SetVisibilityOverride() instead");
+
+    string sFunc = "SetVisibilityOverride";
+    string NWNX_Visibility = "NWNX_Visibility";
+
+    switch(override)
+    {
+        case NWNX_PLAYER_VISIBILITY_DEFAULT:
+            override = -1;
+            break;
+
+        case NWNX_PLAYER_VISIBILITY_HIDDEN:
+            override = 1;
+            break;
+
+        case NWNX_PLAYER_VISIBILITY_VISIBLE:
+            override = 0;
+            break;
+    }
+
+    NWNX_PushArgumentInt(NWNX_Visibility, sFunc, override);
+    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, target);
+    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, player);
+
+    NWNX_CallFunction(NWNX_Visibility, sFunc);
+}
+
+int NWNX_Player_GetVisibilityOverride(object player, object target)
+{
+    WriteTimestampedLogEntry("NWNX_Player: GetVisibilityOverride() is deprecated. Use NWNX_Visibility: GetVisibilityOverride() instead");
+
+    string sFunc = "GetVisibilityOverride";
+    string NWNX_Visibility = "NWNX_Visibility";
+
+    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, target);
+    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, player);
+
+    NWNX_CallFunction(NWNX_Visibility, sFunc);
+
+    int retVal = NWNX_GetReturnValueInt(NWNX_Visibility, sFunc);
+
+    switch(retVal)
+    {
+        case -1:
+            retVal = NWNX_PLAYER_VISIBILITY_DEFAULT;
+            break;
+
+        case 0:
+            retVal = NWNX_PLAYER_VISIBILITY_VISIBLE;
+            break;
+
+        case 1:
+            retVal = NWNX_PLAYER_VISIBILITY_HIDDEN;
+            break;
+    }
+
+    return retVal;
 }
 
 void NWNX_Player_ShowVisualEffect(object player, int effectId, vector position)

--- a/Plugins/Player/Player.hpp
+++ b/Plugins/Player/Player.hpp
@@ -28,8 +28,6 @@ private:
     ArgumentStack GetQuickBarSlot               (ArgumentStack&& args);
     ArgumentStack SetQuickBarSlot               (ArgumentStack&& args);
     ArgumentStack GetBicFileName                (ArgumentStack&& args);
-    ArgumentStack SetVisibilityOverride         (ArgumentStack&& args);
-    ArgumentStack GetVisibilityOverride         (ArgumentStack&& args);
     ArgumentStack ShowVisualEffect              (ArgumentStack&& args);
     ArgumentStack ChangeBackgroundMusic         (ArgumentStack&& args);
     ArgumentStack PlayBackgroundMusic           (ArgumentStack&& args);

--- a/Plugins/Visibility/CMakeLists.txt
+++ b/Plugins/Visibility/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_plugin(Visibility
+    "Visibility.cpp")

--- a/Plugins/Visibility/Documentation/README.md
+++ b/Plugins/Visibility/Documentation/README.md
@@ -1,0 +1,7 @@
+# Visibility Plugin Reference
+
+## Description
+
+Allows the visibility of objects to be overriden globally or per player
+
+## Environment Variables

--- a/Plugins/Visibility/Documentation/README.md
+++ b/Plugins/Visibility/Documentation/README.md
@@ -2,6 +2,6 @@
 
 ## Description
 
-Allows the visibility of objects to be overriden globally or per player
+Allows the visibility of objects to be overridden globally or per player
 
 ## Environment Variables

--- a/Plugins/Visibility/NWScript/nwnx_visibility.nss
+++ b/Plugins/Visibility/NWScript/nwnx_visibility.nss
@@ -3,7 +3,7 @@
 const int NWNX_VISIBILITY_DEFAULT   = -1;
 const int NWNX_VISIBILITY_VISIBLE   = 0;
 const int NWNX_VISIBILITY_HIDDEN    = 1;
-const int NWNX_VISIBLITY_DM_ONLY    = 2;
+const int NWNX_VISIBILITY_DM_ONLY   = 2;
 
 // Queries the existing visibility override for given (player, target) pair
 // If player is OBJECT_INVALID, the global visibility override will be returned
@@ -17,7 +17,7 @@ const int NWNX_VISIBLITY_DM_ONLY    = 2;
 //   NWNX_VISIBILITY_DEFAULT = Global override not set
 //   NWNX_VISIBILITY_VISIBLE = Target is globally visible
 //   NWNX_VISIBILITY_HIDDEN  = Target is globally hidden
-//   NWNX_VISIBLITY_DM_ONLY  = Target is only visible to DMs
+//   NWNX_VISIBILITY_DM_ONLY = Target is only visible to DMs
 int NWNX_Visibility_GetVisibilityOverride(object player, object target);
 
 // Overrides the default visibility rules about how player perceives the target object
@@ -32,11 +32,11 @@ int NWNX_Visibility_GetVisibilityOverride(object player, object target);
 //   NWNX_VISIBILITY_DEFAULT = Remove the global override
 //   NWNX_VISIBILITY_VISIBLE = Target is globally visible
 //   NWNX_VISIBILITY_HIDDEN  = Target is globally hidden
-//   NWNX_VISIBLITY_DM_ONLY  = Target is only visible to DMs
+//   NWNX_VISIBILITY_DM_ONLY = Target is only visible to DMs
 //
 // Note:
 // Player state overrides the global state which means if a global state is set
-// to NWNX_VISIBILITY_HIDDEN or NWNX_VISIBLITY_DM_ONLY but the player's state is
+// to NWNX_VISIBILITY_HIDDEN or NWNX_VISIBILITY_DM_ONLY but the player's state is
 // set to NWNX_VISIBILITY_VISIBLE for the target, the object will be visible to the player
 void NWNX_Visibility_SetVisibilityOverride(object player, object target, int override);
 

--- a/Plugins/Visibility/NWScript/nwnx_visibility.nss
+++ b/Plugins/Visibility/NWScript/nwnx_visibility.nss
@@ -1,0 +1,53 @@
+#include "nwnx"
+
+const int NWNX_VISIBILITY_DEFAULT   = -1;
+const int NWNX_VISIBILITY_VISIBLE   = 0;
+const int NWNX_VISIBILITY_HIDDEN    = 1;
+
+// Queries the existing visibility override for given (player, target) pair
+// If player is OBJECT_INVALID, the global visibility override will be returned
+//
+// Returns:
+//   NWNX_VISIBILITY_DEFAULT = Player override not set
+//   NWNX_VISIBILITY_VISIBLE = Target is visible
+//   NWNX_VISIBILITY_HIDDEN  = Target is hidden
+int NWNX_Visibility_GetVisibilityOverride(object player, object target);
+
+// Overrides the default visibility rules about how player perceives the target object
+// If player is OBJECT_INVALID, the global visibility override will be set
+//
+// override:
+//   NWNX_VISIBILITY_DEFAULT = Remove the player override
+//   NWNX_VISIBILITY_VISIBLE = Target is visible
+//   NWNX_VISIBILITY_HIDDEN  = Target is hidden
+//
+// Note:
+// Player state overrides the global state which means if a global state is set
+// to NWNX_VISIBILITY_HIDDEN but the player's state is set to NWNX_VISIBILITY_VISIBLE
+// for the target, the object will be visible to the player
+void NWNX_Visibility_SetVisibilityOverride(object player, object target, int override);
+
+
+const string NWNX_Visibility = "NWNX_Visibility";
+
+
+int NWNX_Visibility_GetVisibilityOverride(object player, object target)
+{
+    string sFunc = "GetVisibilityOverride";
+
+    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, target);
+    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, player);
+    NWNX_CallFunction(NWNX_Visibility, sFunc);
+
+    return NWNX_GetReturnValueInt(NWNX_Visibility, sFunc);
+}
+
+void NWNX_Visibility_SetVisibilityOverride(object player, object target, int override)
+{
+    string sFunc = "SetVisibilityOverride";
+
+    NWNX_PushArgumentInt(NWNX_Visibility, sFunc, override);
+    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, target);
+    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, player);
+    NWNX_CallFunction(NWNX_Visibility, sFunc);
+}

--- a/Plugins/Visibility/NWScript/nwnx_visibility.nss
+++ b/Plugins/Visibility/NWScript/nwnx_visibility.nss
@@ -3,28 +3,41 @@
 const int NWNX_VISIBILITY_DEFAULT   = -1;
 const int NWNX_VISIBILITY_VISIBLE   = 0;
 const int NWNX_VISIBILITY_HIDDEN    = 1;
+const int NWNX_VISIBLITY_DM_ONLY    = 2;
 
 // Queries the existing visibility override for given (player, target) pair
 // If player is OBJECT_INVALID, the global visibility override will be returned
 //
-// Returns:
+// Player == VALID -> returns:
 //   NWNX_VISIBILITY_DEFAULT = Player override not set
-//   NWNX_VISIBILITY_VISIBLE = Target is visible
-//   NWNX_VISIBILITY_HIDDEN  = Target is hidden
+//   NWNX_VISIBILITY_VISIBLE = Target is always visible for player
+//   NWNX_VISIBILITY_HIDDEN  = Target is always hidden for player
+//
+// Player == OBJECT_INVALID -> returns:
+//   NWNX_VISIBILITY_DEFAULT = Global override not set
+//   NWNX_VISIBILITY_VISIBLE = Target is globally visible
+//   NWNX_VISIBILITY_HIDDEN  = Target is globally hidden
+//   NWNX_VISIBLITY_DM_ONLY  = Target is only visible to DMs
 int NWNX_Visibility_GetVisibilityOverride(object player, object target);
 
 // Overrides the default visibility rules about how player perceives the target object
 // If player is OBJECT_INVALID, the global visibility override will be set
 //
-// override:
+// Player == VALID -> override:
 //   NWNX_VISIBILITY_DEFAULT = Remove the player override
-//   NWNX_VISIBILITY_VISIBLE = Target is visible
-//   NWNX_VISIBILITY_HIDDEN  = Target is hidden
+//   NWNX_VISIBILITY_VISIBLE = Target is always visible for player
+//   NWNX_VISIBILITY_HIDDEN  = Target is always hidden for player
+//
+// Player == OBJECT_INVALID -> override:
+//   NWNX_VISIBILITY_DEFAULT = Remove the global override
+//   NWNX_VISIBILITY_VISIBLE = Target is globally visible
+//   NWNX_VISIBILITY_HIDDEN  = Target is globally hidden
+//   NWNX_VISIBLITY_DM_ONLY  = Target is only visible to DMs
 //
 // Note:
 // Player state overrides the global state which means if a global state is set
-// to NWNX_VISIBILITY_HIDDEN but the player's state is set to NWNX_VISIBILITY_VISIBLE
-// for the target, the object will be visible to the player
+// to NWNX_VISIBILITY_HIDDEN or NWNX_VISIBLITY_DM_ONLY but the player's state is
+// set to NWNX_VISIBILITY_VISIBLE for the target, the object will be visible to the player
 void NWNX_Visibility_SetVisibilityOverride(object player, object target, int override);
 
 

--- a/Plugins/Visibility/Visibility.cpp
+++ b/Plugins/Visibility/Visibility.cpp
@@ -19,7 +19,7 @@ NWNX_PLUGIN_ENTRY Plugin::Info* PluginInfo()
     return new Plugin::Info
     {
         "Visibility",
-        "Allows the visibility of objects to be overriden globally or per player",
+        "Allows the visibility of objects to be overridden globally or per player",
         "Daz",
         "daztek@gmail.com",
         1,

--- a/Plugins/Visibility/Visibility.cpp
+++ b/Plugins/Visibility/Visibility.cpp
@@ -1,0 +1,139 @@
+#include "Visibility.hpp"
+
+#include "API/Constants.hpp"
+#include "API/Globals.hpp"
+#include "API/Functions.hpp"
+#include "API/CNWSObject.hpp"
+#include "Services/Events/Events.hpp"
+#include "Services/PerObjectStorage/PerObjectStorage.hpp"
+#include "ViewPtr.hpp"
+
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+static ViewPtr<Visibility::Visibility> g_plugin;
+
+NWNX_PLUGIN_ENTRY Plugin::Info* PluginInfo()
+{
+    return new Plugin::Info
+    {
+        "Visibility",
+        "Allows the visibility of objects to be overriden globally or per player",
+        "Daz",
+        "daztek@gmail.com",
+        1,
+        true
+    };
+}
+
+NWNX_PLUGIN_ENTRY Plugin* PluginLoad(Plugin::CreateParams params)
+{
+    g_plugin = new Visibility::Visibility(params);
+    return g_plugin;
+}
+
+
+namespace Visibility {
+
+Visibility::Visibility(const Plugin::CreateParams& params)
+    : Plugin(params)
+{
+#define REGISTER(func) \
+    GetServices()->m_events->RegisterEvent(#func, std::bind(&Visibility::func, this, std::placeholders::_1))
+
+    REGISTER(GetVisibilityOverride);
+    REGISTER(SetVisibilityOverride);
+
+#undef REGISTER
+
+    GetServices()->m_hooks->RequestExclusiveHook<API::Functions::CNWSMessage__TestObjectVisible>(&Visibility::TestObjectVisibleHook);
+    m_TestObjectVisibilityHook = GetServices()->m_hooks->FindHookByAddress(API::Functions::CNWSMessage__TestObjectVisible);   
+}
+
+Visibility::~Visibility()
+{
+}
+
+int32_t Visibility::TestObjectVisibleHook(
+    CNWSMessage *pThis,
+    CNWSObject *pAreaObject,
+    CNWSObject *pPlayerGameObject)
+{
+    auto personalOverride = GetPersonalOverride(pPlayerGameObject->m_idSelf, pAreaObject->m_idSelf);
+    bool bInvisible = (personalOverride == -1) ? GetGlobalOverride(pAreaObject->m_idSelf) : personalOverride;
+    
+    return bInvisible ? false : g_plugin->m_TestObjectVisibilityHook->CallOriginal<int32_t>(pThis, pAreaObject, pPlayerGameObject);
+}
+
+bool Visibility::GetGlobalOverride(Types::ObjectID targetId)
+{
+    return g_plugin->m_GlobalVisibilityOverrideSet.find(targetId) != g_plugin->m_GlobalVisibilityOverrideSet.end();
+}
+
+int32_t Visibility::GetPersonalOverride(Types::ObjectID playerId, Types::ObjectID targetId) 
+{
+    int32_t retVal = -1;
+ 
+    if (auto personalOverride = g_plugin->GetServices()->m_perObjectStorage->Get<int>(playerId, Utils::ObjectIDToString(targetId)))
+    {
+        retVal = !!*personalOverride;
+    }
+    
+    return retVal;    
+}
+
+ArgumentStack Visibility::GetVisibilityOverride(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+
+    const auto playerId = Services::Events::ExtractArgument<Types::ObjectID>(args);
+    const auto targetId = Services::Events::ExtractArgument<Types::ObjectID>(args);
+  
+    int32_t retVal = (playerId == Constants::OBJECT_INVALID) ? GetGlobalOverride(targetId) : 
+                                                               GetPersonalOverride(playerId, targetId);
+
+    Services::Events::InsertArgument(stack, retVal);
+    
+    return stack;
+}
+
+ArgumentStack Visibility::SetVisibilityOverride(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+
+    const auto playerId = Services::Events::ExtractArgument<Types::ObjectID>(args);
+    const auto targetId = Services::Events::ExtractArgument<Types::ObjectID>(args);
+    const auto override = Services::Events::ExtractArgument<int32_t>(args);
+
+    if (playerId == Constants::OBJECT_INVALID)
+    {      
+        if (!!override)
+        {
+            m_GlobalVisibilityOverrideSet.insert(targetId);    
+        }
+        else
+        {
+            auto index = m_GlobalVisibilityOverrideSet.find(targetId);
+            if (index != m_GlobalVisibilityOverrideSet.end())
+            {
+                m_GlobalVisibilityOverrideSet.erase(index);
+            }
+        }
+    }
+    else
+    {
+        if (override == -1)
+        {
+            g_plugin->GetServices()->m_perObjectStorage->Remove(playerId, Utils::ObjectIDToString(targetId));
+        }
+        else
+        {            
+            g_plugin->GetServices()->m_perObjectStorage->Set(playerId, Utils::ObjectIDToString(targetId), !!override);
+        }
+    }       
+        
+    return stack;
+}
+
+}

--- a/Plugins/Visibility/Visibility.cpp
+++ b/Plugins/Visibility/Visibility.cpp
@@ -74,14 +74,7 @@ int32_t Visibility::TestObjectVisibleHook(
     }
     else if (globalOverride != -1)
     {
-        if (globalOverride == 2)
-        {
-            bInvisible = !Utils::AsNWSCreature(pPlayerGameObject)->m_pStats->m_bIsDM;
-        }
-        else
-        {
-            bInvisible = !!globalOverride;
-        }
+        bInvisible = (globalOverride == 2) ? !Utils::AsNWSCreature(pPlayerGameObject)->m_pStats->m_bIsDM : !!globalOverride;        
     }
 
     return bInvisible ? false : g_plugin->m_TestObjectVisibilityHook->CallOriginal<int32_t>(pThis, pAreaObject, pPlayerGameObject);

--- a/Plugins/Visibility/Visibility.cpp
+++ b/Plugins/Visibility/Visibility.cpp
@@ -64,6 +64,11 @@ int32_t Visibility::TestObjectVisibleHook(
     CNWSObject *pAreaObject,
     CNWSObject *pPlayerGameObject)
 {    
+    if(pAreaObject->m_idSelf == pPlayerGameObject->m_idSelf)
+    {
+        return g_plugin->m_TestObjectVisibilityHook->CallOriginal<int32_t>(pThis, pAreaObject, pPlayerGameObject);
+    }
+
     bool bInvisible = false;
     int32_t personalOverride = GetPersonalOverride(pPlayerGameObject->m_idSelf, pAreaObject->m_idSelf);
     int32_t globalOverride = GetGlobalOverride(pAreaObject->m_idSelf);

--- a/Plugins/Visibility/Visibility.cpp
+++ b/Plugins/Visibility/Visibility.cpp
@@ -1,9 +1,13 @@
 #include "Visibility.hpp"
 
+#include "API/CAppManager.hpp"
+#include "API/CServerExoApp.hpp"
 #include "API/Constants.hpp"
 #include "API/Globals.hpp"
 #include "API/Functions.hpp"
 #include "API/CNWSObject.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/CNWSCreatureStats.hpp"
 #include "Services/Events/Events.hpp"
 #include "Services/PerObjectStorage/PerObjectStorage.hpp"
 #include "ViewPtr.hpp"
@@ -59,16 +63,40 @@ int32_t Visibility::TestObjectVisibleHook(
     CNWSMessage *pThis,
     CNWSObject *pAreaObject,
     CNWSObject *pPlayerGameObject)
-{
-    auto personalOverride = GetPersonalOverride(pPlayerGameObject->m_idSelf, pAreaObject->m_idSelf);
-    bool bInvisible = (personalOverride == -1) ? GetGlobalOverride(pAreaObject->m_idSelf) : personalOverride;
+{    
+    bool bInvisible = false;
+    int32_t personalOverride = GetPersonalOverride(pPlayerGameObject->m_idSelf, pAreaObject->m_idSelf);
+    int32_t globalOverride = GetGlobalOverride(pAreaObject->m_idSelf);
     
+    if (personalOverride != -1)
+    {
+        bInvisible = !!personalOverride;
+    }
+    else if (globalOverride != -1)
+    {
+        if (globalOverride == 2)
+        {
+            bInvisible = !Utils::AsNWSCreature(pPlayerGameObject)->m_pStats->m_bIsDM;
+        }
+        else
+        {
+            bInvisible = !!globalOverride;
+        }
+    }
+
     return bInvisible ? false : g_plugin->m_TestObjectVisibilityHook->CallOriginal<int32_t>(pThis, pAreaObject, pPlayerGameObject);
 }
 
-bool Visibility::GetGlobalOverride(Types::ObjectID targetId)
+int32_t Visibility::GetGlobalOverride(Types::ObjectID targetId)
 {
-    return g_plugin->m_GlobalVisibilityOverrideSet.find(targetId) != g_plugin->m_GlobalVisibilityOverrideSet.end();
+    int32_t retVal = -1;
+ 
+    if (auto globalOverride = g_plugin->GetServices()->m_perObjectStorage->Get<int>(targetId, "GLOBAL_VISIBILITY_OVERRIDE"))
+    {
+        retVal = *globalOverride;
+    }
+    
+    return retVal;     
 }
 
 int32_t Visibility::GetPersonalOverride(Types::ObjectID playerId, Types::ObjectID targetId) 
@@ -102,36 +130,25 @@ ArgumentStack Visibility::SetVisibilityOverride(ArgumentStack&& args)
 {
     ArgumentStack stack;
 
-    const auto playerId = Services::Events::ExtractArgument<Types::ObjectID>(args);
+    auto playerId = Services::Events::ExtractArgument<Types::ObjectID>(args);
     const auto targetId = Services::Events::ExtractArgument<Types::ObjectID>(args);
     const auto override = Services::Events::ExtractArgument<int32_t>(args);
+    std::string varName = Utils::ObjectIDToString(targetId);
 
     if (playerId == Constants::OBJECT_INVALID)
     {      
-        if (!!override)
-        {
-            m_GlobalVisibilityOverrideSet.insert(targetId);    
-        }
-        else
-        {
-            auto index = m_GlobalVisibilityOverrideSet.find(targetId);
-            if (index != m_GlobalVisibilityOverrideSet.end())
-            {
-                m_GlobalVisibilityOverrideSet.erase(index);
-            }
-        }
+        varName = "GLOBAL_VISIBILITY_OVERRIDE";
+        playerId = targetId;     
+    }
+
+    if (override == -1)
+    {
+        g_plugin->GetServices()->m_perObjectStorage->Remove(playerId, varName);
     }
     else
-    {
-        if (override == -1)
-        {
-            g_plugin->GetServices()->m_perObjectStorage->Remove(playerId, Utils::ObjectIDToString(targetId));
-        }
-        else
-        {            
-            g_plugin->GetServices()->m_perObjectStorage->Set(playerId, Utils::ObjectIDToString(targetId), !!override);
-        }
-    }       
+    {            
+        g_plugin->GetServices()->m_perObjectStorage->Set(playerId, varName, override);
+    }     
         
     return stack;
 }

--- a/Plugins/Visibility/Visibility.hpp
+++ b/Plugins/Visibility/Visibility.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Plugin.hpp"
+#include "Services/Events/Events.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include <set>
+
+using ArgumentStack = NWNXLib::Services::Events::ArgumentStack;
+
+namespace Visibility {
+
+class Visibility : public NWNXLib::Plugin
+{
+public:
+    Visibility(const Plugin::CreateParams& params);
+    virtual ~Visibility();
+
+private:
+
+    static int32_t TestObjectVisibleHook(NWNXLib::API::CNWSMessage *pThis, NWNXLib::API::CNWSObject *pAreaObject, NWNXLib::API::CNWSObject *pPlayerGameObject);
+    NWNXLib::Hooking::FunctionHook* m_TestObjectVisibilityHook;
+    std::set<NWNXLib::API::Types::ObjectID> m_GlobalVisibilityOverrideSet;
+
+    static bool GetGlobalOverride(NWNXLib::API::Types::ObjectID targetId);
+    static int32_t GetPersonalOverride(NWNXLib::API::Types::ObjectID playerId, NWNXLib::API::Types::ObjectID targetId); 
+
+    ArgumentStack GetVisibilityOverride (ArgumentStack&& args);
+    ArgumentStack SetVisibilityOverride (ArgumentStack&& args); 
+};
+
+}

--- a/Plugins/Visibility/Visibility.hpp
+++ b/Plugins/Visibility/Visibility.hpp
@@ -3,7 +3,6 @@
 #include "Plugin.hpp"
 #include "Services/Events/Events.hpp"
 #include "Services/Hooks/Hooks.hpp"
-#include <set>
 
 using ArgumentStack = NWNXLib::Services::Events::ArgumentStack;
 
@@ -19,9 +18,8 @@ private:
 
     static int32_t TestObjectVisibleHook(NWNXLib::API::CNWSMessage *pThis, NWNXLib::API::CNWSObject *pAreaObject, NWNXLib::API::CNWSObject *pPlayerGameObject);
     NWNXLib::Hooking::FunctionHook* m_TestObjectVisibilityHook;
-    std::set<NWNXLib::API::Types::ObjectID> m_GlobalVisibilityOverrideSet;
 
-    static bool GetGlobalOverride(NWNXLib::API::Types::ObjectID targetId);
+    static int32_t GetGlobalOverride(NWNXLib::API::Types::ObjectID targetId);
     static int32_t GetPersonalOverride(NWNXLib::API::Types::ObjectID playerId, NWNXLib::API::Types::ObjectID targetId); 
 
     ArgumentStack GetVisibilityOverride (ArgumentStack&& args);


### PR DESCRIPTION
Moved {Get/Set}VisibilityOverride out of NWNX_Player and added the ability to globally override the visibility state of an object.

Also made it possible to make objects visible to DMs only!