### PR TITLE
Add Lootbox Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Events: Added On{Un}Polymorph events as PolymorphEvents
 - Events: Added Event Data for SpawnObject, GiveItem and GiveAlignment, Heal, Kill, ToggleInvulnerabilty, ForceRest, Limbo, ToggleAI, ToggleImmortal, Goto, Possess, PossessFullPower, ToggleLock, DisableTrap, JumpToPoint, JumpTargetToPoint, JumpAllPlayersToPoint, ChangeDifficulty, ViewInventory, SpawnTrapOnObject events in DMActionEvents
 - Events: Added OnClientConnect events that fire before the player sees the server vault.
+- Events: Added ItemInventory{Open/Close} events to ItemEvents
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite
 - Tweaks: DisableQuickSave

--- a/Plugins/Events/Events/ItemEvents.hpp
+++ b/Plugins/Events/Events/ItemEvents.hpp
@@ -16,6 +16,8 @@ public:
 private:
     static int32_t UseItemHook(NWNXLib::API::CNWSCreature*, NWNXLib::API::Types::ObjectID, uint8_t,
         uint8_t, NWNXLib::API::Types::ObjectID, NWNXLib::API::Vector, NWNXLib::API::Types::ObjectID);
+    static void OpenInventoryHook(NWNXLib::API::CNWSItem*, NWNXLib::API::Types::ObjectID);
+    static void CloseInventoryHook(NWNXLib::API::CNWSItem*, NWNXLib::API::Types::ObjectID, int32_t);
 };
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -48,6 +48,18 @@
         TARGET_POSITION_X       float
         TARGET_POSITION_Y       float
         TARGET_POSITION_Z       float
+
+    NWNX_ON_ITEM_INVENTORY_OPEN_BEFORE
+    NWNX_ON_ITEM_INVENTORY_OPEN_AFTER
+    NWNX_ON_ITEM_INVENTORY_CLOSE_BEFORE
+    NWNX_ON_ITEM_INVENTORY_CLOSE_AFTER
+
+    Usage:
+        OBJECT_SELF = The container
+
+    Event data:
+        Variable Name           Type        Notes
+        OWNER                   object      Convert to object with NWNX_Object_StringToObject()
 ////////////////////////////////////////////////////////////////////////////////
     NWNX_ON_USE_FEAT_BEFORE
     NWNX_ON_USE_FEAT_AFTER


### PR DESCRIPTION
How to make the big $$$:

```
#include "nwnx_events"
#include "nwnx_object"

void main()
{
    object oItem = OBJECT_SELF;
    string sEvent = NWNX_Events_GetCurrentEvent();
    int bBefore = FindSubString(sEvent, "_BEFORE") != -1;

    if (FindSubString(sEvent, "NWNX_ON_ITEM_INVENTORY_OPEN_") != -1)
    {
        object oPlayer = NWNX_Object_StringToObject(NWNX_Events_GetEventData("OWNER"));

        if (bBefore)
        {
            if (GetLocalInt(oItem, "LOOTBOX_OPENED"))
            {
                NWNX_Events_SkipEvent();
            }
            else
            {
                if(Random(100) < 25)
                {
                    // Legendary Greatsword of Slaying Useless Minions +20
                    CreateItemOnObject("nw_wswgs001", oItem);
                }

                CreateItemOnObject("nw_it_gold001", oItem, Random(250));
            }
        }
    }

    if (FindSubString(sEvent, "NWNX_ON_ITEM_INVENTORY_CLOSE_") != -1)
    {
        object oPlayer = NWNX_Object_StringToObject(NWNX_Events_GetEventData("OWNER"));

        if (!bBefore)
        {
            object oInventoryItem = GetFirstItemInInventory(oItem);

            while (GetIsObjectValid(oInventoryItem))
            {
                DestroyObject(oInventoryItem);

                oInventoryItem = GetNextItemInInventory(oItem);
            }

            SetLocalInt(oItem, "LOOTBOX_OPENED", TRUE);
        }

    }
}
```

Adds the following ItemEvents:
```
NWNX_ON_ITEM_INVENTORY_OPEN_BEFORE
NWNX_ON_ITEM_INVENTORY_OPEN_AFTER
NWNX_ON_ITEM_INVENTORY_CLOSE_BEFORE
NWNX_ON_ITEM_INVENTORY_CLOSE_AFTER
```