### PR TITLE
Administration: add {Get/Set}PlayOption()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The following plugins were added:
 - **Rename**: Adds functions to facilitate renaming, overriding and customization of player names
 - **Visibility**: Allows the visibility of objects to be overridden globally or per player
 ##### New NWScript Functions
+- Administration: GetPlayOption()
+- Administration: SetPlayOption()
 - Area: GetNumberOfPlayersInArea()
 - Area: GetLastEntered()
 - Area: GetLastLeft()

--- a/Plugins/Administration/Administration.cpp
+++ b/Plugins/Administration/Administration.cpp
@@ -72,6 +72,8 @@ Administration::Administration(const Plugin::CreateParams& params)
     REGISTER("GET_BANNED_LIST",               OnGetBannedList);
     REGISTER("SET_MODULE_NAME",               OnSetModuleName);
     REGISTER("SET_SERVER_NAME",               OnSetServerName);
+    REGISTER("GET_PLAY_OPTION",               OnGetPlayOption);
+    REGISTER("SET_PLAY_OPTION",               OnSetPlayOption);
 
 #undef REGISTER
 }
@@ -261,6 +263,264 @@ Events::ArgumentStack Administration::OnSetServerName(Events::ArgumentStack&& ar
     const auto newName = Events::ExtractArgument<std::string>(args);
     LOG_NOTICE("Set server name to '%s'.", newName.c_str());
     Globals::AppManager()->m_pServerExoApp->GetNetLayer()->SetSessionName(CExoString(newName.c_str()));
+    return Events::ArgumentStack();
+}
+
+Events::ArgumentStack Administration::OnGetPlayOption(Events::ArgumentStack&& args)
+{
+    Events::ArgumentStack stack;
+    int32_t retVal = -1;
+
+    const auto option = Events::ExtractArgument<int32_t>(args);
+
+    ASSERT_OR_THROW(option >= 0); ASSERT_OR_THROW(option <= 26);
+
+    switch (option)
+    {
+        case 0: // NWNX_ADMINISTRATION_OPTION_ALL_KILLABLE
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bAllKillable;
+            break;
+
+        case 1: // NWNX_ADMINISTRATION_OPTION_NON_PARTY_KILLABLE
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bNonPartyKillable;
+            break;
+
+        case 2: // NWNX_ADMINISTRATION_OPTION_REQUIRE_RESURRECTION
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bRequireResurrection;
+            break;
+
+        case 3: // NWNX_ADMINISTRATION_OPTION_LOSE_STOLEN_ITEMS
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bLoseStolenItems;
+            break;
+
+        case 4: // NWNX_ADMINISTRATION_OPTION_LOSE_ITEMS
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bLoseItems;
+            break;
+
+        case 5: // NWNX_ADMINISTRATION_OPTION_LOSE_EXP
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bLoseExp;
+            break;
+
+        case 6: // NWNX_ADMINISTRATION_OPTION_LOSE_GOLD
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bLoseGold;
+            break;
+
+        case 7: // NWNX_ADMINISTRATION_OPTION_LOSE_GOLD_NUM
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.nLoseGoldNum;
+            break;
+
+        case 8: // NWNX_ADMINISTRATION_OPTION_LOSE_EXP_NUM
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.nLoseExpNum;
+            break;
+
+        case 9: // NWNX_ADMINISTRATION_OPTION_LOSE_ITEMS_NUM
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.nLoseItemsNum;
+            break;
+
+        case 10: // NWNX_ADMINISTRATION_OPTION_PVP_SETTING
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.nPVPSetting;
+            break;
+
+        case 11: // NWNX_ADMINISTRATION_OPTION_PAUSE_AND_PLAY
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bPauseAndPlay;
+            break;
+
+        case 12: // NWNX_ADMINISTRATION_OPTION_ONE_PARTY_ONLY
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bOnePartyOnly;
+            break;
+
+        case 13: // NWNX_ADMINISTRATION_OPTION_ENFORCE_LEGAL_CHARACTERS
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bEnforceLegalCharacters;
+            break;
+
+        case 14: // NWNX_ADMINISTRATION_OPTION_ITEM_LEVEL_RESTRICTIONS
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bItemLevelRestrictions;
+            break;
+
+        case 15: // NWNX_ADMINISTRATION_OPTION_CDKEY_BANLIST_ALLOWLIST
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bCDKeyBanListAllowList;
+            break;
+
+        case 16: // NWNX_ADMINISTRATION_OPTION_DISALLOW_SHOUTING
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bDisallowShouting;
+            break;
+
+        case 17: // NWNX_ADMINISTRATION_OPTION_SHOW_DM_JOIN_MESSAGE
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bShowDMJoinMessage;
+            break;
+
+        case 18: // NWNX_ADMINISTRATION_OPTION_BACKUP_SAVED_CHARACTERS
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bBackupSavedCharacters;
+            break;
+
+        case 19: // NWNX_ADMINISTRATION_OPTION_AUTO_FAIL_SAVE_ON_1
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bAutoFailSaveOn1;
+            break;
+
+        case 20: // NWNX_ADMINISTRATION_OPTION_VALIDATE_SPELLS
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bValidateSpells;
+            break;
+
+        case 21: // NWNX_ADMINISTRATION_OPTION_EXAMINE_EFFECTS
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bExamineEffects;
+            break;
+
+        case 22: // NWNX_ADMINISTRATION_OPTION_EXAMINE_CHALLENGE_RATING
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bExamineChallengeRating;
+            break;
+
+        case 23: // NWNX_ADMINISTRATION_OPTION_USE_MAX_HITPOINTS
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bUseMaxHitPoints;
+            break;
+
+        case 24: // NWNX_ADMINISTRATION_OPTION_RESTORE_SPELLS_USES
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bRestoreSpellsUses;
+            break;
+
+        case 25: // NWNX_ADMINISTRATION_OPTION_RESET_ENCOUNTER_SPAWN_POOL
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bResetEncounterSpawnPool;
+            break;
+
+        case 26: // NWNX_ADMINISTRATION_OPTION_HIDE_HITPOINTS_GAINED
+            retVal = Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bHideHitPointsGained;
+            break;
+
+        default:
+            LOG_NOTICE("Calling NWNX_Administration_GetPlayOption with invalid option: %d", option);
+            break;
+    }
+
+    Events::InsertArgument(stack, retVal);
+
+    return stack;
+}
+
+Events::ArgumentStack Administration::OnSetPlayOption(Events::ArgumentStack&& args)
+{
+    const auto option = Events::ExtractArgument<int32_t>(args);
+    const auto value = Events::ExtractArgument<int32_t>(args);
+
+    ASSERT_OR_THROW(option >= 0); ASSERT_OR_THROW(option <= 26);
+    ASSERT_OR_THROW(value >= 0);
+
+    switch (option)
+    {
+        case 0: // NWNX_ADMINISTRATION_OPTION_ALL_KILLABLE
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bAllKillable = !!value;
+            break;
+
+        case 1: // NWNX_ADMINISTRATION_OPTION_NON_PARTY_KILLABLE
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bNonPartyKillable = !!value;
+            break;
+
+        case 2: // NWNX_ADMINISTRATION_OPTION_REQUIRE_RESURRECTION
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bRequireResurrection = !!value;
+            break;
+
+        case 3: // NWNX_ADMINISTRATION_OPTION_LOSE_STOLEN_ITEMS
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bLoseStolenItems = !!value;
+            break;
+
+        case 4: // NWNX_ADMINISTRATION_OPTION_LOSE_ITEMS
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bLoseItems = !!value;
+            break;
+
+        case 5: // NWNX_ADMINISTRATION_OPTION_LOSE_EXP
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bLoseExp = !!value;
+            break;
+
+        case 6: // NWNX_ADMINISTRATION_OPTION_LOSE_GOLD
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bLoseGold = !!value;
+            break;
+
+        case 7: // NWNX_ADMINISTRATION_OPTION_LOSE_GOLD_NUM
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.nLoseGoldNum = value;
+            break;
+
+        case 8: // NWNX_ADMINISTRATION_OPTION_LOSE_EXP_NUM
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.nLoseExpNum = value;
+            break;
+
+        case 9: // NWNX_ADMINISTRATION_OPTION_LOSE_ITEMS_NUM
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.nLoseItemsNum = value;
+            break;
+
+        case 10: // NWNX_ADMINISTRATION_OPTION_PVP_SETTING
+        {
+            ASSERT_OR_THROW(value <= 2);
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.nPVPSetting = value;
+            break;
+        }
+
+        case 11: // NWNX_ADMINISTRATION_OPTION_PAUSE_AND_PLAY
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bPauseAndPlay = !!value;
+            break;
+
+        case 12: // NWNX_ADMINISTRATION_OPTION_ONE_PARTY_ONLY
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bOnePartyOnly = !!value;
+            break;
+
+        case 13: // NWNX_ADMINISTRATION_OPTION_ENFORCE_LEGAL_CHARACTERS
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bEnforceLegalCharacters = !!value;
+            break;
+
+        case 14: // NWNX_ADMINISTRATION_OPTION_ITEM_LEVEL_RESTRICTIONS
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bItemLevelRestrictions = !!value;
+            break;
+
+        case 15: // NWNX_ADMINISTRATION_OPTION_CDKEY_BANLIST_ALLOWLIST
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bCDKeyBanListAllowList = !!value;
+            break;
+
+        case 16: // NWNX_ADMINISTRATION_OPTION_DISALLOW_SHOUTING
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bDisallowShouting = !!value;
+            break;
+
+        case 17: // NWNX_ADMINISTRATION_OPTION_SHOW_DM_JOIN_MESSAGE
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bShowDMJoinMessage = !!value;
+            break;
+
+        case 18: // NWNX_ADMINISTRATION_OPTION_BACKUP_SAVED_CHARACTERS
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bBackupSavedCharacters = !!value;
+            break;
+
+        case 19: // NWNX_ADMINISTRATION_OPTION_AUTO_FAIL_SAVE_ON_1
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bAutoFailSaveOn1 = !!value;
+            break;
+
+        case 20: // NWNX_ADMINISTRATION_OPTION_VALIDATE_SPELLS
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bValidateSpells = !!value;
+            break;
+
+        case 21: // NWNX_ADMINISTRATION_OPTION_EXAMINE_EFFECTS
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bExamineEffects = !!value;
+            break;
+
+        case 22: // NWNX_ADMINISTRATION_OPTION_EXAMINE_CHALLENGE_RATING
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bExamineChallengeRating = !!value;
+            break;
+
+        case 23: // NWNX_ADMINISTRATION_OPTION_USE_MAX_HITPOINTS
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bUseMaxHitPoints = !!value;
+            break;
+
+        case 24: // NWNX_ADMINISTRATION_OPTION_RESTORE_SPELLS_USES
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bRestoreSpellsUses = !!value;
+            break;
+
+        case 25: // NWNX_ADMINISTRATION_OPTION_RESET_ENCOUNTER_SPAWN_POOL
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bResetEncounterSpawnPool = !!value;
+            break;
+
+        case 26: // NWNX_ADMINISTRATION_OPTION_HIDE_HITPOINTS_GAINED
+            Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_PlayOptions.bHideHitPointsGained = !!value;
+            break;
+
+        default:
+            LOG_NOTICE("Calling NWNX_Administration_SetPlayOption with invalid option: %d", option);
+            break;
+    }
+
     return Events::ArgumentStack();
 }
 

--- a/Plugins/Administration/Administration.hpp
+++ b/Plugins/Administration/Administration.hpp
@@ -27,6 +27,8 @@ public:
     NWNXLib::Services::Events::ArgumentStack OnGetBannedList(NWNXLib::Services::Events::ArgumentStack&& args);
     NWNXLib::Services::Events::ArgumentStack OnSetModuleName(NWNXLib::Services::Events::ArgumentStack&& args);
     NWNXLib::Services::Events::ArgumentStack OnSetServerName(NWNXLib::Services::Events::ArgumentStack&& args);
+    NWNXLib::Services::Events::ArgumentStack OnGetPlayOption(NWNXLib::Services::Events::ArgumentStack&& args);
+    NWNXLib::Services::Events::ArgumentStack OnSetPlayOption(NWNXLib::Services::Events::ArgumentStack&& args);
 
 };
 

--- a/Plugins/Administration/NWScript/nwnx_admin.nss
+++ b/Plugins/Administration/NWScript/nwnx_admin.nss
@@ -1,5 +1,33 @@
 #include "nwnx"
 
+const int NWNX_ADMINISTRATION_OPTION_ALL_KILLABLE               = 0;  // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_NON_PARTY_KILLABLE         = 1;  // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_REQUIRE_RESURRECTION       = 2;  // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_LOSE_STOLEN_ITEMS          = 3;  // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_LOSE_ITEMS                 = 4;  // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_LOSE_EXP                   = 5;  // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_LOSE_GOLD                  = 6;  // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_LOSE_GOLD_NUM              = 7;
+const int NWNX_ADMINISTRATION_OPTION_LOSE_EXP_NUM               = 8;
+const int NWNX_ADMINISTRATION_OPTION_LOSE_ITEMS_NUM             = 9;
+const int NWNX_ADMINISTRATION_OPTION_PVP_SETTING                = 10; // 0 = No PVP, 1 = Party PVP, 2 = Full PVP
+const int NWNX_ADMINISTRATION_OPTION_PAUSE_AND_PLAY             = 11; // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_ONE_PARTY_ONLY             = 12; // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_ENFORCE_LEGAL_CHARACTERS   = 13; // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_ITEM_LEVEL_RESTRICTIONS    = 14; // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_CDKEY_BANLIST_ALLOWLIST    = 15; // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_DISALLOW_SHOUTING          = 16; // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_SHOW_DM_JOIN_MESSAGE       = 17; // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_BACKUP_SAVED_CHARACTERS    = 18; // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_AUTO_FAIL_SAVE_ON_1        = 19; // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_VALIDATE_SPELLS            = 20; // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_EXAMINE_EFFECTS            = 21; // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_EXAMINE_CHALLENGE_RATING   = 22; // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_USE_MAX_HITPOINTS          = 23; // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_RESTORE_SPELLS_USES        = 24; // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_RESET_ENCOUNTER_SPAWN_POOL = 25; // TRUE/FALSE
+const int NWNX_ADMINISTRATION_OPTION_HIDE_HITPOINTS_GAINED      = 26; // TRUE/FALSE
+
 // Gets, sets, and clears the current player password.
 // Note that this password can be an empty string.
 string NWNX_Administration_GetPlayerPassword();
@@ -41,6 +69,11 @@ string NWNX_Administration_GetBannedList();
 void NWNX_Administration_SetModuleName(string name);
 // Set the server's name as shown to the serverlist
 void NWNX_Administration_SetServerName(string name);
+
+// Get a NWNX_ADMINISTRATION_OPTION_* value
+int NWNX_Administration_GetPlayOption(int option)
+// Set a NWNX_ADMINISTRATION_OPTION_* to value
+void NWNX_Administration_SetPlayOption(int option, int value)
 
 
 string NWNX_Administration_GetPlayerPassword()
@@ -137,4 +170,19 @@ void NWNX_Administration_SetServerName(string name)
 {
     NWNX_PushArgumentString("NWNX_Administration", "SET_SERVER_NAME", name);
     NWNX_CallFunction("NWNX_Administration", "SET_SERVER_NAME");
+}
+
+int NWNX_Administration_GetPlayOption(int option)
+{
+    NWNX_PushArgumentInt("NWNX_Administration", "GET_PLAY_OPTION", option);
+    NWNX_CallFunction("NWNX_Administration", "GET_PLAY_OPTION");
+
+    return NWNX_GetReturnValueInt("NWNX_Administration", "GET_PLAY_OPTION");
+}
+
+void NWNX_Administration_SetPlayOption(int option, int value)
+{
+    NWNX_PushArgumentInt("NWNX_Administration", "SET_PLAY_OPTION", value);
+    NWNX_PushArgumentInt("NWNX_Administration", "SET_PLAY_OPTION", option);
+    NWNX_CallFunction("NWNX_Administration", "SET_PLAY_OPTION");
 }

--- a/Plugins/Administration/NWScript/nwnx_admin_t.nss
+++ b/Plugins/Administration/NWScript/nwnx_admin_t.nss
@@ -23,5 +23,8 @@ void main()
     NWNX_Administration_SetDMPassword(sString);
     report("{Set/Get}DMPassword", NWNX_Administration_GetDMPassword() == sString);
 
+    NWNX_Administration_SetPlayOption(NWNX_ADMINISTRATION_OPTION_EXAMINE_EFFECTS, TRUE);
+    report("{Set/Get}PlayOption", NWNX_Administration_GetPlayOption(NWNX_ADMINISTRATION_OPTION_EXAMINE_EFFECTS));
+
     WriteTimestampedLogEntry("NWNX_Administration unit test end.");
 }


### PR DESCRIPTION
Fixes #325 

Lets you override a bunch of server options like `Examine Effects On Creatures` or `Enforce Legal Characters`