### PR TITLE
Map pin events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Added support to build out of tree plugins with the following environment variable: `NWNX_ADDITIONAL_PLUGINS=/path/to/Plugin1;/path/to/Plugin2`
 - Core: Allow changing default plugin state from 'load all' to 'skip all' with the following environment variable: `NWNX_CORE_SKIP_ALL=y`. Use `NWNX_PLUGIN_SKIP=n` to enable specific plugins in this case.
 - Core: Allow passing engine structures to nwnx (Effect/Itemproperty)
-- Events: New events: SkillEvents
-- Events: The following events are now skippable: FeatEvents, ItemEvents, HealersKitEvents, CombatModeEvents, PartyEvents, SkillEvents
+- Events: New events: SkillEvents, MapEvents
+- Events: The following events are now skippable: FeatEvents, ItemEvents, HealersKitEvents, CombatModeEvents, PartyEvents, SkillEvents, MapEvents
 - Events: You can now get the current event name with a nwscript function
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite

--- a/Plugins/Events/CMakeLists.txt
+++ b/Plugins/Events/CMakeLists.txt
@@ -7,6 +7,7 @@ add_plugin(Events
     "Events/ExamineEvents.cpp"
     "Events/FeatEvents.cpp"
     "Events/ItemEvents.cpp"
+    "Events/MapEvents.cpp"
     "Events/StealthEvents.cpp"
     "Events/SpellEvents.cpp"
     "Events/PartyEvents.cpp"

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -10,6 +10,7 @@
 #include "Events/ExamineEvents.hpp"
 #include "Events/FeatEvents.hpp"
 #include "Events/ItemEvents.hpp"
+#include "Events/MapEvents.hpp"
 #include "Events/StealthEvents.hpp"
 #include "Events/SpellEvents.hpp"
 #include "Events/PartyEvents.hpp"
@@ -127,7 +128,12 @@ Events::Events(const Plugin::CreateParams& params)
     if (GetServices()->m_config->Get<bool>("ENABLE_SKILL_EVENTS", true))
     {
         m_skillEvents = std::make_unique<SkillEvents>(GetServices()->m_hooks);
-    }        
+    }
+
+    if (GetServices()->m_config->Get<bool>("ENABLE_MAP_EVENTS", true))
+    {
+        m_mapEvents = std::make_unique<MapEvents>(GetServices()->m_hooks);
+    }
 }
 
 Events::~Events()

--- a/Plugins/Events/Events.hpp
+++ b/Plugins/Events/Events.hpp
@@ -17,6 +17,7 @@ class DMActionEvents;
 class ExamineEvents;
 class FeatEvents;
 class ItemEvents;
+class MapEvents;
 class StealthEvents;
 class SpellEvents;
 class PartyEvents;
@@ -77,6 +78,7 @@ private:
     std::unique_ptr<ExamineEvents> m_examineEvents;
     std::unique_ptr<FeatEvents> m_featEvents;
     std::unique_ptr<ItemEvents> m_itemEvents;
+    std::unique_ptr<MapEvents> m_mapEvents;
     std::unique_ptr<StealthEvents> m_stealthEvents;
     std::unique_ptr<SpellEvents> m_spellEvents;
     std::unique_ptr<PartyEvents> m_partyEvents;

--- a/Plugins/Events/Events/MapEvents.cpp
+++ b/Plugins/Events/Events/MapEvents.cpp
@@ -30,6 +30,7 @@ MapEvents::MapEvents(ViewPtr<Services::HooksProxy> hooker)
     hooker->RequestExclusiveHook<Functions::CNWSMessage__HandlePlayerToServerMapPinDestroyMapPin, int32_t,
         CNWSMessage*, CNWSPlayer*>(&HandleMapPinDestroyMapPinMessageHook);
     m_HandlePlayerToServerMapPinDestroyMapPinHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__HandlePlayerToServerMapPinDestroyMapPin);
+
 }
 template <typename T>
 static T PeekMessage(CNWSMessage *pMessage, int32_t offset)
@@ -59,12 +60,12 @@ int32_t MapEvents::HandleMapPinSetMapPinAtMessageHook(CNWSMessage *thisPtr, CNWS
     // Copy the string over
     std::string note;
     note.reserve(len+1);
-    std::memcpy(note.data(), thisPtr->m_pnReadBuffer + thisPtr->m_nReadBufferPtr + offset, len);
+    note.assign(reinterpret_cast<const char*>(thisPtr->m_pnReadBuffer + thisPtr->m_nReadBufferPtr + offset), len);
     note[len] = '\0';
 
     Events::PushEventData("PIN_X", std::to_string(x));
     Events::PushEventData("PIN_Y", std::to_string(y));
-    Events::PushEventData("PIN_NOTE", note.c_str());
+    Events::PushEventData("PIN_NOTE", note);
     
     if (Events::SignalEvent("NWNX_ON_MAP_PIN_ADD_PIN", oidPlayer))
     {
@@ -96,7 +97,7 @@ int32_t MapEvents::HandleMapPinChangePinMessageHook(CNWSMessage *thisPtr, CNWSPl
     // Copy the string over
     std::string note;
     note.reserve(len+1);
-    std::memcpy(note.data(), thisPtr->m_pnReadBuffer + thisPtr->m_nReadBufferPtr + offset, len);
+    note.assign(reinterpret_cast<const char*>(thisPtr->m_pnReadBuffer + thisPtr->m_nReadBufferPtr + offset), len);
     note[len] = '\0';
     offset += len;
 
@@ -106,7 +107,7 @@ int32_t MapEvents::HandleMapPinChangePinMessageHook(CNWSMessage *thisPtr, CNWSPl
 
     Events::PushEventData("PIN_X", std::to_string(x));
     Events::PushEventData("PIN_Y", std::to_string(y));
-    Events::PushEventData("PIN_NOTE", note.c_str());
+    Events::PushEventData("PIN_NOTE", note);
     Events::PushEventData("PIN_ID", pin_id);
 
     if (Events::SignalEvent("NWNX_ON_MAP_PIN_CHANGE_PIN", oidPlayer))

--- a/Plugins/Events/Events/MapEvents.cpp
+++ b/Plugins/Events/Events/MapEvents.cpp
@@ -1,0 +1,128 @@
+#include "Events/MapEvents.hpp"
+#include "API/CNWSPlayer.hpp"
+#include "API/CNWSMessage.hpp"
+#include "API/Functions.hpp"
+#include "API/Constants.hpp"
+#include "Events.hpp"
+#include "Utils.hpp"
+#include <cstring>
+
+namespace Events {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+using namespace NWNXLib::Platform;
+
+static NWNXLib::Hooking::FunctionHook* m_HandlePlayerToServerMapPinSetMapPinAtHook = nullptr;
+static NWNXLib::Hooking::FunctionHook* m_HandlePlayerToServerMapPinChangePinHook = nullptr;
+static NWNXLib::Hooking::FunctionHook* m_HandlePlayerToServerMapPinDestroyMapPinHook = nullptr;
+
+MapEvents::MapEvents(ViewPtr<Services::HooksProxy> hooker)
+{
+    hooker->RequestExclusiveHook<Functions::CNWSMessage__HandlePlayerToServerMapPinSetMapPinAt, int32_t,
+        CNWSMessage*, CNWSPlayer*>(&HandleMapPinSetMapPinAtMessageHook);
+    m_HandlePlayerToServerMapPinSetMapPinAtHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__HandlePlayerToServerMapPinSetMapPinAt);
+
+    hooker->RequestExclusiveHook<Functions::CNWSMessage__HandlePlayerToServerMapPinChangePin, int32_t,
+        CNWSMessage*, CNWSPlayer*>(&HandleMapPinChangePinMessageHook);
+    m_HandlePlayerToServerMapPinChangePinHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__HandlePlayerToServerMapPinChangePin);
+
+    hooker->RequestExclusiveHook<Functions::CNWSMessage__HandlePlayerToServerMapPinDestroyMapPin, int32_t,
+        CNWSMessage*, CNWSPlayer*>(&HandleMapPinDestroyMapPinMessageHook);
+    m_HandlePlayerToServerMapPinDestroyMapPinHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__HandlePlayerToServerMapPinDestroyMapPin);
+}
+template <typename T>
+static T PeekMessage(CNWSMessage *pMessage, int32_t offset)
+{
+    static_assert(std::is_pod<T>::value);
+    T value;
+    uint8_t *ptr = pMessage->m_pnReadBuffer + pMessage->m_nReadBufferPtr + offset;
+    std::memcpy(&value, ptr, sizeof(T));
+    return value;
+}
+
+int32_t MapEvents::HandleMapPinSetMapPinAtMessageHook(CNWSMessage *thisPtr, CNWSPlayer *pPlayer)
+{
+    int32_t retVal;
+
+    Types::ObjectID oidPlayer = pPlayer ? pPlayer->m_oidNWSObject : Constants::OBJECT_INVALID;
+
+    int offset = 0;
+    // Peek at the coordinates first
+    float x = PeekMessage<float>(thisPtr, offset); offset += sizeof(x);
+    float y = PeekMessage<float>(thisPtr, offset); offset += sizeof(y);
+    float z = PeekMessage<float>(thisPtr, offset); offset += sizeof(z);
+
+    // Get number of bytes for the message
+    int len = PeekMessage<int32_t>(thisPtr, offset); offset += sizeof(len);
+
+    // Copy the string over
+    std::string note;
+    note.reserve(len+1);
+    memcpy(note.data(), thisPtr->m_pnReadBuffer + thisPtr->m_nReadBufferPtr + offset, len);
+    note[len] = '\0';
+
+    Events::PushEventData("PIN_X", std::to_string(x));
+    Events::PushEventData("PIN_Y", std::to_string(y));
+    Events::PushEventData("PIN_NOTE", note.c_str());
+    Events::SignalEvent("NWNX_ON_MAP_PIN_ADD_PIN", oidPlayer);
+
+    retVal = m_HandlePlayerToServerMapPinSetMapPinAtHook->CallOriginal<int32_t>(thisPtr, pPlayer);
+    return retVal;
+}
+
+int32_t MapEvents::HandleMapPinChangePinMessageHook(CNWSMessage *thisPtr, CNWSPlayer *pPlayer)
+{
+    int32_t retVal;
+
+    Types::ObjectID oidPlayer = pPlayer ? pPlayer->m_oidNWSObject : Constants::OBJECT_INVALID;
+
+    int offset = 0;
+
+    // Peek at the coordinates first
+    float x = PeekMessage<float>(thisPtr, offset); offset += sizeof(x);
+    float y = PeekMessage<float>(thisPtr, offset); offset += sizeof(y);
+    float z = PeekMessage<float>(thisPtr, offset); offset += sizeof(z);
+
+    // Get number of bytes for the message
+    int len = PeekMessage<int32_t>(thisPtr, offset); offset += sizeof(len);
+
+    // Copy the string over
+    std::string note;
+    note.reserve(len+1);
+    memcpy(note.data(), thisPtr->m_pnReadBuffer + thisPtr->m_nReadBufferPtr + offset, len);
+    note[len] = '\0';
+    offset += len;
+
+    // Copy the pin id over
+    static std::string pin_id;
+    pin_id = std::to_string(PeekMessage<int32_t>(thisPtr, 0));
+
+    Events::PushEventData("PIN_X", std::to_string(x));
+    Events::PushEventData("PIN_Y", std::to_string(y));
+    Events::PushEventData("PIN_NOTE", note.c_str());
+    Events::PushEventData("PIN_ID", pin_id);
+
+    Events::SignalEvent("NWNX_ON_MAP_PIN_CHANGE_PIN", oidPlayer);
+    retVal = m_HandlePlayerToServerMapPinChangePinHook->CallOriginal<int32_t>(thisPtr, pPlayer);
+    return retVal;
+}
+
+int32_t MapEvents::HandleMapPinDestroyMapPinMessageHook(CNWSMessage *thisPtr, CNWSPlayer *pPlayer)
+{
+    int32_t retVal;
+
+    Types::ObjectID oidPlayer = pPlayer ? pPlayer->m_oidNWSObject : Constants::OBJECT_INVALID;
+
+    // Send the pin id
+    static std::string pin_id;
+    pin_id = std::to_string(PeekMessage<int32_t>(thisPtr, 0));
+
+    Events::PushEventData("PIN_ID", pin_id);
+
+    Events::SignalEvent("NWNX_ON_MAP_PIN_DESTROY_PIN", oidPlayer);
+    retVal = m_HandlePlayerToServerMapPinDestroyMapPinHook->CallOriginal<int32_t>(thisPtr, pPlayer);
+    return retVal;
+}
+
+}

--- a/Plugins/Events/Events/MapEvents.cpp
+++ b/Plugins/Events/Events/MapEvents.cpp
@@ -65,9 +65,15 @@ int32_t MapEvents::HandleMapPinSetMapPinAtMessageHook(CNWSMessage *thisPtr, CNWS
     Events::PushEventData("PIN_X", std::to_string(x));
     Events::PushEventData("PIN_Y", std::to_string(y));
     Events::PushEventData("PIN_NOTE", note.c_str());
-    Events::SignalEvent("NWNX_ON_MAP_PIN_ADD_PIN", oidPlayer);
-
-    retVal = m_HandlePlayerToServerMapPinSetMapPinAtHook->CallOriginal<int32_t>(thisPtr, pPlayer);
+    
+    if (Events::SignalEvent("NWNX_ON_MAP_PIN_ADD_PIN", oidPlayer))
+    {
+        retVal = m_HandlePlayerToServerMapPinSetMapPinAtHook->CallOriginal<int32_t>(thisPtr, pPlayer);
+    } 
+    else 
+    {
+        retVal = false;
+    }
     return retVal;
 }
 
@@ -103,8 +109,14 @@ int32_t MapEvents::HandleMapPinChangePinMessageHook(CNWSMessage *thisPtr, CNWSPl
     Events::PushEventData("PIN_NOTE", note.c_str());
     Events::PushEventData("PIN_ID", pin_id);
 
-    Events::SignalEvent("NWNX_ON_MAP_PIN_CHANGE_PIN", oidPlayer);
-    retVal = m_HandlePlayerToServerMapPinChangePinHook->CallOriginal<int32_t>(thisPtr, pPlayer);
+    if (Events::SignalEvent("NWNX_ON_MAP_PIN_CHANGE_PIN", oidPlayer))
+    {
+        retVal = m_HandlePlayerToServerMapPinChangePinHook->CallOriginal<int32_t>(thisPtr, pPlayer);
+    } 
+    else 
+    {
+        retVal = false;
+    }
     return retVal;
 }
 
@@ -120,8 +132,14 @@ int32_t MapEvents::HandleMapPinDestroyMapPinMessageHook(CNWSMessage *thisPtr, CN
 
     Events::PushEventData("PIN_ID", pin_id);
 
-    Events::SignalEvent("NWNX_ON_MAP_PIN_DESTROY_PIN", oidPlayer);
-    retVal = m_HandlePlayerToServerMapPinDestroyMapPinHook->CallOriginal<int32_t>(thisPtr, pPlayer);
+    if (Events::SignalEvent("NWNX_ON_MAP_PIN_DESTROY_PIN", oidPlayer))
+    {
+        retVal = m_HandlePlayerToServerMapPinDestroyMapPinHook->CallOriginal<int32_t>(thisPtr, pPlayer);
+    } 
+    else 
+    {
+        retVal = false;
+    }
     return retVal;
 }
 

--- a/Plugins/Events/Events/MapEvents.cpp
+++ b/Plugins/Events/Events/MapEvents.cpp
@@ -66,15 +66,22 @@ int32_t MapEvents::HandleMapPinSetMapPinAtMessageHook(CNWSMessage *thisPtr, CNWS
     Events::PushEventData("PIN_X", std::to_string(x));
     Events::PushEventData("PIN_Y", std::to_string(y));
     Events::PushEventData("PIN_NOTE", note);
-    
-    if (Events::SignalEvent("NWNX_ON_MAP_PIN_ADD_PIN", oidPlayer))
+
+    if (Events::SignalEvent("NWNX_ON_MAP_PIN_ADD_PIN_BEFORE", oidPlayer))
     {
         retVal = m_HandlePlayerToServerMapPinSetMapPinAtHook->CallOriginal<int32_t>(thisPtr, pPlayer);
-    } 
-    else 
+    }
+    else
     {
         retVal = false;
     }
+
+    Events::PushEventData("PIN_X", std::to_string(x));
+    Events::PushEventData("PIN_Y", std::to_string(y));
+    Events::PushEventData("PIN_NOTE", note);
+
+    Events::SignalEvent("NWNX_ON_MAP_PIN_ADD_PIN_AFTER", oidPlayer);
+
     return retVal;
 }
 
@@ -102,22 +109,29 @@ int32_t MapEvents::HandleMapPinChangePinMessageHook(CNWSMessage *thisPtr, CNWSPl
     offset += len;
 
     // Copy the pin id over
-    static std::string pin_id;
-    pin_id = std::to_string(PeekMessage<int32_t>(thisPtr, offset));
+    int32_t pin_id = PeekMessage<int32_t>(thisPtr, offset);
 
     Events::PushEventData("PIN_X", std::to_string(x));
     Events::PushEventData("PIN_Y", std::to_string(y));
     Events::PushEventData("PIN_NOTE", note);
-    Events::PushEventData("PIN_ID", pin_id);
+    Events::PushEventData("PIN_ID", std::to_string(pin_id));
 
-    if (Events::SignalEvent("NWNX_ON_MAP_PIN_CHANGE_PIN", oidPlayer))
+    if (Events::SignalEvent("NWNX_ON_MAP_PIN_CHANGE_PIN_BEFORE", oidPlayer))
     {
         retVal = m_HandlePlayerToServerMapPinChangePinHook->CallOriginal<int32_t>(thisPtr, pPlayer);
-    } 
-    else 
+    }
+    else
     {
         retVal = false;
     }
+
+    Events::PushEventData("PIN_X", std::to_string(x));
+    Events::PushEventData("PIN_Y", std::to_string(y));
+    Events::PushEventData("PIN_NOTE", note);
+    Events::PushEventData("PIN_ID", std::to_string(pin_id));
+
+    Events::SignalEvent("NWNX_ON_MAP_PIN_CHANGE_PIN_AFTER", oidPlayer);
+
     return retVal;
 }
 
@@ -128,19 +142,23 @@ int32_t MapEvents::HandleMapPinDestroyMapPinMessageHook(CNWSMessage *thisPtr, CN
     Types::ObjectID oidPlayer = pPlayer ? pPlayer->m_oidNWSObject : Constants::OBJECT_INVALID;
 
     // Send the pin id
-    static std::string pin_id;
-    pin_id = std::to_string(PeekMessage<int32_t>(thisPtr, 0));
+    int32_t pin_id = PeekMessage<int32_t>(thisPtr, 0);
 
-    Events::PushEventData("PIN_ID", pin_id);
+    Events::PushEventData("PIN_ID", std::to_string(pin_id));
 
-    if (Events::SignalEvent("NWNX_ON_MAP_PIN_DESTROY_PIN", oidPlayer))
+    if (Events::SignalEvent("NWNX_ON_MAP_PIN_DESTROY_PIN_BEFORE", oidPlayer))
     {
         retVal = m_HandlePlayerToServerMapPinDestroyMapPinHook->CallOriginal<int32_t>(thisPtr, pPlayer);
-    } 
-    else 
+    }
+    else
     {
         retVal = false;
     }
+
+    Events::PushEventData("PIN_ID", std::to_string(pin_id));
+
+    Events::SignalEvent("NWNX_ON_MAP_PIN_DESTROY_PIN_AFTER", oidPlayer);
+
     return retVal;
 }
 

--- a/Plugins/Events/Events/MapEvents.cpp
+++ b/Plugins/Events/Events/MapEvents.cpp
@@ -59,7 +59,7 @@ int32_t MapEvents::HandleMapPinSetMapPinAtMessageHook(CNWSMessage *thisPtr, CNWS
     // Copy the string over
     std::string note;
     note.reserve(len+1);
-    memcpy(note.data(), thisPtr->m_pnReadBuffer + thisPtr->m_nReadBufferPtr + offset, len);
+    std::memcpy(note.data(), thisPtr->m_pnReadBuffer + thisPtr->m_nReadBufferPtr + offset, len);
     note[len] = '\0';
 
     Events::PushEventData("PIN_X", std::to_string(x));
@@ -96,7 +96,7 @@ int32_t MapEvents::HandleMapPinChangePinMessageHook(CNWSMessage *thisPtr, CNWSPl
     // Copy the string over
     std::string note;
     note.reserve(len+1);
-    memcpy(note.data(), thisPtr->m_pnReadBuffer + thisPtr->m_nReadBufferPtr + offset, len);
+    std::memcpy(note.data(), thisPtr->m_pnReadBuffer + thisPtr->m_nReadBufferPtr + offset, len);
     note[len] = '\0';
     offset += len;
 

--- a/Plugins/Events/Events/MapEvents.cpp
+++ b/Plugins/Events/Events/MapEvents.cpp
@@ -102,7 +102,7 @@ int32_t MapEvents::HandleMapPinChangePinMessageHook(CNWSMessage *thisPtr, CNWSPl
 
     // Copy the pin id over
     static std::string pin_id;
-    pin_id = std::to_string(PeekMessage<int32_t>(thisPtr, 0));
+    pin_id = std::to_string(PeekMessage<int32_t>(thisPtr, offset));
 
     Events::PushEventData("PIN_X", std::to_string(x));
     Events::PushEventData("PIN_Y", std::to_string(y));

--- a/Plugins/Events/Events/MapEvents.hpp
+++ b/Plugins/Events/Events/MapEvents.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "Common.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include "ViewPtr.hpp"
+
+namespace Events {
+
+class MapEvents
+{
+public:
+    MapEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
+
+private:
+    static int32_t HandleMapPinSetMapPinAtMessageHook(NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*);
+    static int32_t HandleMapPinChangePinMessageHook(NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*);
+    static int32_t HandleMapPinDestroyMapPinMessageHook(NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*);
+};
+
+}

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -225,9 +225,12 @@
         TARGET_POSITION_Y       float
         TARGET_POSITION_Z       float        
 ////////////////////////////////////////////////////////////////////////////////
-    NWNX_ON_MAP_PIN_ADD_PIN
-    NWNX_ON_MAP_PIN_CHANGE_PIN
-    NWNX_ON_MAP_PIN_DESTROY_PIN
+    NWNX_ON_MAP_PIN_ADD_PIN_BEFORE
+    NWNX_ON_MAP_PIN_ADD_PIN_AFTER
+    NWNX_ON_MAP_PIN_CHANGE_PIN_BEFORE
+    NWNX_ON_MAP_PIN_CHANGE_PIN_AFTER
+    NWNX_ON_MAP_PIN_DESTROY_PIN_BEFORE
+    NWNX_ON_MAP_PIN_DESTROY_PIN_AFTER
 
     Usage:
         OBJECT_SELF = The player doing the action

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -273,6 +273,7 @@ string NWNX_Events_GetEventData(string tag);
 // - CombatMode events
 // - Party events
 // - Skill events
+// - Map events
 void NWNX_Events_SkipEvent();
 
 // Set the return value of the event.

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -224,6 +224,20 @@
         TARGET_POSITION_X       float
         TARGET_POSITION_Y       float
         TARGET_POSITION_Z       float        
+////////////////////////////////////////////////////////////////////////////////
+    NWNX_ON_MAP_PIN_ADD_PIN
+    NWNX_ON_MAP_PIN_CHANGE_PIN
+    NWNX_ON_MAP_PIN_DESTROY_PIN
+
+    Usage:
+        OBJECT_SELF = The player doing the action
+
+    Event data:
+        Variable Name           Type        Notes
+        PIN_X                   float
+        PIN_Y                   float
+        PIN_ID                  int
+        PIN_NOTE                string
 *///////////////////////////////////////////////////////////////////////////////
 
 // Scripts can subscribe to events.


### PR DESCRIPTION
Map pin event handling

Can be used for example:
- persistence (updating db per pin instead of on_client_leave for example)
- sharing pins with party members (party defines one mapper and all party members get the pins)
- DMs can add pins for players by setting their own and propagating
- deny pin usage for low INT chars

Note: Vector.Z is not used for pins