### PR TITLE
utils: Add GenerateUUID() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recompile all your scripts. 
+NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recompile all your scripts.
 
 ### Added
 - Added support to skip building certain plugins by setting an environment variable, for example: `NWNX_SKIP_PLUGINS="JVM;Lua;Mono;Ruby;SpellChecker"`
@@ -94,6 +94,7 @@ The following plugins were added:
 - Player: SetPlaceableUsable()
 - Player: SetRestDuration()
 - Rename: SetPCNameOverride()
+- Util: GenerateUUID()
 - Util: GetCustomToken()
 - Util: EffectToItemProperty()
 - Util: ItemPropertyToEffect()

--- a/Plugins/Util/NWScript/nwnx_util.nss
+++ b/Plugins/Util/NWScript/nwnx_util.nss
@@ -14,6 +14,8 @@ string NWNX_Util_GetCustomToken(int customTokenNumber);
 itemproperty NWNX_Util_EffectToItemProperty(effect e);
 // Convert an IP type to an effect type
 effect NWNX_Util_ItemPropertyToEffect(itemproperty ip);
+// Generate a v4 UUID.
+string NWNX_Util_GenerateUUID();
 
 
 const string NWNX_Util = "NWNX_Util";
@@ -64,4 +66,11 @@ effect NWNX_Util_ItemPropertyToEffect(itemproperty ip)
     NWNX_PushArgumentItemProperty(NWNX_Util, sFunc, ip);
     NWNX_CallFunction(NWNX_Util, sFunc);
     return NWNX_GetReturnValueEffect(NWNX_Util, sFunc);
+}
+
+string NWNX_Util_GenerateUUID()
+{
+    string sFunc = "GenerateUUID";
+    NWNX_CallFunction(NWNX_Util, sFunc);
+    return NWNX_GetReturnValueString(NWNX_Util, sFunc);
 }

--- a/Plugins/Util/NWScript/nwnx_util_t.nss
+++ b/Plugins/Util/NWScript/nwnx_util_t.nss
@@ -32,5 +32,8 @@ void main()
     e = NWNX_Util_ItemPropertyToEffect(ip);
     report("EffectToItemProperty_ItemPropertyToEffect", GetEffectTag(e) == "NWNX_UTIL_TEST");
 
+    string uuid = NWNX_Util_GenerateUUID();
+    report("GenerateUUID", GetStringLength(uuid) == 36);
+
     WriteTimestampedLogEntry("NWNX_Util unit test end.");
 }

--- a/Plugins/Util/Util.hpp
+++ b/Plugins/Util/Util.hpp
@@ -20,6 +20,7 @@ private:
     ArgumentStack Hash(ArgumentStack&& args);
     ArgumentStack GetCustomToken(ArgumentStack&& args);
     ArgumentStack EffectTypeCast(ArgumentStack&& args);
+    ArgumentStack GenerateUUID(ArgumentStack&& args);
 };
 
 }


### PR DESCRIPTION
Resolves #166 . This is a valid v4 UUID. I don't think anyone cares about which version you get, so this should be good enough without pulling any dependencies.