### PR TITLE
Store the POS in a TURD

### DIFF
--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -189,6 +189,8 @@ void NWNXCore::InitialSetupHooks()
 
     m_services->m_hooks->RequestSharedHook<API::Functions::CNWSObject__CNWSObjectDtor__0, void>(&Services::PerObjectStorage::CNWSObject__CNWSObjectDtor__0_hook);
     m_services->m_hooks->RequestSharedHook<API::Functions::CNWSArea__CNWSAreaDtor__0, void>(&Services::PerObjectStorage::CNWSArea__CNWSAreaDtor__0_hook);
+    m_services->m_hooks->RequestSharedHook<API::Functions::CNWSPlayer__EatTURD, void>(&Services::PerObjectStorage::CNWSPlayer__EatTURD_hook);
+    m_services->m_hooks->RequestSharedHook<API::Functions::CNWSPlayer__DropTURD, void>(&Services::PerObjectStorage::CNWSPlayer__DropTURD_hook);
 
     g_setStringHook = m_services->m_hooks->FindHookByAddress(API::Functions::CNWSScriptVarTable__SetString);
     g_getStringHook = m_services->m_hooks->FindHookByAddress(API::Functions::CNWSScriptVarTable__GetString);

--- a/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
+++ b/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
@@ -2,7 +2,14 @@
 #include "API/CGameObject.hpp"
 #include "API/CNWSArea.hpp"
 #include "API/CNWSObject.hpp"
+#include "API/CNWSPlayer.hpp"
+#include "API/CNWSPlayerTURD.hpp"
+#include "API/CNWSModule.hpp"
+#include "API/CExoLinkedListInternal.hpp"
+#include "API/CExoLinkedListNode.hpp"
 #include "API/Constants.hpp"
+
+#include <sstream>
 
 namespace NWNXLib {
 
@@ -124,7 +131,47 @@ PerObjectStorage::ObjectStorage::~ObjectStorage()
     }
 }
 
+void PerObjectStorage::ObjectStorage::CloneFrom(PerObjectStorage::ObjectStorage *other)
+{
+    if (!other)
+        return;
 
+    if (other->m_IntMap)
+        m_IntMap = std::make_unique<IntMap>(*other->m_IntMap);
+    if (other->m_FloatMap)
+        m_FloatMap = std::make_unique<FloatMap>(*other->m_FloatMap);
+    if (other->m_StringMap)
+        m_StringMap = std::make_unique<StringMap>(*other->m_StringMap);
+    if (other->m_PointerMap)
+        m_PointerMap = std::make_unique<PointerMap>(*other->m_PointerMap);
+}
+
+std::string PerObjectStorage::ObjectStorage::DumpToString()
+{
+    std::stringstream ss;
+    ss << "Object ID: " << std::hex << m_oidOwner << std::endl;
+    if (m_IntMap)
+    {
+        for (auto it: *m_IntMap)
+            ss << it.first << " = " << std::dec << it.second << std::endl;
+    }
+    if (m_FloatMap)
+    {
+        for (auto it: *m_FloatMap)
+            ss << it.first << " = " << it.second << std::endl;
+    }
+    if (m_StringMap)
+    {
+        for (auto it: *m_StringMap)
+            ss << it.first << " = " << it.second << std::endl;
+    }
+    if (m_PointerMap)
+    {
+        for (auto it: *m_PointerMap)
+            ss << it.first << " = " << it.second.first << std::endl;
+    }
+    return ss.str();
+}
 
 PerObjectStorageProxy::PerObjectStorageProxy(PerObjectStorage& perObjectStorage, std::string pluginName)
     : ServiceProxy<PerObjectStorage>(perObjectStorage)
@@ -209,7 +256,6 @@ void PerObjectStorage::DestroyObjectStorage(API::CGameObject *pGameObject)
 {
     if (pGameObject->m_pNwnxData)
     {
-        LOG_DEBUG("Destroying object storage for objectId:0x%08x", pGameObject->m_idSelf);
         delete static_cast<PerObjectStorage::ObjectStorage*>(pGameObject->m_pNwnxData);
         pGameObject->m_pNwnxData = nullptr;
     }
@@ -225,7 +271,22 @@ void PerObjectStorage::CNWSArea__CNWSAreaDtor__0_hook(Services::Hooks::CallType 
     if (type == Services::Hooks::CallType::AFTER_ORIGINAL)
         DestroyObjectStorage(static_cast<API::CGameObject*>(pThis));
 }
-
+void PerObjectStorage::CNWSPlayer__EatTURD_hook(Services::Hooks::CallType type, API::CNWSPlayer* thisPtr, API::CNWSPlayerTURD* pTURD)
+{
+    if (type == Services::Hooks::CallType::BEFORE_ORIGINAL)
+    {
+        GetObjectStorage(thisPtr->m_oidNWSObject)->CloneFrom(GetObjectStorage(pTURD));
+    }
+}
+void PerObjectStorage::CNWSPlayer__DropTURD_hook(Services::Hooks::CallType type, API::CNWSPlayer* thisPtr)
+{
+    if (type == Services::Hooks::CallType::AFTER_ORIGINAL)
+    {
+        auto turdlist = Utils::GetModule()->m_lstTURDList.m_pcExoLinkedListInternal;
+        auto *pTURD = static_cast<API::CNWSPlayerTURD*>(turdlist->pHead->pObject);
+        GetObjectStorage(pTURD)->CloneFrom(GetObjectStorage(thisPtr->m_oidNWSObject));
+    }
+}
 
 }
 }

--- a/NWNXLib/Services/PerObjectStorage/PerObjectStorage.hpp
+++ b/NWNXLib/Services/PerObjectStorage/PerObjectStorage.hpp
@@ -36,6 +36,8 @@ public:
 
     static void CNWSObject__CNWSObjectDtor__0_hook(Services::Hooks::CallType type, API::CNWSObject* thisPtr);
     static void CNWSArea__CNWSAreaDtor__0_hook(Services::Hooks::CallType type, API::CNWSArea* thisPtr);
+    static void CNWSPlayer__EatTURD_hook(Services::Hooks::CallType type, API::CNWSPlayer* thisPtr, API::CNWSPlayerTURD* pTURD);
+    static void CNWSPlayer__DropTURD_hook(Services::Hooks::CallType type, API::CNWSPlayer* thisPtr);
 private:
     class ObjectStorage
     {
@@ -53,6 +55,9 @@ private:
 
         ObjectStorage(API::Types::ObjectID owner);
         ~ObjectStorage();
+
+        void CloneFrom(ObjectStorage *other);
+        std::string DumpToString();
 
         API::Types::ObjectID        m_oidOwner;
         std::unique_ptr<IntMap>     m_IntMap;

--- a/NWNXLib/Utils.cpp
+++ b/NWNXLib/Utils.cpp
@@ -153,6 +153,10 @@ API::CGameObject* GetGameObject(API::Types::ObjectID objectId)
 {
     return API::Globals::AppManager()->m_pServerExoApp->GetGameObject(objectId);
 }
+API::CNWSModule* GetModule()
+{
+    return static_cast<API::CNWSModule*>(API::Globals::AppManager()->m_pServerExoApp->GetModule());
+}
 
 bool AcquireItem(API::CNWSItem *pItem, API::CGameObject *pOwner)
 {

--- a/NWNXLib/Utils.hpp
+++ b/NWNXLib/Utils.hpp
@@ -32,6 +32,7 @@ API::CNWSTrigger*            AsNWSTrigger(API::CGameObject* obj);
 API::CNWSWaypoint*           AsNWSWaypoint(API::CGameObject* obj);
 
 API::CGameObject* GetGameObject(API::Types::ObjectID objectId);
+API::CNWSModule* GetModule();
 
 // Wrappers around non-virtual methods repeated for all NWS types
 bool AcquireItem(API::CNWSItem *pItem, API::CGameObject *pOwner);


### PR DESCRIPTION
Unfortunate acronyms :stuck_out_tongue: 

With this change, any POS variables on the player will be restored when they log back in, within a single restart. The TURD already contains info such as players local variables, their last location, their effect list, etc. So, in any case when nwserver restores those, it'll also restore the POS.

This will not _always_ work with various NWNX functions though. For example, `NWNX_Player_SetAlwaysWalk` stores the flag in POS, but upon relogging, the player is able to run because `CNWSPlayer::m_bForcedWalk` is not preserved. But the next time code tries to refresh that, it will show up. This is up to the various plugins and functions to decide how to handle.