### PR TITLE
minor mistake on return type

### DIFF
--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -297,7 +297,7 @@ int NWNX_Creature_GetFeatRemainingUses(object creature, int feat);
 int NWNX_Creature_GetFeatTotalUses(object creature, int feat);
 
 // Set feat remaining uses of a creature
-int NWNX_Creature_SetFeatRemainingUses(object creature, int feat, int uses);
+void NWNX_Creature_SetFeatRemainingUses(object creature, int feat, int uses);
 
 const string NWNX_Creature = "NWNX_Creature";
 
@@ -1063,7 +1063,7 @@ int NWNX_Creature_GetFeatTotalUses(object creature, int feat)
     return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
 }
 
-int NWNX_Creature_SetFeatRemainingUses(object creature, int feat, int uses)
+void NWNX_Creature_SetFeatRemainingUses(object creature, int feat, int uses)
 {
     string sFunc="SetFeatRemainingUses";
     


### PR DESCRIPTION
On the recent creature feat functions (#287), the return type on the Set call was incorrect.  Should be "void".  I noticed it in the testing module, but neglected to push that back into the git repo.