### PR TITLE
events: Add client connect events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recompile all your scripts. 
+NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recompile all your scripts.
 
 ### Added
 - Added support to skip building certain plugins by setting an environment variable, for example: `NWNX_SKIP_PLUGINS="JVM;Lua;Mono;Ruby;SpellChecker"`
@@ -13,11 +13,12 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Core: Allow changing default plugin state from 'load all' to 'skip all' with the following environment variable: `NWNX_CORE_SKIP_ALL=y`. Use `NWNX_PLUGIN_SKIP=n` to enable specific plugins in this case.
 - Core: Allow passing engine structures to nwnx (Effect/Itemproperty)
 - Events: New events: SkillEvents, MapEvents
-- Events: The following events are now skippable: FeatEvents, ItemEvents, HealersKitEvents, CombatModeEvents, PartyEvents, SkillEvents, MapEvents, PolymorphEvents, DMActionEvents
+- Events: The following events are now skippable: FeatEvents, ItemEvents, HealersKitEvents, CombatModeEvents, PartyEvents, SkillEvents, MapEvents, PolymorphEvents, DMActionEvents, ClientConnectEvents
 - Events: You can now get the current event name with a nwscript function
 - Events: Added On{Listen/Spot}Detection events to StealthEvents
 - Events: Added On{Un}Polymorph events as PolymorphEvents
 - Events: Added SpawnObject, GiveItem and GiveAlignment events to DMActionEvents
+- Events: OnClientConnect events that fire before the player sees the server vault.
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite
 - Tweaks: DisableQuickSave

--- a/Plugins/Events/Events/ClientEvents.cpp
+++ b/Plugins/Events/Events/ClientEvents.cpp
@@ -4,6 +4,9 @@
 #include "API/CNWSPlayer.hpp"
 #include "API/Constants.hpp"
 #include "API/CServerExoApp.hpp"
+#include "API/CNetLayer.hpp"
+#include "API/CNetLayerPlayerInfo.hpp"
+#include "API/CNWSModule.hpp"
 #include "API/Functions.hpp"
 #include "API/Globals.hpp"
 #include "API/Version.hpp"
@@ -16,10 +19,16 @@ using namespace NWNXLib;
 using namespace NWNXLib::API;
 using namespace NWNXLib::Services;
 
+static NWNXLib::Hooking::FunctionHook* m_SendServerToPlayerCharListHook;
+
 ClientEvents::ClientEvents(ViewPtr<HooksProxy> hooker)
 {
     hooker->RequestSharedHook<API::Functions::CServerExoAppInternal__RemovePCFromWorld, void,
         CServerExoAppInternal*, CNWSPlayer*>(&RemovePCFromWorldHook);
+
+    hooker->RequestExclusiveHook<API::Functions::CNWSMessage__SendServerToPlayerCharList, int32_t,
+        CNWSMessage*, CNWSPlayer*>(&SendServerToPlayerCharListHook);
+    m_SendServerToPlayerCharListHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__SendServerToPlayerCharList);
 }
 
 void ClientEvents::RemovePCFromWorldHook(Hooks::CallType type, CServerExoAppInternal*, CNWSPlayer* player)
@@ -37,6 +46,37 @@ void ClientEvents::RemovePCFromWorldHook(Hooks::CallType type, CServerExoAppInte
         Events::SignalEvent("NWNX_ON_CLIENT_DISCONNECT_AFTER", player->m_oidNWSObject);
     }
 
+}
+
+int32_t ClientEvents::SendServerToPlayerCharListHook(CNWSMessage* pThis, CNWSPlayer* pPlayer)
+{
+    int32_t retVal;
+
+    if (!pPlayer)
+        return false;
+
+    auto *pNetLayer = Globals::AppManager()->m_pServerExoApp->GetNetLayer();
+    auto *pPlayerInfo = pNetLayer->GetPlayerInfo(pPlayer->m_nPlayerID);
+
+    std::string reason;
+    auto PushAndSignal = [&](std::string ev) -> bool {
+        Events::PushEventData("PLAYER_NAME", pPlayerInfo->m_sPlayerName.CStr());
+        Events::PushEventData("CDKEY", pPlayerInfo->GetPublicCDKey(0).CStr());
+        Events::PushEventData("IS_DM", std::to_string(pPlayerInfo->m_bGameMasterPrivileges));
+        return Events::SignalEvent(ev, Utils::GetModule()->m_idSelf, &reason);
+    };
+
+    if (PushAndSignal("NWNX_ON_CLIENT_CONNECT_BEFORE"))
+    {
+        retVal = m_SendServerToPlayerCharListHook->CallOriginal<int32_t>(pThis, pPlayer);
+    }
+    else
+    {
+        pNetLayer->DisconnectPlayer(pPlayer->m_nPlayerID, 5838, true, reason.c_str());
+        retVal = false;
+    }
+    PushAndSignal("NWNX_ON_CLIENT_CONNECT_AFTER");
+    return retVal;
 }
 
 }

--- a/Plugins/Events/Events/ClientEvents.hpp
+++ b/Plugins/Events/Events/ClientEvents.hpp
@@ -16,6 +16,7 @@ private:
     static void RemovePCFromWorldHook(NWNXLib::Services::Hooks::CallType type,
         NWNXLib::API::CServerExoAppInternal*,
         NWNXLib::API::CNWSPlayer*);
+    static int32_t SendServerToPlayerCharListHook(NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*);
 };
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -133,6 +133,21 @@
     Usage:
         OBJECT_SELF = The player disconnecting from the server
 ////////////////////////////////////////////////////////////////////////////////
+    NWNX_ON_CLIENT_CONNECT_BEFORE
+    NWNX_ON_CLIENT_CONNECT_AFTER
+
+    Skipping the _BEFORE event will cause the client's connection to be denied.
+    You can optionally pass a reason for this in the event result.
+
+    Usage:
+        OBJECT_SELF = The module
+
+    Event data:
+        Variable Name           Type        Notes
+        PLAYER_NAME             string      Player name of the connecting client
+        CDKEY                   string      Public cdkey of the connecting client
+        IS_DM                   int         Whether the client is connect as DM (1/0)
+////////////////////////////////////////////////////////////////////////////////
     NWNX_ON_START_COMBAT_ROUND_BEFORE
     NWNX_ON_START_COMBAT_ROUND_AFTER
 
@@ -361,6 +376,7 @@ string NWNX_Events_GetEventData(string tag);
 // - Listen/Spot Detection events
 // - Polymorph events
 // - DMAction events
+// - Client connect event
 void NWNX_Events_SkipEvent();
 
 // Set the return value of the event.
@@ -369,6 +385,7 @@ void NWNX_Events_SkipEvent();
 // ONLY WORKS WITH THE FOLLOWING EVENTS:
 // - Healer's Kit event
 // - Listen/Spot Detection events -> "1" or "0"
+// - OnClientConnectBefore -> Reason for disconnect if skipped
 void NWNX_Events_SetEventResult(string data);
 
 // Returns the current event name


### PR DESCRIPTION
Resolves #322 . You now get an event when the player connects, and you can drop them before they get into the servervault. You can also provide a nice reason for it.