### PR TITLE
Add GetTotalEffectBonus()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The following plugins were added:
 - Creature: GetFeatRemainingUses()
 - Creature: GetFeatTotalUses()
 - Creature: SetFeatRemainingUses()
+- Creature: GetTotalEffectBonus()
 - Effect: PackEffect()
 - Effect: UnpackEffect()
 - Encounter: GetNumberOfCreaturesInEncounterList()

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -122,6 +122,7 @@ Creature::Creature(const Plugin::CreateParams& params)
     REGISTER(GetFeatRemainingUses);
     REGISTER(GetFeatTotalUses);
     REGISTER(SetFeatRemainingUses);
+    REGISTER(GetTotalEffectBonus);
 
 #undef REGISTER
 }
@@ -1600,4 +1601,33 @@ ArgumentStack Creature::SetFeatRemainingUses(ArgumentStack&& args)
     return stack;
 }
 
+ArgumentStack Creature::GetTotalEffectBonus(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    int32_t retVal = -1;
+
+    if (auto *pCreature = creature(args))
+    {
+        API::CNWSObject *versus = NULL;
+        const auto bonusType = Services::Events::ExtractArgument<int32_t>(args);
+        const auto versus_id = Services::Events::ExtractArgument<Types::ObjectID>(args);
+        if (versus_id != Constants::OBJECT_INVALID)
+        {
+            API::CGameObject *pObject = API::Globals::AppManager()->m_pServerExoApp->GetGameObject(versus_id);
+            versus = Utils::AsNWSObject(pObject);
+        }
+
+        const auto isElementalDamage = Services::Events::ExtractArgument<int32_t>(args);
+        const auto isForceMax = Services::Events::ExtractArgument<int32_t>(args);
+        const auto saveType = Services::Events::ExtractArgument<int32_t>(args);
+        const auto saveSpecificType = Services::Events::ExtractArgument<int32_t>(args);
+        const auto skill = Services::Events::ExtractArgument<int32_t>(args);
+        const auto abilityScore = Services::Events::ExtractArgument<int32_t>(args);
+        const auto isOffhand = Services::Events::ExtractArgument<int32_t>(args);
+        retVal = pCreature->GetTotalEffectBonus(bonusType, versus, isElementalDamage, isForceMax, saveType, saveSpecificType, skill, abilityScore, isOffhand);
+    }
+
+    Services::Events::InsertArgument(stack, retVal);
+    return stack;
+}
 }

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -86,6 +86,7 @@ private:
     ArgumentStack GetFeatRemainingUses          (ArgumentStack&& args);
     ArgumentStack GetFeatTotalUses              (ArgumentStack&& args);
     ArgumentStack SetFeatRemainingUses          (ArgumentStack&& args);
+    ArgumentStack GetTotalEffectBonus           (ArgumentStack&& args);
 
     NWNXLib::API::CNWSCreature *creature(ArgumentStack& args);
 

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -36,12 +36,12 @@ const int NWNX_CREATURE_CLERIC_DOMAIN_TRICKERY    = 19;
 const int NWNX_CREATURE_CLERIC_DOMAIN_WAR         = 20;
 const int NWNX_CREATURE_CLERIC_DOMAIN_WATER       = 21;
 
-const int NWNX_EFFECT_TYPE_ATTACK        = 1;
-const int NWNX_EFFECT_TYPE_DAMAGE        = 2;
-const int NWNX_EFFECT_TYPE_SAVING_THROW  = 3;
-const int NWNX_EFFECT_TYPE_ABILITY       = 4;
-const int NWNX_EFFECT_TYPE_SKILL         = 5;
-const int NWNX_EFFECT_TYPE_TOUCH_ATTACK  = 6;
+const int NWNX_CREATURE_BONUS_TYPE_ATTACK        = 1;
+const int NWNX_CREATURE_BONUS_TYPE_DAMAGE        = 2;
+const int NWNX_CREATURE_BONUS_TYPE_SAVING_THROW  = 3;
+const int NWNX_CREATURE_BONUS_TYPE_ABILITY       = 4;
+const int NWNX_CREATURE_BONUS_TYPE_SKILL         = 5;
+const int NWNX_CREATURE_BONUS_TYPE_TOUCH_ATTACK  = 6;
 
 struct NWNX_Creature_SpecialAbility
 {
@@ -307,7 +307,7 @@ int NWNX_Creature_GetFeatTotalUses(object creature, int feat);
 void NWNX_Creature_SetFeatRemainingUses(object creature, int feat, int uses);
 
 // Get total effect bonus
-int NWNX_Creature_GetTotalEffectBonus(object creature, int bonusType=NWNX_EFFECT_TYPE_ATTACK, object target=OBJECT_INVALID, int isElemental=0,
+int NWNX_Creature_GetTotalEffectBonus(object creature, int bonusType=NWNX_CREATURE_BONUS_TYPE_ATTACK, object target=OBJECT_INVALID, int isElemental=0,
     int isForceMax=0, int savetype=-1, int saveSpecificType=-1, int skill=-1, int abilityScore=-1, int isOffhand=FALSE);
 
 const string NWNX_Creature = "NWNX_Creature";
@@ -1085,7 +1085,7 @@ void NWNX_Creature_SetFeatRemainingUses(object creature, int feat, int uses)
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
 
-int NWNX_Creature_GetTotalEffectBonus(object creature, int bonusType=NWNX_EFFECT_TYPE_ATTACK, object target=OBJECT_INVALID, int isElemental=0,
+int NWNX_Creature_GetTotalEffectBonus(object creature, int bonusType=NWNX_CREATURE_BONUS_TYPE_ATTACK, object target=OBJECT_INVALID, int isElemental=0,
     int isForceMax=0, int savetype=-1, int saveSpecificType=-1, int skill=-1, int abilityScore=-1, int isOffhand=FALSE)
 {
     string sFunc="GetTotalEffectBonus";

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -36,6 +36,13 @@ const int NWNX_CREATURE_CLERIC_DOMAIN_TRICKERY    = 19;
 const int NWNX_CREATURE_CLERIC_DOMAIN_WAR         = 20;
 const int NWNX_CREATURE_CLERIC_DOMAIN_WATER       = 21;
 
+const int NWNX_EFFECT_TYPE_ATTACK        = 1;
+const int NWNX_EFFECT_TYPE_DAMAGE        = 2;
+const int NWNX_EFFECT_TYPE_SAVING_THROW  = 3;
+const int NWNX_EFFECT_TYPE_ABILITY       = 4;
+const int NWNX_EFFECT_TYPE_SKILL         = 5;
+const int NWNX_EFFECT_TYPE_TOUCH_ATTACK  = 6;
+
 struct NWNX_Creature_SpecialAbility
 {
     int id;
@@ -298,6 +305,10 @@ int NWNX_Creature_GetFeatTotalUses(object creature, int feat);
 
 // Set feat remaining uses of a creature
 void NWNX_Creature_SetFeatRemainingUses(object creature, int feat, int uses);
+
+// Get total effect bonus
+int NWNX_Creature_GetTotalEffectBonus(object creature, int bonusType=NWNX_EFFECT_TYPE_ATTACK, object target=OBJECT_INVALID, int isElemental=0,
+    int isForceMax=0, int savetype=-1, int saveSpecificType=-1, int skill=-1, int abilityScore=-1, int isOffhand=FALSE);
 
 const string NWNX_Creature = "NWNX_Creature";
 
@@ -1072,4 +1083,24 @@ void NWNX_Creature_SetFeatRemainingUses(object creature, int feat, int uses)
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 
     NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+int NWNX_Creature_GetTotalEffectBonus(object creature, int bonusType=NWNX_EFFECT_TYPE_ATTACK, object target=OBJECT_INVALID, int isElemental=0,
+    int isForceMax=0, int savetype=-1, int saveSpecificType=-1, int skill=-1, int abilityScore=-1, int isOffhand=FALSE)
+{
+    string sFunc="GetTotalEffectBonus";
+
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, isOffhand);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, abilityScore);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, skill);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, saveSpecificType);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, savetype);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, isForceMax);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, isElemental);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, target);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, bonusType);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
 }

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -159,5 +159,11 @@ void main()
     NWNX_Creature_SetChallengeRating(oCreature, fCR + 1.0);
     report("SetChallengeRating", GetChallengeRating(oCreature) == (fCR + 1.0));
 
+    int iOldBonus = NWNX_Creature_GetTotalEffectBonus(oCreature, NWNX_CREATURE_BONUS_TYPE_ABILITY, OBJECT_INVALID, 0, 0, -1, -1, -1, ABILITY_STRENGTH);
+    effect eStr = EffectAbilityIncrease(ABILITY_STRENGTH,1);
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eStr, oCreature, 2.0f);
+    int iNewBonus = NWNX_Creature_GetTotalEffectBonus(oCreature, NWNX_CREATURE_BONUS_TYPE_ABILITY, OBJECT_INVALID, 0, 0, -1, -1, -1, ABILITY_STRENGTH);
+    report("GetTotalEffectBonus", iOldBonus+1 == iNewBonus);
+
     WriteTimestampedLogEntry("NWNX_Creature unit test end.");
 }


### PR DESCRIPTION
So we have a custom implementation of Weird that ignores immunities to Fear but uses any fear bonuses in their Will and Fort calculations. `MySavingThrow` would spout out immunity feedback that was confusing to the end user so we needed to write our own calcs and we used `GetSavingThrowVersus` from the old nwnx. 

This exposes the actual bonus value beyond a player's base scores to attack, damage bonus, saves, skills ability scores,and touch attack provided by spells, equipment, potions etc.

Example usage:

```c
NWNX_Creature_GetTotalEffectBonus(oTarget, NWNX_EFFECT_TYPE_SAVING_THROW,
    oSaveVersus, 0, 0, nSavingThrow, SAVING_THROW_TYPE_FEAR);

NWNX_Creature_GetTotalEffectBonus(oTarget, NWNX_EFFECT_TYPE_SKILL,
    OBJECT_INVALID, 0, 0, -1, -1, SKILL_SPOT);

NWNX_Creature_GetTotalEffectBonus(oTarget, NWNX_EFFECT_TYPE_ABILITY,
    OBJECT_INVALID, 0, 0, -1, -1, -1, ABILITY_WISDOM);
```