### PR TITLE
Events: add ItemInventory{Add/Remove}Item events to ItemEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Events: Added On{Un}Polymorph events as PolymorphEvents
 - Events: Added Event Data for SpawnObject, GiveItem and GiveAlignment, Heal, Kill, ToggleInvulnerabilty, ForceRest, Limbo, ToggleAI, ToggleImmortal, Goto, Possess, PossessFullPower, ToggleLock, DisableTrap, JumpToPoint, JumpTargetToPoint, JumpAllPlayersToPoint, ChangeDifficulty, ViewInventory, SpawnTrapOnObject events in DMActionEvents
 - Events: Added OnClientConnect events that fire before the player sees the server vault.
-- Events: Added ItemInventory{Open/Close} events to ItemEvents
+- Events: Added ItemInventory{Open/Close} and ItemInventory{Add/Remove}Item events to ItemEvents
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite
 - Tweaks: DisableQuickSave

--- a/Plugins/Events/Events/ItemEvents.hpp
+++ b/Plugins/Events/Events/ItemEvents.hpp
@@ -18,6 +18,8 @@ private:
         uint8_t, NWNXLib::API::Types::ObjectID, NWNXLib::API::Vector, NWNXLib::API::Types::ObjectID);
     static void OpenInventoryHook(NWNXLib::API::CNWSItem*, NWNXLib::API::Types::ObjectID);
     static void CloseInventoryHook(NWNXLib::API::CNWSItem*, NWNXLib::API::Types::ObjectID, int32_t);
+    static int32_t AddItemHook(NWNXLib::API::CItemRepository*, NWNXLib::API::CNWSItem**, uint8_t, uint8_t, int32_t, int32_t);
+    static void RemoveItemHook(NWNXLib::Services::Hooks::CallType, NWNXLib::API::CItemRepository*, NWNXLib::API::CNWSItem*);
 };
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -60,6 +60,20 @@
     Event data:
         Variable Name           Type        Notes
         OWNER                   object      Convert to object with NWNX_Object_StringToObject()
+
+    NWNX_ON_ITEM_INVENTORY_ADD_ITEM_BEFORE
+    NWNX_ON_ITEM_INVENTORY_ADD_ITEM_AFTER
+    NWNX_ON_ITEM_INVENTORY_REMOVE_ITEM_BEFORE
+    NWNX_ON_ITEM_INVENTORY_REMOVE_ITEM_AFTER
+
+    Note: NWNX_ON_ITEM_INVENTORY_REMOVE_ITEM_* is not skippable
+
+    Usage:
+        OBJECT_SELF = The container
+
+    Event data:
+        Variable Name           Type        Notes
+        ITEM                    object      Convert to object with NWNX_Object_StringToObject()
 ////////////////////////////////////////////////////////////////////////////////
     NWNX_ON_USE_FEAT_BEFORE
     NWNX_ON_USE_FEAT_AFTER


### PR DESCRIPTION
Adds the following ItemEvents:
```
NWNX_ON_ITEM_INVENTORY_ADD_ITEM_BEFORE
NWNX_ON_ITEM_INVENTORY_ADD_ITEM_AFTER
NWNX_ON_ITEM_INVENTORY_REMOVE_ITEM_BEFORE
NWNX_ON_ITEM_INVENTORY_REMOVE_ITEM_AFTER
```
Note: NWNX_ON_ITEM_INVENTORY_REMOVE_ITEM_* is not skippable because it makes bad things happen.