### PR TITLE
tweaks: Add ability to hide DMs on module char list

### DIFF
--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -7,4 +7,5 @@ add_plugin(Tweaks
     "Tweaks/CompareVarsForMerge.cpp"
     "Tweaks/ParryAllAttacks.cpp"
     "Tweaks/SneakAttackCritImmunity.cpp"
-    "Tweaks/PreserveDepletedItems.cpp")
+    "Tweaks/PreserveDepletedItems.cpp"
+    "Tweaks/HideDMsOnCharList.cpp")

--- a/Plugins/Tweaks/Documentation/README.md
+++ b/Plugins/Tweaks/Documentation/README.md
@@ -14,3 +14,5 @@ Tweaks stuff. See below.
 * `NWNX_TWEAKS_PARRY_ALL_ATTACKS`: true or false
 * `NWNX_TWEAKS_SNEAK_ATTACK_IGNORE_CRIT_IMMUNITY`: true or false
 * `NWNX_TWEAKS_PRESERVE_DEPLETED_ITEMS`: true or false
+* `NWNX_TWEAKS_DISABLE_SHADOWS`: true or false
+* `NWNX_TWEAKS_HIDE_DMS_ON_CHAR_LIST`: true or false

--- a/Plugins/Tweaks/Tweaks.cpp
+++ b/Plugins/Tweaks/Tweaks.cpp
@@ -7,6 +7,7 @@
 #include "Tweaks/ParryAllAttacks.hpp"
 #include "Tweaks/SneakAttackCritImmunity.hpp"
 #include "Tweaks/PreserveDepletedItems.hpp"
+#include "Tweaks/HideDMsOnCharList.hpp"
 
 #include "Services/Config/Config.hpp"
 
@@ -112,7 +113,13 @@ Tweaks::Tweaks(const Plugin::CreateParams& params)
             Platform::Assembly::PushImmInstruction(0),
             Platform::Assembly::NoopInstruction()
         ); NWNX_EXPECT_VERSION(8186);
-    }   
+    }
+
+    if (GetServices()->m_config->Get<bool>("HIDE_DMS_ON_CHAR_LIST", false))
+    {
+        LOG_INFO("DMs will not be visible on character list");
+        m_HideDMsOnCharList = std::make_unique<HideDMsOnCharList>(GetServices()->m_hooks.get());
+    }
 }
 
 Tweaks::~Tweaks()

--- a/Plugins/Tweaks/Tweaks.hpp
+++ b/Plugins/Tweaks/Tweaks.hpp
@@ -13,6 +13,7 @@ class CompareVarsForMerge;
 class ParryAllAttacks;
 class SneakAttackCritImmunity;
 class PreserveDepletedItems;
+class HideDMsOnCharList;
 
 class Tweaks : public NWNXLib::Plugin
 {
@@ -29,6 +30,7 @@ private:
     std::unique_ptr<ParryAllAttacks> m_ParryAllAttacks;
     std::unique_ptr<SneakAttackCritImmunity> m_SneakAttackCritImmunity;
     std::unique_ptr<PreserveDepletedItems> m_PreserveDepletedItems;
+    std::unique_ptr<HideDMsOnCharList> m_HideDMsOnCharList;
 };
 
 }

--- a/Plugins/Tweaks/Tweaks/HideDMsOnCharList.cpp
+++ b/Plugins/Tweaks/Tweaks/HideDMsOnCharList.cpp
@@ -1,0 +1,52 @@
+#include "Tweaks/HideDMsOnCharList.hpp"
+
+#include "Services/Hooks/Hooks.hpp"
+
+#include "API/CAppManager.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/CNWSCreatureStats.hpp"
+#include "API/CNWSPlayer.hpp"
+#include "API/CNWSMessage.hpp"
+#include "API/CServerExoApp.hpp"
+#include "API/CServerExoAppInternal.hpp"
+#include "API/CExoLinkedListTemplatedCNWSClient.hpp"
+#include "API/CExoLinkedListInternal.hpp"
+#include "API/CExoLinkedListNode.hpp"
+#include "API/Functions.hpp"
+#include "API/Globals.hpp"
+
+namespace Tweaks {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+HideDMsOnCharList::HideDMsOnCharList(ViewPtr<Services::HooksProxy> hooker)
+{
+    hooker->RequestExclusiveHook<API::Functions::CNWSMessage__HandlePlayerToServerPlayModuleCharacterList_Start>
+        (&HandlePlayerToServerPlayModuleCharacterList_StartHook);
+}
+
+int32_t HideDMsOnCharList::HandlePlayerToServerPlayModuleCharacterList_StartHook(
+    CNWSMessage* pThis, CNWSPlayer* pPlayer)
+{
+    if (pThis->MessageReadOverflow(true) || pThis->MessageReadUnderflow(true))
+        return false;
+
+    auto *server = Globals::AppManager()->m_pServerExoApp->m_pcExoAppInternal;
+    auto *players = server->m_pNWSPlayerList->m_pcExoLinkedListInternal;
+
+    for (auto *node = players->pHead; node; node = node->pNext)
+    {
+        auto *other = static_cast<CNWSPlayer*>(node->pObject);
+        if (other && other->m_nCharacterType != 2 /*DM*/)
+        {
+            pThis->SendServerToPlayerPlayModuleCharacterListResponse(
+                pPlayer->m_nPlayerID, other->m_oidNWSObject, true);
+        }
+    }
+
+    pPlayer->m_bPlayModuleListingCharacters = true;
+    return true;
+}
+
+}

--- a/Plugins/Tweaks/Tweaks/HideDMsOnCharList.hpp
+++ b/Plugins/Tweaks/Tweaks/HideDMsOnCharList.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "Common.hpp"
+#include "ViewPtr.hpp"
+
+namespace Tweaks {
+
+class HideDMsOnCharList
+{
+public:
+    HideDMsOnCharList(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
+
+private:
+    static int32_t HandlePlayerToServerPlayModuleCharacterList_StartHook(
+        NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*);
+};
+
+}


### PR DESCRIPTION
Implements #139. Unfortunately, I couldn't easily make it so that if you're logging in as DM you can see them, since your DMness is tied to your characters. I can work around it if it is an important feature, but for now I think this will do.