### PR TITLE
Events: Add Event Data support for group based DMActionEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Events: You can now get the current event name with a nwscript function
 - Events: Added On{Listen/Spot}Detection events to StealthEvents
 - Events: Added On{Un}Polymorph events as PolymorphEvents
-- Events: Added SpawnObject, GiveItem and GiveAlignment events to DMActionEvents
+- Events: Added SpawnObject, GiveItem and GiveAlignment, Heal, Kill, ToggleInvulnerabilty, ForceRest, Limbo, ToggleAI, ToggleImmortal events to DMActionEvents
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite
 - Tweaks: DisableQuickSave
@@ -106,6 +106,7 @@ The following plugins were added:
 - Docker: Set default log level to 6
 - Docker: Skip all plugins except ServerLogRedirector by default
 - Redis: Lots of stuff, be sure to update the redis nwscripts!
+- Events: Changed `NUM_LEVELS` to `AMOUNT` for DMActionEvent GiveLevel
 
 ### Deprecated
 - Player: {Get/Set}VisibilityOverride are deprecated, please use the new Visibility plugin!

--- a/Plugins/Events/Events/DMActionEvents.cpp
+++ b/Plugins/Events/Events/DMActionEvents.cpp
@@ -38,8 +38,8 @@ static T PeekMessage(CNWSMessage *pMessage, int32_t offset)
     return value;
 }
 
-int32_t HandleGiveEvent(CNWSMessage *pMessage, CNWSPlayer *pPlayer, uint8_t nMinor, int32_t bGroup,
-                        const std::string &event, int32_t alignmentType = 0)
+int32_t DMActionEvents::HandleGiveEvent(CNWSMessage *pMessage, CNWSPlayer *pPlayer, uint8_t nMinor, int32_t bGroup,
+                                        const std::string &event, int32_t alignmentType = 0)
 {
     int32_t retVal;
     Types::ObjectID oidDM = pPlayer ? pPlayer->m_oidNWSObject : OBJECT_INVALID;
@@ -70,7 +70,8 @@ int32_t HandleGiveEvent(CNWSMessage *pMessage, CNWSPlayer *pPlayer, uint8_t nMin
     return retVal;
 }
 
-int32_t HandleGroupEvent(CNWSMessage *pMessage, CNWSPlayer *pPlayer, uint8_t nMinor, int32_t bGroup, const std::string &event)
+int32_t DMActionEvents::HandleGroupEvent(CNWSMessage *pMessage, CNWSPlayer *pPlayer, uint8_t nMinor, int32_t bGroup,
+                                        const std::string &event)
 {
     int32_t retVal;
     Types::ObjectID oidDM = pPlayer ? pPlayer->m_oidNWSObject : OBJECT_INVALID;

--- a/Plugins/Events/Events/DMActionEvents.cpp
+++ b/Plugins/Events/Events/DMActionEvents.cpp
@@ -38,13 +38,89 @@ static T PeekMessage(CNWSMessage *pMessage, int32_t offset)
     return value;
 }
 
+int32_t HandleGiveEvent(CNWSMessage *pMessage, CNWSPlayer *pPlayer, uint8_t nMinor, int32_t bGroup,
+                        const std::string &event, int32_t alignmentType = 0)
+{
+    int32_t retVal;
+    Types::ObjectID oidDM = pPlayer ? pPlayer->m_oidNWSObject : OBJECT_INVALID;
+    std::string amount = std::to_string(PeekMessage<int32_t>(pMessage, 0));
+    std::string target = Utils::ObjectIDToString(PeekMessage<Types::ObjectID>(pMessage, 4) & 0x7FFFFFFF);
+
+    auto PushAndSignalGiveEvent = [&](std::string ev) -> bool {
+        Events::PushEventData("AREA", amount);
+        Events::PushEventData("OBJECT", target);
+        if (alignmentType > 0)
+        {
+            Events::PushEventData("ALIGNMENT_TYPE", std::to_string(alignmentType));
+        }
+        return Events::SignalEvent(ev, oidDM);
+    };
+
+    if (PushAndSignalGiveEvent(event + "_BEFORE"))
+    {
+        retVal = m_HandlePlayerToServerDungeonMasterMessageHook->CallOriginal<int32_t>(pMessage, pPlayer, nMinor, bGroup);
+    }
+    else
+    {
+        retVal = false;
+    }
+
+    PushAndSignalGiveEvent(event + "_AFTER");
+
+    return retVal;
+}
+
+int32_t HandleGroupEvent(CNWSMessage *pMessage, CNWSPlayer *pPlayer, uint8_t nMinor, int32_t bGroup, const std::string &event)
+{
+    int32_t retVal;
+    Types::ObjectID oidDM = pPlayer ? pPlayer->m_oidNWSObject : OBJECT_INVALID;
+    int32_t offset = 0;
+    int32_t groupSize = 1;
+
+    if (bGroup)
+    {
+        groupSize = PeekMessage<int32_t>(pMessage, offset);
+        offset += sizeof(groupSize);
+    }
+
+    Types::ObjectID targets[groupSize];
+
+    for (int32_t target = 0; target < groupSize; target++)
+    {
+        targets[target] = PeekMessage<Types::ObjectID>(pMessage, offset) & 0x7FFFFFFF;
+        offset += sizeof(targets[target]);
+    }
+
+    auto PushAndSignalGroupEvent = [&](std::string ev) -> bool {
+        Events::PushEventData("NUM_TARGETS", std::to_string(groupSize));
+        for(int32_t target = 0; target < groupSize; target++)
+        {
+            Events::PushEventData("TARGET_" + std::to_string(target + 1), Utils::ObjectIDToString(targets[target]));
+        }
+        return Events::SignalEvent(ev, oidDM);
+    };
+
+    if (PushAndSignalGroupEvent(event + "_BEFORE"))
+    {
+        retVal = m_HandlePlayerToServerDungeonMasterMessageHook->CallOriginal<int32_t>(pMessage, pPlayer, nMinor, bGroup);
+    }
+    else
+    {
+        retVal = false;
+    }
+
+    PushAndSignalGroupEvent(event + "_AFTER");
+
+    return retVal;
+}
+
 int32_t DMActionEvents::HandleDMMessageHook(CNWSMessage *thisPtr, CNWSPlayer *pPlayer, uint8_t nMinor, int32_t bGroup)
 {
     int32_t retVal;
     std::string event = "NWNX_ON_DM_";
     Types::ObjectID oidDM = pPlayer ? pPlayer->m_oidNWSObject : OBJECT_INVALID;
 
-    auto DefaultSignalEvent = [&](std::string event) -> void {
+    auto DefaultSignalEvent = [&]() -> void {
         if (Events::SignalEvent(event + "_BEFORE", oidDM))
         {
             retVal = m_HandlePlayerToServerDungeonMasterMessageHook->CallOriginal<int32_t>(thisPtr, pPlayer, nMinor, bGroup);
@@ -123,191 +199,133 @@ int32_t DMActionEvents::HandleDMMessageHook(CNWSMessage *thisPtr, CNWSPlayer *pP
             }
 
             PushAndSignal(event +"_AFTER");
-
             break;
         }
         case MessageDungeonMasterMinor::Difficulty:
         {
             event += "CHANGE_DIFFICULTY";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::ViewInventory:
         {
             event += "VIEW_INVENTORY";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::SpawnTrapOnObject:
         {
             event += "SPAWN_TRAP_ON_OBJECT";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::Heal:
         {
             event += "HEAL";
-            DefaultSignalEvent(event);
+            retVal = HandleGroupEvent(thisPtr, pPlayer, nMinor, bGroup, event);
             break;
         }
         case MessageDungeonMasterMinor::Kill:
         {
             event += "KILL";
-            DefaultSignalEvent(event);
+            retVal = HandleGroupEvent(thisPtr, pPlayer, nMinor, bGroup, event);
             break;
         }
         case MessageDungeonMasterMinor::Goto:
         {
             event += "JUMP";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::Possess:
         {
             event += "POSSESS";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::Invulnerable:
         {
             event += "TOGGLE_INVULNERABLE";
-            DefaultSignalEvent(event);
+            retVal = HandleGroupEvent(thisPtr, pPlayer, nMinor, bGroup, event);
             break;
         }
         case MessageDungeonMasterMinor::Rest:
         {
             event += "FORCE_REST";
-            DefaultSignalEvent(event);
+            retVal = HandleGroupEvent(thisPtr, pPlayer, nMinor, bGroup, event);
             break;
         }
         case MessageDungeonMasterMinor::Limbo:
         {
             event += "LIMBO";
-            DefaultSignalEvent(event);
+            retVal = HandleGroupEvent(thisPtr, pPlayer, nMinor, bGroup, event);
             break;
         }
         case MessageDungeonMasterMinor::ToggleAI:
         {
             event += "TOGGLE_AI";
-            DefaultSignalEvent(event);
+            retVal = HandleGroupEvent(thisPtr, pPlayer, nMinor, bGroup, event);
             break;
         }
         case MessageDungeonMasterMinor::ToggleLock:
         {
             event += "TOGGLE_LOCK";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::DisableTrap:
         {
             event += "DISABLE_TRAP";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::Manifest:
         {
             event += "APPEAR";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::Unmanifest:
         {
             event += "DISAPPEAR";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::Immortal:
         {
             event += "TOGGLE_IMMORTAL";
-            DefaultSignalEvent(event);
+            retVal = HandleGroupEvent(thisPtr, pPlayer, nMinor, bGroup, event);
             break;
         }
         case MessageDungeonMasterMinor::GotoPoint:
         {
             event += "JUMP_TO_POINT";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::GiveXP:
         {
             event += "GIVE_XP";
-
-            std::string amount = std::to_string(PeekMessage<int32_t>(thisPtr, 0));
-            std::string target = Utils::ObjectIDToString(PeekMessage<Types::ObjectID>(thisPtr, 4) & 0x7FFFFFFF);
-
-            auto PushAndSignal = [&](std::string ev) -> bool {
-                Events::PushEventData("AMOUNT", amount);
-                Events::PushEventData("TARGET", target);
-                return Events::SignalEvent(ev, oidDM);
-            };
-
-            if (PushAndSignal(event + "_BEFORE"))
-            {
-                retVal = m_HandlePlayerToServerDungeonMasterMessageHook->CallOriginal<int32_t>(thisPtr, pPlayer, nMinor, bGroup);
-            }
-            else
-            {
-                retVal = false;
-            }
-
-            PushAndSignal(event +"_AFTER");
+            retVal = HandleGiveEvent(thisPtr, pPlayer, nMinor, bGroup, event);
             break;
         }
         case MessageDungeonMasterMinor::GiveLevel:
         {
             event += "GIVE_LEVEL";
-
-            std::string numLevels = std::to_string(PeekMessage<int32_t>(thisPtr, 0));
-            std::string target = Utils::ObjectIDToString(PeekMessage<Types::ObjectID>(thisPtr, 4) & 0x7FFFFFFF);
-
-            auto PushAndSignal = [&](std::string ev) -> bool {
-                Events::PushEventData("NUM_LEVELS", numLevels);
-                Events::PushEventData("TARGET", target);
-                return Events::SignalEvent(ev, oidDM);
-            };
-
-            if (PushAndSignal(event + "_BEFORE"))
-            {
-                retVal = m_HandlePlayerToServerDungeonMasterMessageHook->CallOriginal<int32_t>(thisPtr, pPlayer, nMinor, bGroup);
-            }
-            else
-            {
-                retVal = false;
-            }
-
-            PushAndSignal(event +"_AFTER");
+            retVal = HandleGiveEvent(thisPtr, pPlayer, nMinor, bGroup, event);
             break;
         }
         case MessageDungeonMasterMinor::GiveGold:
         {
             event += "GIVE_GOLD";
-
-            std::string amount = std::to_string(PeekMessage<int32_t>(thisPtr, 0));
-            std::string target = Utils::ObjectIDToString(PeekMessage<Types::ObjectID>(thisPtr, 4) & 0x7FFFFFFF);
-
-            auto PushAndSignal = [&](std::string ev) -> bool {
-                Events::PushEventData("AMOUNT", amount);
-                Events::PushEventData("TARGET", target);
-                return Events::SignalEvent(ev, oidDM);
-            };
-
-            if (PushAndSignal(event + "_BEFORE"))
-            {
-                retVal = m_HandlePlayerToServerDungeonMasterMessageHook->CallOriginal<int32_t>(thisPtr, pPlayer, nMinor, bGroup);
-            }
-            else
-            {
-                retVal = false;
-            }
-
-            PushAndSignal(event +"_AFTER");
+            retVal = HandleGiveEvent(thisPtr, pPlayer, nMinor, bGroup, event);
             break;
         }
         case MessageDungeonMasterMinor::SetFaction:
         case MessageDungeonMasterMinor::SetFactionByName:
         {
             event += "SET_FACTION";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::GiveItem:
@@ -338,64 +356,67 @@ int32_t DMActionEvents::HandleDMMessageHook(CNWSMessage *thisPtr, CNWSPlayer *pP
         case MessageDungeonMasterMinor::TakeItem:
         {
             event += "TAKE_ITEM";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::GotoPointTarget:
         {
             event += "JUMP_TARGET_TO_POINT";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::GotoPointAllPlayers:
         {
             event += "JUMP_ALL_PLAYERS_TO_POINT";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::SetStat:
         {
             event += "SET_STAT";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::GetVar:
         {
             event += "GET_VARIABLE";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::SetVar:
+        {
             event += "SET_VARIABLE";
+            DefaultSignalEvent();
             break;
+        }
         case MessageDungeonMasterMinor::SetTime:
         {
             event += "SET_TIME";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::SetDate:
         {
             event += "SET_DATE";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::SetFactionReputation:
         {
             event += "SET_FACTION_REPUTATION";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::GetFactionReputation:
         {
             event += "GET_FACTION_REPUTATION";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::DumpLocals:
         {
             event += "DUMP_LOCALS";
-            DefaultSignalEvent(event);
+            DefaultSignalEvent();
             break;
         }
         case MessageDungeonMasterMinor::GiveGoodAlignment:
@@ -405,10 +426,7 @@ int32_t DMActionEvents::HandleDMMessageHook(CNWSMessage *thisPtr, CNWSPlayer *pP
         {
             event += "GIVE_ALIGNMENT";
 
-            int32_t alignmentType;
-            std::string amount = std::to_string(PeekMessage<int32_t>(thisPtr, 0));
-            std::string target = Utils::ObjectIDToString(PeekMessage<Types::ObjectID>(thisPtr, 4) & 0x7FFFFFFF);
-
+            int32_t alignmentType = 0;
             switch (nMinor)
             {
                 case MessageDungeonMasterMinor::GiveGoodAlignment:
@@ -428,23 +446,7 @@ int32_t DMActionEvents::HandleDMMessageHook(CNWSMessage *thisPtr, CNWSPlayer *pP
                     break;
             }
 
-            auto PushAndSignal = [&](std::string ev) -> bool {
-                Events::PushEventData("ALIGNMENT_TYPE", std::to_string(alignmentType));
-                Events::PushEventData("AMOUNT", amount);
-                Events::PushEventData("TARGET", target);
-                return Events::SignalEvent(ev, oidDM);
-            };
-
-            if (PushAndSignal(event + "_BEFORE"))
-            {
-                retVal = m_HandlePlayerToServerDungeonMasterMessageHook->CallOriginal<int32_t>(thisPtr, pPlayer, nMinor, bGroup);
-            }
-            else
-            {
-                retVal = false;
-            }
-
-            PushAndSignal(event +"_AFTER");
+            retVal = HandleGiveEvent(thisPtr, pPlayer, nMinor, bGroup, event, alignmentType);
             break;
         }
         default:

--- a/Plugins/Events/Events/DMActionEvents.hpp
+++ b/Plugins/Events/Events/DMActionEvents.hpp
@@ -14,6 +14,8 @@ public:
     DMActionEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
 
 private:
+    static int32_t HandleGiveEvent(NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*, uint8_t, int32_t, const std::string&, int32_t);
+    static int32_t HandleGroupEvent(NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*, uint8_t, int32_t, const std::string&);
     static int32_t HandleDMMessageHook(NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*, uint8_t, int32_t);
 };
 

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -69,25 +69,19 @@
     NWNX_ON_DM_GIVE_GOLD_AFTER
     NWNX_ON_DM_GIVE_XP_BEFORE
     NWNX_ON_DM_GIVE_XP_AFTER
+    NWNX_ON_DM_GIVE_LEVEL_BEFORE
+    NWNX_ON_DM_GIVE_LEVEL_AFTER
+    NWNX_ON_DM_GIVE_ALIGNMENT_BEFORE
+    NWNX_ON_DM_GIVE_ALIGNMENT_AFTER
 
     Usage:
-        OBJECT_SELF = The DM giving the gold/xp
+        OBJECT_SELF = The DM giving the gold/xp/level/alignment
 
     Event data:
         Variable Name           Type        Notes
         AMOUNT                  int
         TARGET                  object      Convert to object with NWNX_Object_StringToObject()
-
-    NWNX_ON_DM_GIVE_LEVEL_BEFORE
-    NWNX_ON_DM_GIVE_LEVEL_AFTER
-
-    Usage:
-        OBJECT_SELF = The DM giving the levels
-
-    Event data:
-        Variable Name           Type        Notes
-        NUM_LEVELS              int
-        TARGET                  object      Convert to object with NWNX_Object_StringToObject()
+        ALIGNMENT_TYPE          int         Only valid for NWNX_ON_DM_GIVE_ALIGNMENT_*
 
     NWNX_ON_DM_SPAWN_OBJECT_BEFORE
     NWNX_ON_DM_SPAWN_OBJECT_AFTER
@@ -115,17 +109,28 @@
         TARGET                  object      Convert to object with NWNX_Object_StringToObject()
         ITEM                    object      Only returns a valid object in *_AFTER
 
-    NWNX_ON_DM_GIVE_ALIGNMENT_BEFORE
-    NWNX_ON_DM_GIVE_ALIGNMENT_AFTER
+    NWNX_ON_DM_HEAL_BEFORE
+    NWNX_ON_DM_HEAL_AFTER
+    NWNX_ON_DM_KILL_BEFORE
+    NWNX_ON_DM_KILL_AFTER
+    NWNX_ON_DM_TOGGLE_INVULNERABLE_BEFORE
+    NWNX_ON_DM_TOGGLE_INVULNERABLE_AFTER
+    NWNX_ON_DM_FORCE_REST_BEFORE
+    NWNX_ON_DM_FORCE_REST_AFTER
+    NWNX_ON_DM_LIMBO_BEFORE
+    NWNX_ON_DM_LIMBO_AFTER
+    NWNX_ON_DM_TOGGLE_AI_BEFORE
+    NWNX_ON_DM_TOGGLE_AI_AFTER
+    NWNX_ON_DM_TOGGLE_IMMORTAL_BEFORE
+    NWNX_ON_DM_TOGGLE_IMMORTAL_AFTER
 
     Usage:
-        OBJECT_SELF = The DM giving the alignment
+        OBJECT_SELF = The DM doing the thing
 
     Event data:
         Variable Name           Type        Notes
-        ALIGNMENT_TYPE          int         Returns ALIGNMENT_*
-        AMOUNT                  int
-        TARGET                  object      Convert to object with NWNX_Object_StringToObject()
+        NUM_TARGETS             int         The number of targets affected
+        TARGET_*                object      * = 1 <= NUM_TARGETS
 ////////////////////////////////////////////////////////////////////////////////
     NWNX_ON_CLIENT_DISCONNECT_BEFORE
     NWNX_ON_CLIENT_DISCONNECT_AFTER


### PR DESCRIPTION
Adds event data support for the following events:
```
NWNX_ON_DM_HEAL_BEFORE
NWNX_ON_DM_HEAL_AFTER
NWNX_ON_DM_KILL_BEFORE
NWNX_ON_DM_KILL_AFTER
NWNX_ON_DM_TOGGLE_INVULNERABLE_BEFORE
NWNX_ON_DM_TOGGLE_INVULNERABLE_AFTER
NWNX_ON_DM_FORCE_REST_BEFORE
NWNX_ON_DM_FORCE_REST_AFTER
NWNX_ON_DM_LIMBO_BEFORE
NWNX_ON_DM_LIMBO_AFTER
NWNX_ON_DM_TOGGLE_AI_BEFORE
NWNX_ON_DM_TOGGLE_AI_AFTER
NWNX_ON_DM_TOGGLE_IMMORTAL_BEFORE
NWNX_ON_DM_TOGGLE_IMMORTAL_AFTER
```

Test / Usage Example:
```
#include "nwnx_events"
#include "nwnx_object"

void main()
{
    object oDM = OBJECT_SELF;
    string sEvent = NWNX_Events_GetCurrentEvent();
    int bBefore = FindSubString(sEvent, "_BEFORE") != -1;

    if (FindSubString(sEvent, "NWNX_ON_DM_KILL_") != -1)
    {
        int numTargets = StringToInt(NWNX_Events_GetEventData("NUM_TARGETS"));

        if(bBefore && numTargets == 3)
        {
            NWNX_Events_SkipEvent();
        }

        SendMessageToPC(oDM, (bBefore ? "BEFORE: " : "AFTER: ") + "NUM_TARGETS: " + IntToString(numTargets));

        int i;
        for(i = 1; i <= numTargets; i++)
        {
            object oTarget = NWNX_Object_StringToObject(NWNX_Events_GetEventData("TARGET_" + IntToString(i)));
            SendMessageToPC(oDM, (bBefore ? "BEFORE: " : "AFTER: ") + "TARGET_" + IntToString(i) + ": " + GetName(oTarget));
        }
    }
}
```

Also changes the Event Data Variable `NUM_LEVELS` to `AMOUNT` for the GiveLevel event

