### PR TITLE
Added the ability to obfuscate player names.

### DIFF
--- a/Plugins/Rename/Documentation/README.md
+++ b/Plugins/Rename/Documentation/README.md
@@ -12,4 +12,4 @@ This plugin facilitates renaming, overriding and customization of player names.
 Script function | Description  
 ----------------|-------------
 NWNX_Rename_SetPCNameOverride | Set a PC's floaty/chat name(sPrefix+sNewName+sSuffix) and name (sNewName) on the player list. If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OVERRIDE the player name will change to (sNewName) on tells. If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OBFUSCATE the player name will be set to a random string.
-If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_DEFAULT the player name will be untouched. Will not persist through saving, resets or logout.
+If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_DEFAULT the player name will be untouched. DMs and the player themselves will still see their original player name regardless of option set Will not persist through saving, resets or logout.

--- a/Plugins/Rename/Documentation/README.md
+++ b/Plugins/Rename/Documentation/README.md
@@ -11,4 +11,5 @@ This plugin facilitates renaming, overriding and customization of player names.
 
 Script function | Description  
 ----------------|-------------
-NWNX_Rename_SetPlayerNameOverride | Set a player's floaty name(sPrefix+sNewName+sSuffix) and name on the player list (sNewName). Will not persist through saving, resets or logout.
+NWNX_Rename_SetPCNameOverride | Set a PC's floaty/chat name(sPrefix+sNewName+sSuffix) and name (sNewName) on the player list. If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OVERRIDE the player name will change to (sNewName) on tells. If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OBFUSCATE the player name will be set to a random string.
+If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_DEFAULT the player name will be untouched. Will not persist through saving, resets or logout.

--- a/Plugins/Rename/NWScript/nwnx_rename.nss
+++ b/Plugins/Rename/NWScript/nwnx_rename.nss
@@ -2,14 +2,24 @@
 
 const string NWNX_Rename = "NWNX_Rename";
 
-//Set a player's floaty name(sPrefix+sNewName+sSuffix) and name on the player list (sNewName). Will not persist through saving, resets or logout.
-void NWNX_Rename_SetPlayerNameOverride(object oPlayer, string sPrefix, string sNewName, string sSuffix);
+//Constant
+const int NWNX_RENAME_PLAYERNAME_DEFAULT = 0;
+const int NWNX_RENAME_PLAYERNAME_OBFUSCATE = 1;
+const int NWNX_RENAME_PLAYERNAME_OVERRIDE = 2;
+
+//Set a PC's floaty/chat name(sPrefix+sNewName+sSuffix) and name (sNewName) on the player list.
+//If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OVERRIDE the player name will change to (sNewName) on tells.
+//If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OBFUSCATE the player name will be set to a random string.
+//If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_DEFAULT the player name will be untouched.
+//Will not persist through saving, resets or logout.
+void NWNX_Rename_SetPCNameOverride(object oPlayer, string sPrefix, string sNewName, string sSuffix, int iPlayerNameState);
 
 
-void NWNX_Rename_SetPlayerNameOverride(object oPlayer, string sPrefix, string sNewName, string sSuffix)
+void NWNX_Rename_SetPCNameOverride(object oPlayer, string sPrefix, string sNewName, string sSuffix, int iPlayerNameState)
 {
-    string sFunc = "SetPlayerNameOverride";
+    string sFunc = "SetPCNameOverride";
     
+    NWNX_PushArgumentInt(NWNX_Rename, sFunc, bOverridePlayerName);
     NWNX_PushArgumentString(NWNX_Rename, sFunc, sSuffix);
     NWNX_PushArgumentString(NWNX_Rename, sFunc, sNewName);
     NWNX_PushArgumentString(NWNX_Rename, sFunc, sPrefix);

--- a/Plugins/Rename/NWScript/nwnx_rename.nss
+++ b/Plugins/Rename/NWScript/nwnx_rename.nss
@@ -2,7 +2,7 @@
 
 const string NWNX_Rename = "NWNX_Rename";
 
-//Constant
+//Constants for Player Name states.
 const int NWNX_RENAME_PLAYERNAME_DEFAULT = 0;
 const int NWNX_RENAME_PLAYERNAME_OBFUSCATE = 1;
 const int NWNX_RENAME_PLAYERNAME_OVERRIDE = 2;

--- a/Plugins/Rename/NWScript/nwnx_rename.nss
+++ b/Plugins/Rename/NWScript/nwnx_rename.nss
@@ -12,10 +12,10 @@ const int NWNX_RENAME_PLAYERNAME_OVERRIDE = 2;
 //If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OBFUSCATE the player name will be set to a random string.
 //If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_DEFAULT the player name will be untouched.
 //Will not persist through saving, resets or logout.
-void NWNX_Rename_SetPCNameOverride(object oPlayer, string sPrefix, string sNewName, string sSuffix, int iPlayerNameState);
+void NWNX_Rename_SetPCNameOverride(object oPC, string sPrefix, string sNewName, string sSuffix, int iPlayerNameState);
 
 
-void NWNX_Rename_SetPCNameOverride(object oPlayer, string sPrefix, string sNewName, string sSuffix, int iPlayerNameState)
+void NWNX_Rename_SetPCNameOverride(object oPC, string sPrefix, string sNewName, string sSuffix, int iPlayerNameState)
 {
     string sFunc = "SetPCNameOverride";
     
@@ -23,7 +23,7 @@ void NWNX_Rename_SetPCNameOverride(object oPlayer, string sPrefix, string sNewNa
     NWNX_PushArgumentString(NWNX_Rename, sFunc, sSuffix);
     NWNX_PushArgumentString(NWNX_Rename, sFunc, sNewName);
     NWNX_PushArgumentString(NWNX_Rename, sFunc, sPrefix);
-    NWNX_PushArgumentObject(NWNX_Rename, sFunc, oPlayer);
+    NWNX_PushArgumentObject(NWNX_Rename, sFunc, oPC);
 
     NWNX_CallFunction(NWNX_Rename, sFunc);
 }

--- a/Plugins/Rename/NWScript/nwnx_rename.nss
+++ b/Plugins/Rename/NWScript/nwnx_rename.nss
@@ -11,6 +11,7 @@ const int NWNX_RENAME_PLAYERNAME_OVERRIDE = 2;
 //If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OVERRIDE the player name will change to (sNewName) on tells.
 //If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OBFUSCATE the player name will be set to a random string.
 //If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_DEFAULT the player name will be untouched.
+//DMs and the player themselves will still see their original player name regardless of option set
 //Will not persist through saving, resets or logout.
 void NWNX_Rename_SetPCNameOverride(object oPC, string sPrefix, string sNewName, string sSuffix, int iPlayerNameState);
 

--- a/Plugins/Rename/Rename.cpp
+++ b/Plugins/Rename/Rename.cpp
@@ -128,17 +128,18 @@ void Rename::HookPartyInvite(Services::Hooks::CallType cType, NWNXLib::API::CNWS
 void Rename::GlobalNameChange(bool bOriginal)
 {
     API::CServerExoAppInternal* server = Globals::AppManager()->m_pServerExoApp->m_pcExoAppInternal;
- 
-    //go through all the players and change their names or restore them based on bOriginal.
-    
     API::CExoLinkedListInternal* playerList = server->m_pNWSPlayerList->m_pcExoLinkedListInternal;
     
+    std::string lsFirstName;
+    std::string lsLastName;
+    
+    //go through all the players and change their names or restore them based on bOriginal.
     for (API::CExoLinkedListNode* head = playerList->pHead; head; head = head->pNext) 
     {
-        CNWSClient* client = reinterpret_cast<API::CNWSClient*>(head->pObject);
+        CNWSClient* client = static_cast<API::CNWSClient*>(head->pObject);
         Types::ObjectID pcObjectID = static_cast<CNWSPlayer*>(client)->m_oidNWSObject;
-        std::string lsFirstName = (bOriginal) ?  *g_plugin->GetServices()->m_perObjectStorage->Get<std::string>(pcObjectID,firstNameKey) :  *g_plugin->GetServices()->m_perObjectStorage->Get<std::string>(pcObjectID,overrideNameKey);
-        std::string lsLastName = (bOriginal) ?  *g_plugin->GetServices()->m_perObjectStorage->Get<std::string>(pcObjectID,lastNameKey) : std::string("");
+        lsFirstName = (bOriginal) ?  *g_plugin->GetServices()->m_perObjectStorage->Get<std::string>(pcObjectID,firstNameKey) :  *g_plugin->GetServices()->m_perObjectStorage->Get<std::string>(pcObjectID,overrideNameKey);
+        lsLastName = (bOriginal) ?  *g_plugin->GetServices()->m_perObjectStorage->Get<std::string>(pcObjectID,lastNameKey) : std::string("");
         CNWSCreature* pCreature = server->GetCreatureByGameObjectID(pcObjectID);
         
         if (pCreature && !lsFirstName.empty() && ( bOriginal || !pCreature->m_sDisplayName.IsEmpty()))
@@ -149,14 +150,14 @@ void Rename::GlobalNameChange(bool bOriginal)
     }
 }
 
-std::string Rename::ExtractString(CExoLocString locStr)
+std::string Rename::ExtractString(CExoLocString& locStr)
 {
     CExoString str;
     locStr.GetStringLoc(0,&str,0);
     return std::string(str.CStr());
 }
 
-CExoLocString Rename::ContainString(std::string str)
+CExoLocString Rename::ContainString(const std::string& str)
 {
     CExoLocString locStr;
     locStr.AddString(0,CExoString(str.c_str()),0);

--- a/Plugins/Rename/Rename.hpp
+++ b/Plugins/Rename/Rename.hpp
@@ -27,8 +27,8 @@ private:
   static void HookPlayerList(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSMessage* message, NWNXLib::API::CNWSPlayer* pPlayer);
   static void HookPartyInvite(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSMessage* message, NWNXLib::API::CNWSPlayer* pPlayer, unsigned char c);
   
-  NWNXLib::API::CExoLocString ContainString(std::string str);
-  std::string ExtractString(NWNXLib::API::CExoLocString locStr);
+  NWNXLib::API::CExoLocString ContainString(const std::string& str);
+  std::string ExtractString(NWNXLib::API::CExoLocString& locStr);
   
   void GlobalNameChange(bool bOriginal);
   void UpdateName(NWNXLib::API::CNWSCreature* targetObject);

--- a/Plugins/Rename/Rename.hpp
+++ b/Plugins/Rename/Rename.hpp
@@ -24,16 +24,17 @@ public:
   
 private:
 
-  static void HookPlayerList(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSMessage* message, NWNXLib::API::CNWSPlayer* pPlayer);
-  static void HookPartyInvite(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSMessage* message, NWNXLib::API::CNWSPlayer* pPlayer, unsigned char c);
+  static void HookPlayerList(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer* pPlayer);
+  static void HookPartyInvite(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*, unsigned char);
   
   NWNXLib::API::CExoLocString ContainString(const std::string& str);
   std::string ExtractString(NWNXLib::API::CExoLocString& locStr);
+  std::string GenerateRandomPlayerName(size_t length);
   
-  void GlobalNameChange(bool bOriginal);
+  void GlobalNameChange(bool bOriginal, NWNXLib::API::CNWSPlayer* pPlayer);
   void UpdateName(NWNXLib::API::CNWSCreature* targetObject);
   
-  ArgumentStack SetPlayerNameOverride(ArgumentStack&& args);
+  ArgumentStack SetPCNameOverride(ArgumentStack&& args);
    
   NWNXLib::API::CNWSPlayer *player(NWNXLib::API::Types::ObjectID playerId);
 };


### PR DESCRIPTION
NWNX_SetPCNameOverride can be set to randomize playernames for characters with an override mapped, replace them with their affixless overrides or be left alone.