### PR TITLE
Events: Updated nwnx_events.nss with all DMActionEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Events: You can now get the current event name with a nwscript function
 - Events: Added On{Listen/Spot}Detection events to StealthEvents
 - Events: Added On{Un}Polymorph events as PolymorphEvents
-- Events: Added SpawnObject, GiveItem and GiveAlignment, Heal, Kill, ToggleInvulnerabilty, ForceRest, Limbo, ToggleAI, ToggleImmortal, Goto, Possess, PossessFullPower, ToggleLock, DisableTrap, JumpToPoint, JumpTargetToPoint, JumpAllPlayersToPoint events to DMActionEvents
+- Events: Added Event Data for SpawnObject, GiveItem and GiveAlignment, Heal, Kill, ToggleInvulnerabilty, ForceRest, Limbo, ToggleAI, ToggleImmortal, Goto, Possess, PossessFullPower, ToggleLock, DisableTrap, JumpToPoint, JumpTargetToPoint, JumpAllPlayersToPoint, ChangeDifficulty, ViewInventory, SpawnTrapOnObject events in DMActionEvents
 - Events: Added OnClientConnect events that fire before the player sees the server vault.
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite

--- a/Plugins/Events/Events/DMActionEvents.cpp
+++ b/Plugins/Events/Events/DMActionEvents.cpp
@@ -296,19 +296,74 @@ int32_t DMActionEvents::HandleDMMessageHook(CNWSMessage *thisPtr, CNWSPlayer *pP
         case MessageDungeonMasterMinor::Difficulty:
         {
             event += "CHANGE_DIFFICULTY";
-            DefaultSignalEvent(); // Int
+
+            std::string difficulty = std::to_string(PeekMessage<int32_t>(thisPtr, 0));
+
+            auto PushAndSignal = [&](std::string ev) -> bool {
+                Events::PushEventData("DIFFICULTY_SETTING", difficulty);
+                return Events::SignalEvent(ev, oidDM);
+            };
+
+            if (PushAndSignal(event + "_BEFORE"))
+            {
+                retVal = m_HandlePlayerToServerDungeonMasterMessageHook->CallOriginal<int32_t>(thisPtr, pPlayer, nMinor, bGroup);
+            }
+            else
+            {
+                retVal = false;
+            }
+
+            PushAndSignal(event +"_AFTER");
             break;
         }
         case MessageDungeonMasterMinor::ViewInventory:
         {
             event += "VIEW_INVENTORY";
-            DefaultSignalEvent(); // bOpenInventory, Target
+
+            std::string openInventory = std::to_string(PeekMessage<int32_t>(thisPtr, 0));
+            std::string target = Utils::ObjectIDToString(PeekMessage<Types::ObjectID>(thisPtr, 4) & 0x7FFFFFFF);
+
+            auto PushAndSignal = [&](std::string ev) -> bool {
+                Events::PushEventData("OPEN_INVENTORY", openInventory);
+                Events::PushEventData("TARGET", target);
+                return Events::SignalEvent(ev, oidDM);
+            };
+
+            if (PushAndSignal(event + "_BEFORE"))
+            {
+                retVal = m_HandlePlayerToServerDungeonMasterMessageHook->CallOriginal<int32_t>(thisPtr, pPlayer, nMinor, bGroup);
+            }
+            else
+            {
+                retVal = false;
+            }
+
+            PushAndSignal(event +"_AFTER");
             break;
         }
         case MessageDungeonMasterMinor::SpawnTrapOnObject:
         {
             event += "SPAWN_TRAP_ON_OBJECT";
-            DefaultSignalEvent();
+
+            std::string area = Utils::ObjectIDToString(PeekMessage<Types::ObjectID>(thisPtr, 0) & 0x7FFFFFFF);
+            std::string target = Utils::ObjectIDToString(PeekMessage<Types::ObjectID>(thisPtr, 4) & 0x7FFFFFFF);
+
+            auto PushAndSignal = [&](std::string ev) -> bool {
+                Events::PushEventData("AREA", area);
+                Events::PushEventData("TARGET", target);
+                return Events::SignalEvent(ev, oidDM);
+            };
+
+            if (PushAndSignal(event + "_BEFORE"))
+            {
+                retVal = m_HandlePlayerToServerDungeonMasterMessageHook->CallOriginal<int32_t>(thisPtr, pPlayer, nMinor, bGroup);
+            }
+            else
+            {
+                retVal = false;
+            }
+
+            PushAndSignal(event +"_AFTER");
             break;
         }
         case MessageDungeonMasterMinor::Heal:

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -169,7 +169,72 @@
         POS_Y                   float
         POS_Z                   float
         NUM_TARGETS             int         Only valid for NWNX_ON_DM_JUMP_TARGET_TO_POINT_*
-        TARGET_*                object      * = 1 <= NUM_TARGETS, Only valid for NWNX_ON_DM_JUMP_TARGET_TO_POINT_
+        TARGET_*                object      * = 1 <= NUM_TARGETS, Only valid for NWNX_ON_DM_JUMP_TARGET_TO_POINT_*
+
+    NWNX_ON_DM_CHANGE_DIFFICULTY_BEFORE
+    NWNX_ON_DM_CHANGE_DIFFICULTY_AFTER
+
+    Usage:
+        OBJECT_SELF = The DM
+
+    Event data:
+        Variable Name           Type        Notes
+        DIFFICULTY_SETTING      int
+
+    NWNX_ON_DM_VIEW_INVENTORY_BEFORE
+    NWNX_ON_DM_VIEW_INVENTORY_AFTER
+
+    Usage:
+        OBJECT_SELF = The DM
+
+    Event data:
+        Variable Name           Type        Notes
+        OPEN_INVENTORY          int         TRUE if opening an inventory, FALSE if closing
+        TARGET                  object      Convert to object with NWNX_Object_StringToObject()
+
+    NWNX_ON_DM_SPAWN_TRAP_ON_OBJECT_BEFORE
+    NWNX_ON_DM_SPAWN_TRAP_ON_OBJECT_AFTER
+
+    Usage:
+        OBJECT_SELF = The DM
+
+    Event data:
+        Variable Name           Type        Notes
+        AREA                    object      Convert to object with NWNX_Object_StringToObject()
+        TARGET                  object      Convert to object with NWNX_Object_StringToObject()
+
+    NWNX_ON_DM_APPEAR_BEFORE
+    NWNX_ON_DM_APPEAR_AFTER
+    NWNX_ON_DM_DISAPPEAR_BEFORE
+    NWNX_ON_DM_DISAPPEAR_AFTER
+    NWNX_ON_DM_SET_FACTION_BEFORE
+    NWNX_ON_DM_SET_FACTION_AFTER
+    NWNX_ON_DM_TAKE_ITEM_BEFORE
+    NWNX_ON_DM_TAKE_ITEM_AFTER
+    NWNX_ON_DM_SET_STAT_BEFORE
+    NWNX_ON_DM_SET_STAT_AFTER
+    NWNX_ON_DM_GET_VARIABLE_BEFORE
+    NWNX_ON_DM_GET_VARIABLE_AFTER
+    NWNX_ON_DM_SET_VARIABLE_BEFORE
+    NWNX_ON_DM_SET_VARIABLE_AFTER
+    NWNX_ON_DM_SET_TIME_BEFORE
+    NWNX_ON_DM_SET_TIME_AFTER
+    NWNX_ON_DM_SET_DATE_BEFORE
+    NWNX_ON_DM_SET_DATE_AFTER
+    NWNX_ON_DM_SET_FACTION_REPUTATION_BEFORE
+    NWNX_ON_DM_SET_FACTION_REPUTATION_AFTER
+    NWNX_ON_DM_GET_FACTION_REPUTATION_BEFORE
+    NWNX_ON_DM_GET_FACTION_REPUTATION_AFTER
+    NWNX_ON_DM_DUMP_LOCALS_BEFORE
+    NWNX_ON_DM_DUMP_LOCALS_AFTER
+
+    These events do not have event data implemented and can only be skipped
+
+    Usage:
+        OBJECT_SELF = The DM
+
+    Event data:
+        Variable Name           Type        Notes
 ////////////////////////////////////////////////////////////////////////////////
     NWNX_ON_CLIENT_DISCONNECT_BEFORE
     NWNX_ON_CLIENT_DISCONNECT_AFTER


### PR DESCRIPTION
Really, really done with them now, I swear.

Added eventdata for the following events:
```
NWNX_ON_DM_CHANGE_DIFFICULTY_BEFORE
NWNX_ON_DM_CHANGE_DIFFICULTY_AFTER
NWNX_ON_DM_VIEW_INVENTORY_BEFORE
NWNX_ON_DM_VIEW_INVENTORY_AFTER
NWNX_ON_DM_SPAWN_TRAP_ON_OBJECT_BEFORE
NWNX_ON_DM_SPAWN_TRAP_ON_OBJECT_AFTER
```

Added events that can only be skipped at the moment to nwnx_events.nss
```
NWNX_ON_DM_APPEAR_BEFORE
NWNX_ON_DM_APPEAR_AFTER
NWNX_ON_DM_DISAPPEAR_BEFORE
NWNX_ON_DM_DISAPPEAR_AFTER
NWNX_ON_DM_SET_FACTION_BEFORE
NWNX_ON_DM_SET_FACTION_AFTER
NWNX_ON_DM_TAKE_ITEM_BEFORE
NWNX_ON_DM_TAKE_ITEM_AFTER
NWNX_ON_DM_SET_STAT_BEFORE
NWNX_ON_DM_SET_STAT_AFTER
NWNX_ON_DM_GET_VARIABLE_BEFORE
NWNX_ON_DM_GET_VARIABLE_AFTER
NWNX_ON_DM_SET_VARIABLE_BEFORE
NWNX_ON_DM_SET_VARIABLE_AFTER
NWNX_ON_DM_SET_TIME_BEFORE
NWNX_ON_DM_SET_TIME_AFTER
NWNX_ON_DM_SET_DATE_BEFORE
NWNX_ON_DM_SET_DATE_AFTER
NWNX_ON_DM_SET_FACTION_REPUTATION_BEFORE
NWNX_ON_DM_SET_FACTION_REPUTATION_AFTER
NWNX_ON_DM_GET_FACTION_REPUTATION_BEFORE
NWNX_ON_DM_GET_FACTION_REPUTATION_AFTER
NWNX_ON_DM_DUMP_LOCALS_BEFORE
NWNX_ON_DM_DUMP_LOCALS_AFTER
```