### PR TITLE
Events: Add GetCurrentEvent()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Core: Allow passing engine structures to nwnx (Effect/Itemproperty)
 - Events: New events: SkillEvents
 - Events: The following events are now skippable: FeatEvents, ItemEvents, HealersKitEvents, CombatModeEvents, PartyEvents, SkillEvents
+- Events: You can now get the current event name with a nwscript function
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite
 - Tweaks: DisableQuickSave
@@ -64,6 +65,7 @@ The following plugins were added:
 - Encounter: SetPlayerTriggeredOnly()
 - Encounter: GetResetTime()
 - Encounter: SetResetTime()
+- Events: GetCurrentEvent()
 - Feedback: GetMessageHidden()
 - Feedback: SetMessageHidden()
 - Player: ShowVisualEffect()

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -54,6 +54,7 @@ Events::Events(const Plugin::CreateParams& params)
     GetServices()->m_events->RegisterEvent("GET_EVENT_DATA", std::bind(&Events::OnGetEventData, this, std::placeholders::_1));
     GetServices()->m_events->RegisterEvent("SKIP_EVENT", std::bind(&Events::OnSkipEvent, this, std::placeholders::_1));
     GetServices()->m_events->RegisterEvent("EVENT_RESULT", std::bind(&Events::OnEventResult, this, std::placeholders::_1));
+    GetServices()->m_events->RegisterEvent("GET_CURRENT_EVENT", std::bind(&Events::OnGetCurrentEvent, this, std::placeholders::_1));
 
     GetServices()->m_messaging->SubscribeMessage("NWNX_EVENT_SIGNAL_EVENT",
         [](const std::vector<std::string> message)
@@ -171,6 +172,8 @@ bool Events::SignalEvent(const std::string& eventName, const API::Types::ObjectI
 
     g_plugin->CreateNewEventDataIfNeeded();
 
+    g_plugin->m_eventData.top().m_EventName = eventName;
+
     for (const auto& script : g_plugin->m_eventMap[eventName])
     {
         LOG_DEBUG("Dispatching notification for event '%s' to script '%s'.", eventName.c_str(), script.c_str());
@@ -267,6 +270,20 @@ Services::Events::ArgumentStack Events::OnEventResult(Services::Events::Argument
     LOG_DEBUG("Received event result '%s'.", data.c_str());
 
     return Services::Events::ArgumentStack();
+}
+
+Services::Events::ArgumentStack Events::OnGetCurrentEvent(Services::Events::ArgumentStack&& args)
+{
+    if (m_eventDepth == 0 || m_eventData.empty())
+    {
+        throw std::runtime_error("Attempted to get the current event in an invalid context.");
+    }
+
+    std::string eventName = g_plugin->m_eventData.top().m_EventName;
+
+    Services::Events::ArgumentStack stack;
+    Services::Events::InsertArgument(stack, eventName);
+    return stack;
 }
 
 void Events::CreateNewEventDataIfNeeded()

--- a/Plugins/Events/Events.hpp
+++ b/Plugins/Events/Events.hpp
@@ -36,6 +36,9 @@ public: // Structures
 
         // The result of the event, if any, is stored here
         std::string m_Result;
+
+        // The current event name
+        std::string m_EventName;
     };
 
 public:
@@ -61,6 +64,7 @@ private:
     NWNXLib::Services::Events::ArgumentStack OnGetEventData(NWNXLib::Services::Events::ArgumentStack&& args);
     NWNXLib::Services::Events::ArgumentStack OnSkipEvent(NWNXLib::Services::Events::ArgumentStack&& args);
     NWNXLib::Services::Events::ArgumentStack OnEventResult(NWNXLib::Services::Events::ArgumentStack&& args);
+    NWNXLib::Services::Events::ArgumentStack OnGetCurrentEvent(NWNXLib::Services::Events::ArgumentStack&& args);
 
     // Pushes a brand new event data onto the event data stack, set up with the correct defaults.
     // Only does it if needed though, based on the current event depth!

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -266,6 +266,11 @@ void NWNX_Events_SkipEvent();
 // THIS SHOULD ONLY BE CALLED FROM WITHIN AN EVENT HANDLER.
 void NWNX_Events_SetEventResult(string data);
 
+// Returns the current event name
+//
+// THIS SHOULD ONLY BE CALLED FROM WITHIN AN EVENT HANDLER.
+string NWNX_Events_GetCurrentEvent();
+
 
 void NWNX_Events_SubscribeEvent(string evt, string script)
 {
@@ -305,4 +310,10 @@ void NWNX_Events_SetEventResult(string data)
 {
     NWNX_PushArgumentString("NWNX_Events", "EVENT_RESULT", data);
     NWNX_CallFunction("NWNX_Events", "EVENT_RESULT");
+}
+
+string NWNX_Events_GetCurrentEvent()
+{
+    NWNX_CallFunction("NWNX_Events", "GET_CURRENT_EVENT");
+    return NWNX_GetReturnValueString("NWNX_Events", "GET_CURRENT_EVENT");
 }


### PR DESCRIPTION
Lets you do cool things like:

```
void main()
{
    object oExaminer = OBJECT_SELF;
    object oExaminee = NWNX_Object_StringToObject(NWNX_Events_GetEventData("EXAMINEE_OBJECT_ID"));

    string sCurrentEvent = NWNX_Events_GetCurrentEvent();

    if (sCurrentEvent == "NWNX_ON_EXAMINE_OBJECT_BEFORE")
    {
        SendMessageToPC(oExaminer, "[BEFORE] " + GetName(oExaminer) + " examining " + GetName(oExaminee));
    }
    else
    if (sCurrentEvent == "NWNX_ON_EXAMINE_OBJECT_AFTER")
    {
        SendMessageToPC(oExaminer, "[AFTER] " + GetName(oExaminer) + " examining " + GetName(oExaminee));
    }
}
```