### PR TITLE
Add ASSERT_OR_THROW()

### DIFF
--- a/NWNXLib/Assert.cpp
+++ b/NWNXLib/Assert.cpp
@@ -1,10 +1,9 @@
 #include "Assert.hpp"
 #include "Platform/Debug.hpp"
-#include "Utils.hpp"
 
 #include <cstdlib>
 #include <cstring>
-#include <stdexcept>
+
 
 #ifdef _WIN32
     #include "Windows.h"
@@ -87,11 +86,6 @@ void Fail(const char* condition, const char* file, int line, const char* message
     {
         std::abort();
     }
-}
-
-void Throw(const char* condition)
-{
-    throw std::runtime_error("ASSERTION FAILURE: (" + std::string(condition) + ") in NWScript: " + Utils::GetCurrentScript());
 }
 
 }

--- a/NWNXLib/Assert.cpp
+++ b/NWNXLib/Assert.cpp
@@ -4,7 +4,6 @@
 #include <cstdlib>
 #include <cstring>
 
-
 #ifdef _WIN32
     #include "Windows.h"
 #else

--- a/NWNXLib/Assert.cpp
+++ b/NWNXLib/Assert.cpp
@@ -1,8 +1,10 @@
 #include "Assert.hpp"
 #include "Platform/Debug.hpp"
+#include "Utils.hpp"
 
 #include <cstdlib>
 #include <cstring>
+#include <stdexcept>
 
 #ifdef _WIN32
     #include "Windows.h"
@@ -85,6 +87,11 @@ void Fail(const char* condition, const char* file, int line, const char* message
     {
         std::abort();
     }
+}
+
+void Throw(const char* condition)
+{
+    throw std::runtime_error("ASSERTION FAILURE: (" + std::string(condition) + ") in NWScript: " + Utils::GetCurrentScript());
 }
 
 }

--- a/NWNXLib/Assert.hpp
+++ b/NWNXLib/Assert.hpp
@@ -31,7 +31,7 @@ namespace Assert {
     #define ASSERT_FAIL_MSG(format, ...) (void)0
 #endif
 
-    #define ASSERT_THROW(condition) \
+    #define ASSERT_OR_THROW(condition) \
         do \
         { \
             if(!(condition)) throw std::runtime_error("ASSERTION FAILURE: (" + std::string(#condition) + ") in NWScript: " + Utils::GetCurrentScript()); \

--- a/NWNXLib/Assert.hpp
+++ b/NWNXLib/Assert.hpp
@@ -31,12 +31,20 @@ namespace Assert {
     #define ASSERT_FAIL_MSG(format, ...) (void)0
 #endif
 
+    #define ASSERT_THROW(condition) \
+        do \
+        { \
+            if(!(condition)) ::NWNXLib::Assert::Throw((#condition)); \
+        } while (0)
+
 void Fail(const char* condition, const char* file, int line, const char* message);
 
 template <typename ... Args>
 void Fail(const char* condition, const char* file, int line, const char* format, Args ... args);
 
 void SetCrashOnFailure(bool crash);
+
+void Throw(const char* condition);
 
 #include "Assert.inl"
 

--- a/NWNXLib/Assert.hpp
+++ b/NWNXLib/Assert.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Utils.hpp"
 #include <cstdio>
 
 namespace NWNXLib {

--- a/NWNXLib/Assert.hpp
+++ b/NWNXLib/Assert.hpp
@@ -34,7 +34,7 @@ namespace Assert {
     #define ASSERT_THROW(condition) \
         do \
         { \
-            if(!(condition)) ::NWNXLib::Assert::Throw((#condition)); \
+            if(!(condition)) throw std::runtime_error("ASSERTION FAILURE: (" + std::string(#condition) + ") in NWScript: " + Utils::GetCurrentScript()); \
         } while (0)
 
 void Fail(const char* condition, const char* file, int line, const char* message);
@@ -43,8 +43,6 @@ template <typename ... Args>
 void Fail(const char* condition, const char* file, int line, const char* format, Args ... args);
 
 void SetCrashOnFailure(bool crash);
-
-void Throw(const char* condition);
 
 #include "Assert.inl"
 

--- a/Plugins/Area/Area.cpp
+++ b/Plugins/Area/Area.cpp
@@ -159,9 +159,9 @@ ArgumentStack Area::SetPVPSetting(ArgumentStack&& args)
     {
         auto pvpSetting = Services::Events::ExtractArgument<int32_t>(args);
         
-        if (pvpSetting < 0) pvpSetting = 0;
-        if (pvpSetting > 3) pvpSetting = 3;
-        
+        ASSERT_OR_THROW(pvpSetting >= 0);
+        ASSERT_OR_THROW(pvpSetting <= 3);
+
         pArea->m_nPVPSetting = pvpSetting;
     }    
 
@@ -248,6 +248,8 @@ ArgumentStack Area::SetNoRestingAllowed(ArgumentStack&& args)
     if (auto *pArea = area(args))
     {
         const auto noRestingAllowed = Services::Events::ExtractArgument<int32_t>(args);
+
+        ASSERT_OR_THROW(noRestingAllowed >= 0);
         
         pArea->m_bNoRestingAllowed = noRestingAllowed;
     }    
@@ -278,8 +280,8 @@ ArgumentStack Area::SetWindPower(ArgumentStack&& args)
     {
         auto windPower = Services::Events::ExtractArgument<int32_t>(args);
         
-        if (windPower < 0 ) windPower = 0;
-        if (windPower > 2) windPower = 2; 
+        ASSERT_OR_THROW(windPower >= 0);
+        ASSERT_OR_THROW(windPower <= 2);
 
         pArea->m_nWindAmount = windPower;
     }    
@@ -331,8 +333,8 @@ ArgumentStack Area::SetWeatherChance(ArgumentStack&& args)
 
         auto chance = Services::Events::ExtractArgument<int32_t>(args);
 
-        if (chance < 0 ) chance = 0;
-        if (chance > 100) chance = 100;    
+        ASSERT_OR_THROW(chance >= 0);
+        ASSERT_OR_THROW(chance <= 100);
 
         switch (type)
         {
@@ -379,7 +381,7 @@ ArgumentStack Area::SetFogClipDistance(ArgumentStack&& args)
     {
         auto distance = Services::Events::ExtractArgument<float>(args);
         
-        if (distance < 0.0) distance = 0.0;
+        ASSERT_OR_THROW(distance >= 0.0);
 
         pArea->m_fFogClipDistance = distance;
     }    
@@ -410,8 +412,8 @@ ArgumentStack Area::SetShadowOpacity(ArgumentStack&& args)
     {
         auto shadowOpacity = Services::Events::ExtractArgument<int32_t>(args);
         
-        if (shadowOpacity < 0 ) shadowOpacity = 0;
-        if (shadowOpacity > 100) shadowOpacity = 100; 
+        ASSERT_OR_THROW(shadowOpacity >= 0);
+        ASSERT_OR_THROW(shadowOpacity <= 100);
 
         pArea->m_nShadowOpacity = shadowOpacity;
     }    

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -168,7 +168,7 @@ ArgumentStack Creature::AddFeatByLevel(ArgumentStack&& args)
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
-            ASSERT_OR_THROW(pLevelStats);
+            ASSERT(pLevelStats);
             pLevelStats->AddFeat(static_cast<uint16_t>(feat));
             pCreature->m_pStats->AddFeat(static_cast<uint16_t>(feat));
         }
@@ -214,7 +214,7 @@ ArgumentStack Creature::GetFeatCountByLevel(ArgumentStack&& args)
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
-            ASSERT_OR_THROW(pLevelStats);
+            ASSERT(pLevelStats);
             retVal = pLevelStats->m_lstFeats.num;
         }
     }
@@ -234,7 +234,7 @@ ArgumentStack Creature::GetFeatByLevel(ArgumentStack&& args)
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
-            ASSERT_OR_THROW(pLevelStats);
+            ASSERT(pLevelStats);
 
             if (index < pLevelStats->m_lstFeats.num)
                 retVal = pLevelStats->m_lstFeats.element[index];
@@ -301,7 +301,7 @@ ArgumentStack Creature::GetSpecialAbility(ArgumentStack&& args)
         const auto index = Services::Events::ExtractArgument<int32_t>(args);
 
         auto *pAbilities = pCreature->m_pStats->m_pSpellLikeAbilityList;
-        ASSERT_OR_THROW(pAbilities);
+        ASSERT(pAbilities);
         if (index < pAbilities->num)
         {
             id    = static_cast<int32_t>(pAbilities->element[index].m_nSpellId);
@@ -322,7 +322,7 @@ ArgumentStack Creature::GetSpecialAbilityCount(ArgumentStack&& args)
     if (auto *pCreature = creature(args))
     {
         auto *pAbilities = pCreature->m_pStats->m_pSpellLikeAbilityList;
-        ASSERT_OR_THROW(pAbilities);
+        ASSERT(pAbilities);
 
         // Need to count them manually, since some might be set to invalid
         retVal = 0;
@@ -346,7 +346,7 @@ ArgumentStack Creature::AddSpecialAbility(ArgumentStack&& args)
         ASSERT_OR_THROW(id >= 0);
 
         auto *pAbilities = pCreature->m_pStats->m_pSpellLikeAbilityList;
-        ASSERT_OR_THROW(pAbilities);
+        ASSERT(pAbilities);
 
         // Check for an empty slot somewhere first
         for (int32_t i = 0; i < pAbilities->num; i++)
@@ -364,7 +364,7 @@ ArgumentStack Creature::AddSpecialAbility(ArgumentStack&& args)
         {
             pAbilities->Allocate(pAbilities->array_size + 1);
         }
-        ASSERT_OR_THROW(pAbilities->array_size > pAbilities->num);
+        ASSERT(pAbilities->array_size > pAbilities->num);
         pAbilities->element[pAbilities->num].m_nSpellId     = static_cast<uint32_t>(id);
         pAbilities->element[pAbilities->num].m_bReadied     = ready;
         pAbilities->element[pAbilities->num].m_nCasterLevel = static_cast<uint8_t>(level);
@@ -381,7 +381,7 @@ ArgumentStack Creature::RemoveSpecialAbility(ArgumentStack&& args)
         const auto index = Services::Events::ExtractArgument<int32_t>(args);
 
         auto *pAbilities = pCreature->m_pStats->m_pSpellLikeAbilityList;
-        ASSERT_OR_THROW(pAbilities);
+        ASSERT(pAbilities);
         if (index < pAbilities->num)
         {
             pAbilities->element[index].m_nSpellId = ~0u;
@@ -404,7 +404,7 @@ ArgumentStack Creature::SetSpecialAbility(ArgumentStack&& args)
         ASSERT_OR_THROW(id >= 0);
 
         auto *pAbilities = pCreature->m_pStats->m_pSpellLikeAbilityList;
-        ASSERT_OR_THROW(pAbilities);
+        ASSERT(pAbilities);
         if (index < pAbilities->num)
         {
             pAbilities->element[index].m_nSpellId     = static_cast<uint32_t>(id);
@@ -426,7 +426,7 @@ ArgumentStack Creature::GetClassByLevel(ArgumentStack&& args)
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
-            ASSERT_OR_THROW(pLevelStats);
+            ASSERT(pLevelStats);
 
             retVal = pLevelStats->m_nClass;
         }
@@ -541,7 +541,7 @@ ArgumentStack Creature::ModifyRawAbilityScore(ArgumentStack&& args)
     if (auto *pCreature = creature(args))
     {
         const auto ability = Services::Events::ExtractArgument<int32_t>(args);
-        const auto offset  = Services::Events::ExtractArgument<int32_t>(args); ASSERT(offset <= 255);
+        const auto offset  = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(offset <= 255);
 
         switch (ability)
         {
@@ -882,7 +882,7 @@ ArgumentStack Creature::GetMaxHitPointsByLevel(ArgumentStack&& args)
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
-            ASSERT_OR_THROW(pLevelStats);
+            ASSERT(pLevelStats);
 
             retVal = pLevelStats->m_nHitDie;
         }
@@ -902,7 +902,7 @@ ArgumentStack Creature::SetMaxHitPointsByLevel(ArgumentStack&& args)
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
-            ASSERT_OR_THROW(pLevelStats);
+            ASSERT(pLevelStats);
 
             pLevelStats->m_nHitDie = static_cast<uint8_t>(value);
         }
@@ -1424,7 +1424,7 @@ ArgumentStack Creature::LevelUp(ArgumentStack&& args)
                 if (bSkipLevelUpValidation)
                 {
                     // NPCs can have at most 60 levels
-                    ASSERT_OR_THROW(!pThis->m_bIsPC);
+                    ASSERT(!pThis->m_bIsPC);
                     return pThis->GetLevel(false) < 60;
                 }
                 return pCanLevelUp_hook->CallOriginal<int32_t>(pThis);
@@ -1436,7 +1436,7 @@ ArgumentStack Creature::LevelUp(ArgumentStack&& args)
             {
                 if (bSkipLevelUpValidation)
                 {
-                    ASSERT_OR_THROW(!pThis->m_bIsPC);
+                    ASSERT(!pThis->m_bIsPC);
                     pThis->LevelUp(pLevelStats, nDomain1, nDomain2, nSchool, true);
                     pThis->UpdateCombatInformation();
                     return 0;

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -149,7 +149,7 @@ ArgumentStack Creature::AddFeat(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto feat = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(feat <= 65535);
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(feat >= 0); ASSERT_OR_THROW(feat <= 65535);
 
         pCreature->m_pStats->AddFeat(static_cast<uint16_t>(feat));
     }
@@ -162,8 +162,8 @@ ArgumentStack Creature::AddFeatByLevel(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto feat  = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(feat <= 65535);
-        const auto level = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(level <= 40);
+        const auto feat  = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(feat >= 0); ASSERT_OR_THROW(feat <= 65535);
+        const auto level = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 1); ASSERT_OR_THROW(level <= 40);
 
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
@@ -181,7 +181,7 @@ ArgumentStack Creature::RemoveFeat(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto feat = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(feat <= 65535);
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(feat >= 0); ASSERT_OR_THROW(feat <= 65535);
 
         pCreature->m_pStats->RemoveFeat(static_cast<uint16_t>(feat));
 
@@ -195,7 +195,7 @@ ArgumentStack Creature::GetKnowsFeat(ArgumentStack&& args)
     int32_t retVal = 0;
     if (auto *pCreature = creature(args))
     {
-        const auto feat = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(feat <= 65535);
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(feat >= 0); ASSERT_OR_THROW(feat <= 65535);
 
         retVal = pCreature->m_pStats->HasFeat(static_cast<uint16_t>(feat));
     }
@@ -209,9 +209,9 @@ ArgumentStack Creature::GetFeatCountByLevel(ArgumentStack&& args)
     int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto level = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(level <= 40);
+        const auto level = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 1); ASSERT_OR_THROW(level <= 40);
 
-        if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
+        if (level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
             ASSERT(pLevelStats);
@@ -228,10 +228,10 @@ ArgumentStack Creature::GetFeatByLevel(ArgumentStack&& args)
     int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto level = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(level <= 40);
+        const auto level = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 1); ASSERT_OR_THROW(level <= 40);
         const auto index = Services::Events::ExtractArgument<int32_t>(args);
 
-        if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
+        if (level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
             ASSERT(pLevelStats);
@@ -279,7 +279,7 @@ ArgumentStack Creature::GetMeetsFeatRequirements(ArgumentStack&& args)
     int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto feat = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(feat <= 65535);
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(feat >= 0); ASSERT_OR_THROW(feat <= 65535);
         // TODO: Need to clean up these templated arraylist APIs
         CExoArrayListTemplatedshortunsignedint unused = {};
 
@@ -421,7 +421,7 @@ ArgumentStack Creature::GetClassByLevel(ArgumentStack&& args)
     int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto level = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(level <= 40);
+        const auto level = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 1); ASSERT_OR_THROW(level <= 40);
 
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
@@ -465,7 +465,7 @@ ArgumentStack Creature::SetRawAbilityScore(ArgumentStack&& args)
     if (auto *pCreature = creature(args))
     {
         const auto ability = Services::Events::ExtractArgument<int32_t>(args);
-        const auto value   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(value <= 255);
+        const auto value   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(value >= 0); ASSERT_OR_THROW(value <= 255);
 
         switch (ability)
         {
@@ -579,9 +579,9 @@ ArgumentStack Creature::GetMemorisedSpell(ArgumentStack&& args)
     id = ready = meta = domain = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
-        const auto index   = Services::Events::ExtractArgument<int32_t>(args);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0); ASSERT_OR_THROW(classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 0); ASSERT_OR_THROW(level < 10);
+        const auto index   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(index >= 0); ASSERT_OR_THROW(index <= 255);
 
         for (int32_t i = 0; i < 3; i++)
         {
@@ -613,8 +613,8 @@ ArgumentStack Creature::GetMemorisedSpellCountByLevel(ArgumentStack&& args)
     int32_t retVal = 0;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0); ASSERT_OR_THROW(classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 0); ASSERT_OR_THROW(level < 10);
 
         for (int32_t i = 0; i < 3; i++)
         {
@@ -635,14 +635,14 @@ ArgumentStack Creature::SetMemorisedSpell(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
-        const auto index   = Services::Events::ExtractArgument<int32_t>(args);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0); ASSERT_OR_THROW(classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 0); ASSERT_OR_THROW(level < 10);
+        const auto index   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(index >= 0); ASSERT_OR_THROW(index <= 255);
 
         const auto domain  = Services::Events::ExtractArgument<int32_t>(args);
         const auto meta    = Services::Events::ExtractArgument<int32_t>(args);
         const auto ready   = Services::Events::ExtractArgument<int32_t>(args);
-        const auto id      = Services::Events::ExtractArgument<int32_t>(args);
+        const auto id      = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(id >= 0);
 
         for (int32_t i = 0; i < 3; i++)
         {
@@ -672,8 +672,8 @@ ArgumentStack Creature::GetRemainingSpellSlots(ArgumentStack&& args)
     int32_t retVal = 0;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0); ASSERT_OR_THROW(classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 0); ASSERT_OR_THROW(level < 10);
 
         for (int32_t i = 0; i < 3; i++)
         {
@@ -694,9 +694,9 @@ ArgumentStack Creature::SetRemainingSpellSlots(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
-        const auto slots   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(slots <= 255);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0); ASSERT_OR_THROW(classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 0); ASSERT_OR_THROW(level < 10);
+        const auto slots   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(slots >= 0); ASSERT_OR_THROW(slots <= 255);
 
         for (int32_t i = 0; i < 3; i++)
         {
@@ -717,8 +717,8 @@ ArgumentStack Creature::GetMaxSpellSlots(ArgumentStack&& args)
     int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0); ASSERT_OR_THROW(classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 0); ASSERT_OR_THROW(level < 10);
 
         for (int32_t i = 0; i < 3; i++)
         {
@@ -740,9 +740,9 @@ ArgumentStack Creature::GetKnownSpell(ArgumentStack&& args)
     int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
-        const auto index   = Services::Events::ExtractArgument<int32_t>(args);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0); ASSERT_OR_THROW(classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 0); ASSERT_OR_THROW(level < 10);
+        const auto index   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(index >= 0); ASSERT_OR_THROW(index <= 255);
 
         for (int32_t i = 0; i < 3; i++)
         {
@@ -766,8 +766,8 @@ ArgumentStack Creature::GetKnownSpellCount(ArgumentStack&& args)
     int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0); ASSERT_OR_THROW(classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 0); ASSERT_OR_THROW(level < 10);
 
         for (int32_t i = 0; i < 3; i++)
         {
@@ -788,9 +788,9 @@ ArgumentStack Creature::RemoveKnownSpell(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
-        const auto spellId = Services::Events::ExtractArgument<int32_t>(args);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0); ASSERT_OR_THROW(classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 0); ASSERT_OR_THROW(level < 10);
+        const auto spellId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(spellId >= 0);
 
         for (int32_t i = 0; i < 3; i++)
         {
@@ -810,9 +810,9 @@ ArgumentStack Creature::AddKnownSpell(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
-        const auto spellId = Services::Events::ExtractArgument<int32_t>(args);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0); ASSERT_OR_THROW(classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 0); ASSERT_OR_THROW(level < 10);
+        const auto spellId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(spellId >= 0);
 
         for (int32_t i = 0; i < 3; i++)
         {
@@ -832,8 +832,8 @@ ArgumentStack Creature::ClearMemorisedKnownSpells(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
-        const auto id      = Services::Events::ExtractArgument<int32_t>(args);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0); ASSERT_OR_THROW(classId <= 255);
+        const auto id      = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(id >= 0);
 
         for (int32_t i = 0; i < 3; i++)
         {
@@ -853,9 +853,9 @@ ArgumentStack Creature::ClearMemorisedSpell(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
-        const auto index   = Services::Events::ExtractArgument<int32_t>(args);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0); ASSERT_OR_THROW(classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 0); ASSERT_OR_THROW(level < 10);
+        const auto index   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(index >= 0); ASSERT_OR_THROW(index <= 255);
 
         for (int32_t i = 0; i < 3; i++)
         {
@@ -878,7 +878,7 @@ ArgumentStack Creature::GetMaxHitPointsByLevel(ArgumentStack&& args)
     int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto level = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level <= 40);
+        const auto level = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 1); ASSERT_OR_THROW(level <= 40);
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
@@ -896,8 +896,8 @@ ArgumentStack Creature::SetMaxHitPointsByLevel(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto level = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level <= 40);
-        const auto value = Services::Events::ExtractArgument<int32_t>(args);
+        const auto level = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 1); ASSERT_OR_THROW(level <= 40);
+        const auto value = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(value >= 0); ASSERT_OR_THROW(value <= 255);
 
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
@@ -1055,7 +1055,7 @@ ArgumentStack Creature::SetSoundset(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto soundset = Services::Events::ExtractArgument<int32_t>(args);
+        const auto soundset = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(soundset >= 0);
         pCreature->m_nSoundSet = static_cast<uint16_t>(soundset);
     }
     return stack;
@@ -1148,7 +1148,7 @@ ArgumentStack Creature::SetGender(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto gender = Services::Events::ExtractArgument<int32_t>(args);
+        const auto gender = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(gender >= 0); ASSERT_OR_THROW(gender <= 255);
 
         pCreature->m_pStats->m_nGender = gender;
     }
@@ -1180,7 +1180,7 @@ ArgumentStack Creature::RestoreSpells(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto level = Services::Events::ExtractArgument<int32_t>(args);
+        const auto level = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level >= 0); ASSERT_OR_THROW(level <= 255);
 
         if (level >= 0 && level <= 9)
         {
@@ -1247,7 +1247,7 @@ ArgumentStack Creature::SetRacialType(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto race = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(race <= 65535);
+        const auto race = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(race >= 0); ASSERT_OR_THROW(race <= 65535);
 
         pCreature->m_pStats->m_nRace = static_cast<uint16_t>(race);
     }
@@ -1385,7 +1385,7 @@ ArgumentStack Creature::SetBaseSavingThrow(ArgumentStack&& args)
     if (auto *pCreature = creature(args))
     {
         const auto which = Services::Events::ExtractArgument<int32_t>(args);
-        const auto value = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(value >= -128 && value <= 127);
+        const auto value = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(value >= -128); ASSERT_OR_THROW(value <= 127);
         int8_t base;
         switch (which)
         {
@@ -1568,7 +1568,7 @@ ArgumentStack Creature::GetFeatRemainingUses(ArgumentStack&& args)
     int32_t retval = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(feat <= 65535); /* word */
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(feat >= 0); ASSERT_OR_THROW(feat <= 65535); /* word */
         retval = pCreature->m_pStats->GetFeatRemainingUses(feat);
     }
     Services::Events::InsertArgument(stack, retval);
@@ -1581,7 +1581,7 @@ ArgumentStack Creature::GetFeatTotalUses(ArgumentStack&& args)
     int32_t retval = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(feat <= 65535); /* word */
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(feat >= 0); ASSERT_OR_THROW(feat <= 65535); /* word */
         retval = pCreature->m_pStats->GetFeatTotalUses(feat);
     }
     Services::Events::InsertArgument(stack, retval);
@@ -1593,8 +1593,8 @@ ArgumentStack Creature::SetFeatRemainingUses(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(feat <= 65535); /* word */
-        const auto uses = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(uses <= 255); /* byte */
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(feat >= 0); ASSERT_OR_THROW(feat <= 65535); /* word */
+        const auto uses = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(uses >= 0); ASSERT_OR_THROW(uses <= 255); /* byte */
 
         pCreature->m_pStats->SetFeatRemainingUses(feat, uses);
     }

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -149,7 +149,7 @@ ArgumentStack Creature::AddFeat(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto feat = Services::Events::ExtractArgument<int32_t>(args);  ASSERT(feat <= 65535);
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(feat <= 65535);
 
         pCreature->m_pStats->AddFeat(static_cast<uint16_t>(feat));
     }
@@ -162,13 +162,13 @@ ArgumentStack Creature::AddFeatByLevel(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto feat  = Services::Events::ExtractArgument<int32_t>(args);  ASSERT(feat <= 65535);
-        const auto level = Services::Events::ExtractArgument<int32_t>(args);  ASSERT(level <= 40);
+        const auto feat  = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(feat <= 65535);
+        const auto level = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(level <= 40);
 
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
-            ASSERT(pLevelStats);
+            ASSERT_OR_THROW(pLevelStats);
             pLevelStats->AddFeat(static_cast<uint16_t>(feat));
             pCreature->m_pStats->AddFeat(static_cast<uint16_t>(feat));
         }
@@ -181,7 +181,7 @@ ArgumentStack Creature::RemoveFeat(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto feat = Services::Events::ExtractArgument<int32_t>(args);  ASSERT(feat <= 65535);
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(feat <= 65535);
 
         pCreature->m_pStats->RemoveFeat(static_cast<uint16_t>(feat));
 
@@ -192,102 +192,102 @@ ArgumentStack Creature::RemoveFeat(ArgumentStack&& args)
 ArgumentStack Creature::GetKnowsFeat(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = 0;
+    int32_t retVal = 0;
     if (auto *pCreature = creature(args))
     {
-        const auto feat = Services::Events::ExtractArgument<int32_t>(args);  ASSERT(feat <= 65535);
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(feat <= 65535);
 
-        retval = pCreature->m_pStats->HasFeat(static_cast<uint16_t>(feat));
+        retVal = pCreature->m_pStats->HasFeat(static_cast<uint16_t>(feat));
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
 ArgumentStack Creature::GetFeatCountByLevel(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto level = Services::Events::ExtractArgument<int32_t>(args);  ASSERT(level <= 40);
+        const auto level = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(level <= 40);
 
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
-            ASSERT(pLevelStats);
-            retval = pLevelStats->m_lstFeats.num;
+            ASSERT_OR_THROW(pLevelStats);
+            retVal = pLevelStats->m_lstFeats.num;
         }
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
 ArgumentStack Creature::GetFeatByLevel(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto level = Services::Events::ExtractArgument<int32_t>(args);  ASSERT(level <= 40);
+        const auto level = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(level <= 40);
         const auto index = Services::Events::ExtractArgument<int32_t>(args);
 
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
-            ASSERT(pLevelStats);
+            ASSERT_OR_THROW(pLevelStats);
 
             if (index < pLevelStats->m_lstFeats.num)
-                retval = pLevelStats->m_lstFeats.element[index];
+                retVal = pLevelStats->m_lstFeats.element[index];
         }
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
 ArgumentStack Creature::GetFeatCount(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        retval = pCreature->m_pStats->m_lstFeats.num;
+        retVal = pCreature->m_pStats->m_lstFeats.num;
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
 ArgumentStack Creature::GetFeatByIndex(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
         const auto index = Services::Events::ExtractArgument<int32_t>(args);
 
         if (index < pCreature->m_pStats->m_lstFeats.num)
         {
-            retval = pCreature->m_pStats->m_lstFeats.element[index];
+            retVal = pCreature->m_pStats->m_lstFeats.element[index];
         }
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
 ArgumentStack Creature::GetMeetsFeatRequirements(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto feat = Services::Events::ExtractArgument<int32_t>(args);  ASSERT(feat <= 65535);
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(feat <= 65535);
         // TODO: Need to clean up these templated arraylist APIs
         CExoArrayListTemplatedshortunsignedint unused = {};
 
-        retval = pCreature->m_pStats->FeatRequirementsMet(static_cast<uint16_t>(feat),
+        retVal = pCreature->m_pStats->FeatRequirementsMet(static_cast<uint16_t>(feat),
                     reinterpret_cast<CExoArrayListTemplatedunsignedshort*>(&unused));
         free(unused.element);
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -301,7 +301,7 @@ ArgumentStack Creature::GetSpecialAbility(ArgumentStack&& args)
         const auto index = Services::Events::ExtractArgument<int32_t>(args);
 
         auto *pAbilities = pCreature->m_pStats->m_pSpellLikeAbilityList;
-        ASSERT(pAbilities);
+        ASSERT_OR_THROW(pAbilities);
         if (index < pAbilities->num)
         {
             id    = static_cast<int32_t>(pAbilities->element[index].m_nSpellId);
@@ -318,18 +318,18 @@ ArgumentStack Creature::GetSpecialAbility(ArgumentStack&& args)
 ArgumentStack Creature::GetSpecialAbilityCount(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
         auto *pAbilities = pCreature->m_pStats->m_pSpellLikeAbilityList;
-        ASSERT(pAbilities);
+        ASSERT_OR_THROW(pAbilities);
 
         // Need to count them manually, since some might be set to invalid
-        retval = 0;
+        retVal = 0;
         for (int32_t i = 0; i < pAbilities->num; i++)
-            retval += (pAbilities->element[i].m_nSpellId != ~0u);
+            retVal += (pAbilities->element[i].m_nSpellId != ~0u);
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -342,11 +342,11 @@ ArgumentStack Creature::AddSpecialAbility(ArgumentStack&& args)
         const auto ready = Services::Events::ExtractArgument<int32_t>(args);
         const auto id    = Services::Events::ExtractArgument<int32_t>(args);
 
-        ASSERT(level >= 0);
-        ASSERT(id >= 0);
+        ASSERT_OR_THROW(level >= 0);
+        ASSERT_OR_THROW(id >= 0);
 
         auto *pAbilities = pCreature->m_pStats->m_pSpellLikeAbilityList;
-        ASSERT(pAbilities);
+        ASSERT_OR_THROW(pAbilities);
 
         // Check for an empty slot somewhere first
         for (int32_t i = 0; i < pAbilities->num; i++)
@@ -364,7 +364,7 @@ ArgumentStack Creature::AddSpecialAbility(ArgumentStack&& args)
         {
             pAbilities->Allocate(pAbilities->array_size + 1);
         }
-        ASSERT(pAbilities->array_size > pAbilities->num);
+        ASSERT_OR_THROW(pAbilities->array_size > pAbilities->num);
         pAbilities->element[pAbilities->num].m_nSpellId     = static_cast<uint32_t>(id);
         pAbilities->element[pAbilities->num].m_bReadied     = ready;
         pAbilities->element[pAbilities->num].m_nCasterLevel = static_cast<uint8_t>(level);
@@ -381,7 +381,7 @@ ArgumentStack Creature::RemoveSpecialAbility(ArgumentStack&& args)
         const auto index = Services::Events::ExtractArgument<int32_t>(args);
 
         auto *pAbilities = pCreature->m_pStats->m_pSpellLikeAbilityList;
-        ASSERT(pAbilities);
+        ASSERT_OR_THROW(pAbilities);
         if (index < pAbilities->num)
         {
             pAbilities->element[index].m_nSpellId = ~0u;
@@ -400,11 +400,11 @@ ArgumentStack Creature::SetSpecialAbility(ArgumentStack&& args)
         const auto ready = Services::Events::ExtractArgument<int32_t>(args);
         const auto id    = Services::Events::ExtractArgument<int32_t>(args);
 
-        ASSERT(level >= 0);
-        ASSERT(id >= 0);
+        ASSERT_OR_THROW(level >= 0);
+        ASSERT_OR_THROW(id >= 0);
 
         auto *pAbilities = pCreature->m_pStats->m_pSpellLikeAbilityList;
-        ASSERT(pAbilities);
+        ASSERT_OR_THROW(pAbilities);
         if (index < pAbilities->num)
         {
             pAbilities->element[index].m_nSpellId     = static_cast<uint32_t>(id);
@@ -418,20 +418,20 @@ ArgumentStack Creature::SetSpecialAbility(ArgumentStack&& args)
 ArgumentStack Creature::GetClassByLevel(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto level = Services::Events::ExtractArgument<int32_t>(args);  ASSERT(level <= 40);
+        const auto level = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(level <= 40);
 
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
-            ASSERT(pLevelStats);
+            ASSERT_OR_THROW(pLevelStats);
 
-            retval = pLevelStats->m_nClass;
+            retVal = pLevelStats->m_nClass;
         }
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -440,7 +440,7 @@ ArgumentStack Creature::SetBaseAC(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto ac = Services::Events::ExtractArgument<int32_t>(args); ASSERT(ac <= 255);
+        const auto ac = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(ac <= 255);
 
         pCreature->m_pStats->m_nACNaturalBase = static_cast<char>(ac);
     }
@@ -450,12 +450,12 @@ ArgumentStack Creature::SetBaseAC(ArgumentStack&& args)
 ArgumentStack Creature::GetBaseAC(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        retval = pCreature->m_pStats->m_nACNaturalBase;
+        retVal = pCreature->m_pStats->m_nACNaturalBase;
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -465,7 +465,7 @@ ArgumentStack Creature::SetRawAbilityScore(ArgumentStack&& args)
     if (auto *pCreature = creature(args))
     {
         const auto ability = Services::Events::ExtractArgument<int32_t>(args);
-        const auto value   = Services::Events::ExtractArgument<int32_t>(args); ASSERT(value <= 255);
+        const auto value   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(value <= 255);
 
         switch (ability)
         {
@@ -499,7 +499,7 @@ ArgumentStack Creature::SetRawAbilityScore(ArgumentStack&& args)
 ArgumentStack Creature::GetRawAbilityScore(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
 
     if (auto *pCreature = creature(args))
     {
@@ -508,22 +508,22 @@ ArgumentStack Creature::GetRawAbilityScore(ArgumentStack&& args)
         switch (ability)
         {
             case Constants::ABILITY_STRENGTH:
-                retval = pCreature->m_pStats->m_nStrengthBase;
+                retVal = pCreature->m_pStats->m_nStrengthBase;
                 break;
             case Constants::ABILITY_DEXTERITY:
-                retval = pCreature->m_pStats->m_nDexterityBase;
+                retVal = pCreature->m_pStats->m_nDexterityBase;
                 break;
             case Constants::ABILITY_CONSTITUTION:
-                retval = pCreature->m_pStats->m_nConstitutionBase;
+                retVal = pCreature->m_pStats->m_nConstitutionBase;
                 break;
             case Constants::ABILITY_INTELLIGENCE:
-                retval = pCreature->m_pStats->m_nIntelligenceBase;
+                retVal = pCreature->m_pStats->m_nIntelligenceBase;
                 break;
             case Constants::ABILITY_WISDOM:
-                retval = pCreature->m_pStats->m_nWisdomBase;
+                retVal = pCreature->m_pStats->m_nWisdomBase;
                 break;
             case Constants::ABILITY_CHARISMA:
-                retval = pCreature->m_pStats->m_nCharismaBase;
+                retVal = pCreature->m_pStats->m_nCharismaBase;
                 break;
             default:
                 LOG_NOTICE("Calling NWNX_Creature_GetRawAbilityScore with invalid ability ID:%d", ability);
@@ -531,7 +531,7 @@ ArgumentStack Creature::GetRawAbilityScore(ArgumentStack&& args)
                 break;
         }
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -579,8 +579,8 @@ ArgumentStack Creature::GetMemorisedSpell(ArgumentStack&& args)
     id = ready = meta = domain = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT(level < 10);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
         const auto index   = Services::Events::ExtractArgument<int32_t>(args);
 
         for (int32_t i = 0; i < 3; i++)
@@ -610,23 +610,23 @@ ArgumentStack Creature::GetMemorisedSpell(ArgumentStack&& args)
 ArgumentStack Creature::GetMemorisedSpellCountByLevel(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = 0;
+    int32_t retVal = 0;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT(level < 10);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
 
         for (int32_t i = 0; i < 3; i++)
         {
             auto& classInfo = pCreature->m_pStats->m_ClassInfo[i];
             if (classInfo.m_nClass == classId)
             {
-                retval = classInfo.GetNumberMemorizedSpellSlots(static_cast<unsigned char>(level));
+                retVal = classInfo.GetNumberMemorizedSpellSlots(static_cast<unsigned char>(level));
                 break;
             }
         }
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -635,8 +635,8 @@ ArgumentStack Creature::SetMemorisedSpell(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT(level < 10);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
         const auto index   = Services::Events::ExtractArgument<int32_t>(args);
 
         const auto domain  = Services::Events::ExtractArgument<int32_t>(args);
@@ -669,23 +669,23 @@ ArgumentStack Creature::SetMemorisedSpell(ArgumentStack&& args)
 ArgumentStack Creature::GetRemainingSpellSlots(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = 0;
+    int32_t retVal = 0;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT(level < 10);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
 
         for (int32_t i = 0; i < 3; i++)
         {
             auto& classInfo = pCreature->m_pStats->m_ClassInfo[i];
             if (classInfo.m_nClass == classId)
             {
-                retval = classInfo.GetSpellsPerDayLeft(static_cast<unsigned char>(level));
+                retVal = classInfo.GetSpellsPerDayLeft(static_cast<unsigned char>(level));
                 break;
             }
         }
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -694,9 +694,9 @@ ArgumentStack Creature::SetRemainingSpellSlots(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT(level < 10);
-        const auto slots   = Services::Events::ExtractArgument<int32_t>(args); ASSERT(slots <= 255);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
+        const auto slots   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(slots <= 255);
 
         for (int32_t i = 0; i < 3; i++)
         {
@@ -714,34 +714,34 @@ ArgumentStack Creature::SetRemainingSpellSlots(ArgumentStack&& args)
 ArgumentStack Creature::GetMaxSpellSlots(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT(level < 10);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
 
         for (int32_t i = 0; i < 3; i++)
         {
             auto& classInfo = pCreature->m_pStats->m_ClassInfo[i];
             if (classInfo.m_nClass == classId)
             {
-                retval = pCreature->m_pStats->GetSpellGainWithBonus(i, level) + classInfo.m_nBonusSpellsList[level];
+                retVal = pCreature->m_pStats->GetSpellGainWithBonus(i, level) + classInfo.m_nBonusSpellsList[level];
                 break;
             }
         }
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
 ArgumentStack Creature::GetKnownSpell(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT(level < 10);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
         const auto index   = Services::Events::ExtractArgument<int32_t>(args);
 
         for (int32_t i = 0; i < 3; i++)
@@ -749,37 +749,37 @@ ArgumentStack Creature::GetKnownSpell(ArgumentStack&& args)
             auto& classInfo = pCreature->m_pStats->m_ClassInfo[i];
             if (classInfo.m_nClass == classId)
             {
-                retval = static_cast<int32_t>(classInfo.GetKnownSpell(
+                retVal = static_cast<int32_t>(classInfo.GetKnownSpell(
                         static_cast<unsigned char>(level),
                         static_cast<unsigned char>(index)));
                 break;
             }
         }
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
 ArgumentStack Creature::GetKnownSpellCount(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT(level < 10);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
 
         for (int32_t i = 0; i < 3; i++)
         {
             auto& classInfo = pCreature->m_pStats->m_ClassInfo[i];
             if (classInfo.m_nClass == classId)
             {
-                retval = classInfo.GetNumberKnownSpells(static_cast<unsigned char>(level));
+                retVal = classInfo.GetNumberKnownSpells(static_cast<unsigned char>(level));
                 break;
             }
         }
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -788,8 +788,8 @@ ArgumentStack Creature::RemoveKnownSpell(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT(level < 10);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
         const auto spellId = Services::Events::ExtractArgument<int32_t>(args);
 
         for (int32_t i = 0; i < 3; i++)
@@ -810,8 +810,8 @@ ArgumentStack Creature::AddKnownSpell(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT(level < 10);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
         const auto spellId = Services::Events::ExtractArgument<int32_t>(args);
 
         for (int32_t i = 0; i < 3; i++)
@@ -832,7 +832,7 @@ ArgumentStack Creature::ClearMemorisedKnownSpells(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT(classId >= 0 && classId <= 255);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
         const auto id      = Services::Events::ExtractArgument<int32_t>(args);
 
         for (int32_t i = 0; i < 3; i++)
@@ -853,8 +853,8 @@ ArgumentStack Creature::ClearMemorisedSpell(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT(classId >= 0 && classId <= 255);
-        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT(level < 10);
+        const auto classId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(classId >= 0 && classId <= 255);
+        const auto level   = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level < 10);
         const auto index   = Services::Events::ExtractArgument<int32_t>(args);
 
         for (int32_t i = 0; i < 3; i++)
@@ -875,19 +875,19 @@ ArgumentStack Creature::ClearMemorisedSpell(ArgumentStack&& args)
 ArgumentStack Creature::GetMaxHitPointsByLevel(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto level = Services::Events::ExtractArgument<int32_t>(args); ASSERT(level <= 40);
+        const auto level = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level <= 40);
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
-            ASSERT(pLevelStats);
+            ASSERT_OR_THROW(pLevelStats);
 
-            retval = pLevelStats->m_nHitDie;
+            retVal = pLevelStats->m_nHitDie;
         }
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -896,13 +896,13 @@ ArgumentStack Creature::SetMaxHitPointsByLevel(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto level = Services::Events::ExtractArgument<int32_t>(args); ASSERT(level <= 40);
+        const auto level = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(level <= 40);
         const auto value = Services::Events::ExtractArgument<int32_t>(args);
 
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
-            ASSERT(pLevelStats);
+            ASSERT_OR_THROW(pLevelStats);
 
             pLevelStats->m_nHitDie = static_cast<uint8_t>(value);
         }
@@ -927,8 +927,8 @@ ArgumentStack Creature::SetAlignmentGoodEvil(ArgumentStack&& args)
     if (auto *pCreature = creature(args))
     {
         const auto value = Services::Events::ExtractArgument<int32_t>(args);
-        ASSERT(value <= 32767);
-        ASSERT(value >= -32768);
+        ASSERT_OR_THROW(value <= 32767);
+        ASSERT_OR_THROW(value >= -32768);
         pCreature->m_pStats->m_nAlignmentGoodEvil = static_cast<int16_t>(value);
     }
     return stack;
@@ -940,8 +940,8 @@ ArgumentStack Creature::SetAlignmentLawChaos(ArgumentStack&& args)
     if (auto *pCreature = creature(args))
     {
         const auto value = Services::Events::ExtractArgument<int32_t>(args);
-        ASSERT(value <= 32767);
-        ASSERT(value >= -32768);
+        ASSERT_OR_THROW(value <= 32767);
+        ASSERT_OR_THROW(value >= -32768);
         pCreature->m_pStats->m_nAlignmentLawChaos = static_cast<int16_t>(value);
     }
     return stack;
@@ -950,24 +950,24 @@ ArgumentStack Creature::SetAlignmentLawChaos(ArgumentStack&& args)
 ArgumentStack Creature::GetClericDomain(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
         const auto index = Services::Events::ExtractArgument<int32_t>(args);
-        ASSERT(index >= 1);
-        ASSERT(index <= 2);
+        ASSERT_OR_THROW(index >= 1);
+        ASSERT_OR_THROW(index <= 2);
 
         for (int32_t i = 0; i < 3; i++)
         {
             auto& classInfo = pCreature->m_pStats->m_ClassInfo[i];
             if (classInfo.m_nClass == Constants::CLASS_TYPE_CLERIC)
             {
-                retval = classInfo.m_nDomain[index - 1];
+                retVal = classInfo.m_nDomain[index - 1];
                 break;
             }
         }
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -977,11 +977,11 @@ ArgumentStack Creature::SetClericDomain(ArgumentStack&& args)
     if (auto *pCreature = creature(args))
     {
         const auto index = Services::Events::ExtractArgument<int32_t>(args);
-        ASSERT(index >= 1);
-        ASSERT(index <= 2);
+        ASSERT_OR_THROW(index >= 1);
+        ASSERT_OR_THROW(index <= 2);
         const auto domain = Services::Events::ExtractArgument<int32_t>(args);
-        ASSERT(domain <= 255);
-        ASSERT(domain >= 0);
+        ASSERT_OR_THROW(domain <= 255);
+        ASSERT_OR_THROW(domain >= 0);
 
         for (int32_t i = 0; i < 3; i++)
         {
@@ -999,7 +999,7 @@ ArgumentStack Creature::SetClericDomain(ArgumentStack&& args)
 ArgumentStack Creature::GetWizardSpecialization(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
         for (int32_t i = 0; i < 3; i++)
@@ -1007,12 +1007,12 @@ ArgumentStack Creature::GetWizardSpecialization(ArgumentStack&& args)
             auto& classInfo = pCreature->m_pStats->m_ClassInfo[i];
             if (classInfo.m_nClass == Constants::CLASS_TYPE_WIZARD)
             {
-                retval = classInfo.m_nSchool;
+                retVal = classInfo.m_nSchool;
                 break;
             }
         }
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -1022,8 +1022,8 @@ ArgumentStack Creature::SetWizardSpecialization(ArgumentStack&& args)
     if (auto *pCreature = creature(args))
     {
         const auto school = Services::Events::ExtractArgument<int32_t>(args);
-        ASSERT(school <= 255);
-        ASSERT(school >= 0);
+        ASSERT_OR_THROW(school <= 255);
+        ASSERT_OR_THROW(school >= 0);
 
         for (int32_t i = 0; i < 3; i++)
         {
@@ -1041,12 +1041,12 @@ ArgumentStack Creature::SetWizardSpecialization(ArgumentStack&& args)
 ArgumentStack Creature::GetSoundset(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        retval = pCreature->m_nSoundSet;
+        retVal = pCreature->m_nSoundSet;
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -1068,10 +1068,10 @@ ArgumentStack Creature::SetSkillRank(ArgumentStack&& args)
     {
         const auto skill = Services::Events::ExtractArgument<int32_t>(args);
         const auto rank = Services::Events::ExtractArgument<int32_t>(args);
-        ASSERT(skill >= 0);
-        ASSERT(skill <= 255);
-        ASSERT(rank >= -127);
-        ASSERT(rank <= 128);
+        ASSERT_OR_THROW(skill >= 0);
+        ASSERT_OR_THROW(skill <= 255);
+        ASSERT_OR_THROW(rank >= -127);
+        ASSERT_OR_THROW(rank <= 128);
 
         pCreature->m_pStats->SetSkillRank(static_cast<uint8_t>(skill), static_cast<int8_t>(rank));
     }
@@ -1085,10 +1085,10 @@ ArgumentStack Creature::SetClassByPosition(ArgumentStack&& args)
     {
         const auto position = Services::Events::ExtractArgument<int32_t>(args);
         const auto classID = Services::Events::ExtractArgument<int32_t>(args);
-        ASSERT(position >= 0);
-        ASSERT(position <= 2);
-        ASSERT(classID >= 0);
-        ASSERT(classID <= 255);
+        ASSERT_OR_THROW(position >= 0);
+        ASSERT_OR_THROW(position <= 2);
+        ASSERT_OR_THROW(classID >= 0);
+        ASSERT_OR_THROW(classID <= 255);
 
         pCreature->m_pStats->SetClass(static_cast<uint8_t>(position), static_cast<uint8_t>(classID));
     }
@@ -1102,10 +1102,10 @@ ArgumentStack Creature::SetLevelByPosition(ArgumentStack&& args)
     {
         const auto position = Services::Events::ExtractArgument<int32_t>(args);
         const auto level = Services::Events::ExtractArgument<int32_t>(args);
-        ASSERT(position >= 0);
-        ASSERT(position <= 2);
-        ASSERT(level >= 0);
-        ASSERT(level <= 60);
+        ASSERT_OR_THROW(position >= 0);
+        ASSERT_OR_THROW(position <= 2);
+        ASSERT_OR_THROW(level >= 0);
+        ASSERT_OR_THROW(level <= 60);
 
         pCreature->m_pStats->SetClassLevel(static_cast<uint8_t>(position), static_cast<uint8_t>(level));
     }
@@ -1118,8 +1118,8 @@ ArgumentStack Creature::SetBaseAttackBonus(ArgumentStack&& args)
     if (auto *pCreature = creature(args))
     {
         const auto bab = Services::Events::ExtractArgument<int32_t>(args);
-        ASSERT(bab >= 0);
-        ASSERT(bab <= 254);
+        ASSERT_OR_THROW(bab >= 0);
+        ASSERT_OR_THROW(bab <= 254);
 
         pCreature->m_pStats->m_nBaseAttackBonus = static_cast<uint8_t>(bab);
     }
@@ -1129,17 +1129,17 @@ ArgumentStack Creature::SetBaseAttackBonus(ArgumentStack&& args)
 ArgumentStack Creature::GetAttacksPerRound(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
         const auto bBaseAPR = Services::Events::ExtractArgument<int32_t>(args);
 
         if (bBaseAPR || pCreature->m_pStats->m_nOverrideBaseAttackBonus == 0)
-            retval = pCreature->m_pStats->GetAttacksPerRound();
+            retVal = pCreature->m_pStats->GetAttacksPerRound();
         else
-            retval = pCreature->m_pStats->m_nOverrideBaseAttackBonus;
+            retVal = pCreature->m_pStats->m_nOverrideBaseAttackBonus;
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -1220,12 +1220,12 @@ ArgumentStack Creature::SetSize(ArgumentStack&& args)
 ArgumentStack Creature::GetSkillPointsRemaining(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
-        retval = pCreature->m_pStats->m_nSkillPointsRemaining;
+        retVal = pCreature->m_pStats->m_nSkillPointsRemaining;
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -1235,7 +1235,7 @@ ArgumentStack Creature::SetSkillPointsRemaining(ArgumentStack&& args)
     if (auto *pCreature = creature(args))
     {
         const auto points = Services::Events::ExtractArgument<int32_t>(args);
-        ASSERT(points >= 0); ASSERT(points <= 65535);
+        ASSERT_OR_THROW(points >= 0); ASSERT_OR_THROW(points <= 65535);
 
         pCreature->m_pStats->m_nSkillPointsRemaining = static_cast<uint16_t>(points);
     }
@@ -1247,7 +1247,7 @@ ArgumentStack Creature::SetRacialType(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto race = Services::Events::ExtractArgument<int32_t>(args); ASSERT(race <= 65535);
+        const auto race = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(race <= 65535);
 
         pCreature->m_pStats->m_nRace = static_cast<uint16_t>(race);
     }
@@ -1263,7 +1263,7 @@ ArgumentStack Creature::GetMovementType(ArgumentStack&& args)
     const int MOVEMENT_TYPE_WALK_BACKWARDS  = 4;
 
     ArgumentStack stack;
-    int retval = MOVEMENT_TYPE_STATIONARY;
+    int retVal = MOVEMENT_TYPE_STATIONARY;
     if (auto *pCreature = creature(args))
     {
 
@@ -1272,23 +1272,23 @@ ArgumentStack Creature::GetMovementType(ArgumentStack&& args)
             case 2:  // walk
             case 84: // walk forward left
             case 85: // walk forward right
-                retval = MOVEMENT_TYPE_WALK;
+                retVal = MOVEMENT_TYPE_WALK;
                 break;
             case 3:  // walk backwards
-                retval = MOVEMENT_TYPE_WALK_BACKWARDS;
+                retVal = MOVEMENT_TYPE_WALK_BACKWARDS;
                 break;
             case 4:  // run
             case 86: // run forward left
             case 87: // run forward right
-                retval = MOVEMENT_TYPE_RUN;
+                retVal = MOVEMENT_TYPE_RUN;
                 break;
             case 78: // walk left
             case 79: // walk right
-                retval = MOVEMENT_TYPE_SIDESTEP;
+                retVal = MOVEMENT_TYPE_SIDESTEP;
                 break;
         }
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -1345,7 +1345,7 @@ ArgumentStack Creature::SetCorpseDecayTime(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto nDecayTime = Services::Events::ExtractArgument<int32_t>(args); ASSERT(nDecayTime >= 0);
+        const auto nDecayTime = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(nDecayTime >= 0);
         pCreature->m_nDecayTime = nDecayTime;
     }
     return stack;
@@ -1355,27 +1355,27 @@ ArgumentStack Creature::GetBaseSavingThrow(ArgumentStack&& args)
 {
     // NOTE: The misc fields are used for creature save override, and will mess with ELC.
     ArgumentStack stack;
-    int32_t retval = -1;
+    int32_t retVal = -1;
     if (auto *pCreature = creature(args))
     {
         const auto which = Services::Events::ExtractArgument<int32_t>(args);
         switch (which)
         {
             case Constants::SAVING_THROW_REFLEX:
-                retval = pCreature->m_pStats->m_nReflexSavingThrowMisc + pCreature->m_pStats->GetBaseReflexSavingThrow();
+                retVal = pCreature->m_pStats->m_nReflexSavingThrowMisc + pCreature->m_pStats->GetBaseReflexSavingThrow();
                 break;
             case Constants::SAVING_THROW_FORT:
-                retval = pCreature->m_pStats->m_nFortSavingThrowMisc + pCreature->m_pStats->GetBaseFortSavingThrow();
+                retVal = pCreature->m_pStats->m_nFortSavingThrowMisc + pCreature->m_pStats->GetBaseFortSavingThrow();
                 break;
             case Constants::SAVING_THROW_WILL:
-                retval = pCreature->m_pStats->m_nWillSavingThrowMisc + pCreature->m_pStats->GetBaseWillSavingThrow();
+                retVal = pCreature->m_pStats->m_nWillSavingThrowMisc + pCreature->m_pStats->GetBaseWillSavingThrow();
                 break;
             default:
                 LOG_WARNING("GetBaseSavingThrow() called for bad save constant %d", which);
                 break;
         }
     }
-    Services::Events::InsertArgument(stack, retval);
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 
@@ -1385,7 +1385,7 @@ ArgumentStack Creature::SetBaseSavingThrow(ArgumentStack&& args)
     if (auto *pCreature = creature(args))
     {
         const auto which = Services::Events::ExtractArgument<int32_t>(args);
-        const auto value = Services::Events::ExtractArgument<int32_t>(args); ASSERT(value >= -128 && value <= 127);
+        const auto value = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(value >= -128 && value <= 127);
         int8_t base;
         switch (which)
         {
@@ -1424,7 +1424,7 @@ ArgumentStack Creature::LevelUp(ArgumentStack&& args)
                 if (bSkipLevelUpValidation)
                 {
                     // NPCs can have at most 60 levels
-                    ASSERT(!pThis->m_bIsPC);
+                    ASSERT_OR_THROW(!pThis->m_bIsPC);
                     return pThis->GetLevel(false) < 60;
                 }
                 return pCanLevelUp_hook->CallOriginal<int32_t>(pThis);
@@ -1436,7 +1436,7 @@ ArgumentStack Creature::LevelUp(ArgumentStack&& args)
             {
                 if (bSkipLevelUpValidation)
                 {
-                    ASSERT(!pThis->m_bIsPC);
+                    ASSERT_OR_THROW(!pThis->m_bIsPC);
                     pThis->LevelUp(pLevelStats, nDomain1, nDomain2, nSchool, true);
                     pThis->UpdateCombatInformation();
                     return 0;
@@ -1530,7 +1530,7 @@ ArgumentStack Creature::SetChallengeRating(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto fCR = Services::Events::ExtractArgument<float>(args); ASSERT(fCR >= 0.0);
+        const auto fCR = Services::Events::ExtractArgument<float>(args); ASSERT_OR_THROW(fCR >= 0.0);
         pCreature->m_pStats->m_fChallengeRating = fCR;
     }
     return stack;
@@ -1568,7 +1568,7 @@ ArgumentStack Creature::GetFeatRemainingUses(ArgumentStack&& args)
     int32_t retval = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT(feat <= 65535); /* word */
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(feat <= 65535); /* word */
         retval = pCreature->m_pStats->GetFeatRemainingUses(feat);
     }
     Services::Events::InsertArgument(stack, retval);
@@ -1581,7 +1581,7 @@ ArgumentStack Creature::GetFeatTotalUses(ArgumentStack&& args)
     int32_t retval = -1;
     if (auto *pCreature = creature(args))
     {
-        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT(feat <= 65535); /* word */
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(feat <= 65535); /* word */
         retval = pCreature->m_pStats->GetFeatTotalUses(feat);
     }
     Services::Events::InsertArgument(stack, retval);
@@ -1593,8 +1593,8 @@ ArgumentStack Creature::SetFeatRemainingUses(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pCreature = creature(args))
     {
-        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT(feat <= 65535); /* word */
-        const auto uses = Services::Events::ExtractArgument<int32_t>(args); ASSERT(uses <= 255); /* byte */
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(feat <= 65535); /* word */
+        const auto uses = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(uses <= 255); /* byte */
 
         pCreature->m_pStats->SetFeatRemainingUses(feat, uses);
     }

--- a/Plugins/Encounter/Encounter.cpp
+++ b/Plugins/Encounter/Encounter.cpp
@@ -128,16 +128,17 @@ ArgumentStack Encounter::SetEncounterCreatureByIndex(ArgumentStack&& args)
     if (auto *pEncounter = encounter(args))
     {
         const auto index = Services::Events::ExtractArgument<int32_t>(args);
-        const auto resref = Services::Events::ExtractArgument<std::string>(args);
+        const auto resRef = Services::Events::ExtractArgument<std::string>(args);
         auto cr = Services::Events::ExtractArgument<float>(args);
         auto unique = Services::Events::ExtractArgument<int32_t>(args);
 
-        if (cr < 0.0) cr = 0.0;
+        ASSERT_OR_THROW(cr >= 0.0);
+
         unique = !!unique;
         
         if (index < pEncounter->m_nNumEncounterListEntries)
         {
-            pEncounter->m_pEncounterList[index].m_cCreatureResRef = resref.c_str();
+            pEncounter->m_pEncounterList[index].m_cCreatureResRef = resRef.c_str();
             pEncounter->m_pEncounterList[index].m_fCR = cr;
             pEncounter->m_pEncounterList[index].m_fCreaturePoints = pEncounter->CalculatePointsFromCR(cr);
             pEncounter->m_pEncounterList[index].m_bUnique = unique; 
@@ -170,8 +171,8 @@ ArgumentStack Encounter::SetFactionId(ArgumentStack&& args)
     {
         auto factionId = Services::Events::ExtractArgument<int32_t>(args);
 
-        if (factionId < 0) factionId = 0;
-        
+        ASSERT_OR_THROW(factionId >= 0);
+
         pEncounter->m_nFactionId = factionId;
     }
 
@@ -232,7 +233,7 @@ ArgumentStack Encounter::SetResetTime(ArgumentStack&& args)
     {
         auto resetTime = Services::Events::ExtractArgument<int32_t>(args);
 
-        if (resetTime < 0) resetTime = 0;
+        ASSERT_OR_THROW(resetTime >= 0);
         
         pEncounter->m_nResetTime = resetTime;
     }

--- a/Plugins/Feedback/Feedback.cpp
+++ b/Plugins/Feedback/Feedback.cpp
@@ -151,6 +151,8 @@ ArgumentStack Feedback::SetMessageHidden(ArgumentStack&& args)
     const auto messageId = Services::Events::ExtractArgument<int32_t>(args);
     const auto state = Services::Events::ExtractArgument<int32_t>(args);
 
+    ASSERT_OR_THROW(messageId >= 0);
+
     if (playerId == Constants::OBJECT_INVALID)
     {
         std::set<int32_t>* hiddenMessageSet = messageType ? &plugin.m_GlobalHiddenCombatLogMessageSet : &plugin.m_GlobalHiddenFeedbackMessageSet;

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -300,7 +300,7 @@ ArgumentStack Object::SetAppearance(ArgumentStack&& args)
     ArgumentStack stack;
     if (auto *pObject = object(args))
     {
-        const auto app = Services::Events::ExtractArgument<int32_t>(args);  ASSERT(app <= 65535);
+        const auto app = Services::Events::ExtractArgument<int32_t>(args);  ASSERT_OR_THROW(app <= 65535);
         if(pObject->m_nObjectType == Constants::OBJECT_TYPE_PLACEABLE)
         {
             static_cast<CNWSPlaceable*>(pObject)->m_nAppearance=app;

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -281,7 +281,7 @@ ArgumentStack Player::GetQuickBarSlot(ArgumentStack&& args)
     if (auto *pPlayer = player(args))
     {
         auto slot = Services::Events::ExtractArgument<int32_t>(args);
-        ASSERT(slot < 36);
+        ASSERT_OR_THROW(slot < 36);
 
         CNWSCreature *pCreature = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(pPlayer->m_oidNWSObject);
         if (!pCreature->m_pQuickbarButton)
@@ -312,7 +312,7 @@ ArgumentStack Player::SetQuickBarSlot(ArgumentStack&& args)
     if (auto *pPlayer = player(args))
     {
         auto slot = Services::Events::ExtractArgument<int32_t>(args);
-        ASSERT(slot < 36);
+        ASSERT_OR_THROW(slot < 36);
 
         CNWSCreature *pCreature = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(pPlayer->m_oidNWSObject);
         if (!pCreature->m_pQuickbarButton)
@@ -354,7 +354,7 @@ ArgumentStack Player::ShowVisualEffect(ArgumentStack&& args)
     if (auto *pPlayer = player(args))
     {
         Vector pos;
-        auto effectId = Services::Events::ExtractArgument<int32_t>(args); ASSERT(effectId >= 0); ASSERT(effectId <= 0xFFFF);
+        auto effectId = Services::Events::ExtractArgument<int32_t>(args); ASSERT_OR_THROW(effectId >= 0); ASSERT_OR_THROW(effectId <= 0xFFFF);
         pos.z = Services::Events::ExtractArgument<float>(args);
         pos.y = Services::Events::ExtractArgument<float>(args);
         pos.x = Services::Events::ExtractArgument<float>(args);
@@ -378,8 +378,8 @@ ArgumentStack Player::ChangeBackgroundMusic(ArgumentStack&& args)
         auto day = Services::Events::ExtractArgument<int32_t>(args);
 
         auto track = Services::Events::ExtractArgument<int32_t>(args);
-        ASSERT(track >= 0);
-        ASSERT(track <= 0xFFFF);
+        ASSERT_OR_THROW(track >= 0);
+        ASSERT_OR_THROW(track <= 0xFFFF);
 
         auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
         if (pMessage)
@@ -416,8 +416,8 @@ ArgumentStack Player::ChangeBattleMusic(ArgumentStack&& args)
         const auto oidPlayer = pPlayer->m_nPlayerID;
 
         auto track = Services::Events::ExtractArgument<int32_t>(args);
-        ASSERT(track >= 0);
-        ASSERT(track <= 0xFFFF);
+        ASSERT_OR_THROW(track >= 0);
+        ASSERT_OR_THROW(track <= 0xFFFF);
 
         auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
         if (pMessage)

--- a/Plugins/Util/Util.cpp
+++ b/Plugins/Util/Util.cpp
@@ -107,26 +107,25 @@ ArgumentStack Util::Hash(ArgumentStack&& args)
 ArgumentStack Util::GetCustomToken(ArgumentStack&& args)
 {
     ArgumentStack stack;
-    std::string retVal = "";
+    std::string retVal;
 
     const auto tokenNumber = Services::Events::ExtractArgument<int32_t>(args);
 
-    if (tokenNumber >= 0)
-    {
-        auto *pTlk = API::Globals::TlkTable();
-        auto *pTokens = pTlk->m_pTokensCustom;
-        int numTokens = pTlk->m_nTokensCustom;
+    ASSERT_OR_THROW(tokenNumber >= 0);
 
-        CTlkTableTokenCustom token;
-        token.m_nNumber = tokenNumber;
-        
-        auto *foundToken = (CTlkTableTokenCustom*)std::bsearch(&token, pTokens, numTokens, sizeof(token),
-            +[](const void *a, const void *b){ return (int32_t)((CTlkTableTokenCustom*)a)->m_nNumber - (int32_t)((CTlkTableTokenCustom*)b)->m_nNumber; });
-        
-        if(foundToken)
-        { 
-            retVal = foundToken->m_sValue.CStr();
-        }
+    auto *pTlk = API::Globals::TlkTable();
+    auto *pTokens = pTlk->m_pTokensCustom;
+    int numTokens = pTlk->m_nTokensCustom;
+
+    CTlkTableTokenCustom token;
+    token.m_nNumber = tokenNumber;
+
+    auto *foundToken = (CTlkTableTokenCustom*)std::bsearch(&token, pTokens, numTokens, sizeof(token),
+        +[](const void *a, const void *b){ return (int32_t)((CTlkTableTokenCustom*)a)->m_nNumber - (int32_t)((CTlkTableTokenCustom*)b)->m_nNumber; });
+
+    if(foundToken)
+    {
+        retVal = foundToken->m_sValue.CStr();
     }
 
     Services::Events::InsertArgument(stack, retVal);


### PR DESCRIPTION
Fixes #320

A nicer `ASSERT()` that will just jump out of function handlers with a runtime error exception.

Looks like this in the log:
```E [22:31:48] [NWNXLib] [{File}.cpp:{Line}] Plugin '{Plugin}' failed event '{Function Handler}'. Error: ASSERTION FAILURE: ({Condition}) in NWScript: {Script File}```