### PR TITLE
Add StripColors function to Util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ The following plugins were added:
 - Util: GetCustomToken()
 - Util: EffectToItemProperty()
 - Util: ItemPropertyToEffect()
+- Util: StripColors()
 - Visibility: GetVisibilityOverride()
 - Visibility: SetVisibilityOverride()
 - Weapon: SetWeaponIsMonkWeapon()

--- a/Plugins/Util/NWScript/nwnx_util.nss
+++ b/Plugins/Util/NWScript/nwnx_util.nss
@@ -16,6 +16,8 @@ itemproperty NWNX_Util_EffectToItemProperty(effect e);
 effect NWNX_Util_ItemPropertyToEffect(itemproperty ip);
 // Generate a v4 UUID.
 string NWNX_Util_GenerateUUID();
+// Strip any color codes from a string
+string NWNX_Util_StripColors(string str);
 
 
 const string NWNX_Util = "NWNX_Util";
@@ -71,6 +73,14 @@ effect NWNX_Util_ItemPropertyToEffect(itemproperty ip)
 string NWNX_Util_GenerateUUID()
 {
     string sFunc = "GenerateUUID";
+    NWNX_CallFunction(NWNX_Util, sFunc);
+    return NWNX_GetReturnValueString(NWNX_Util, sFunc);
+}
+
+string NWNX_Util_StripColors(string str)
+{
+    string sFunc = "StripColors";
+    NWNX_PushArgumentString(NWNX_Util, sFunc, str);
     NWNX_CallFunction(NWNX_Util, sFunc);
     return NWNX_GetReturnValueString(NWNX_Util, sFunc);
 }

--- a/Plugins/Util/NWScript/nwnx_util_t.nss
+++ b/Plugins/Util/NWScript/nwnx_util_t.nss
@@ -1,4 +1,5 @@
 #include "nwnx_util"
+#include "x3_inc_string"
 
 void report(string func, int bSuccess)
 {
@@ -34,6 +35,11 @@ void main()
 
     string uuid = NWNX_Util_GenerateUUID();
     report("GenerateUUID", GetStringLength(uuid) == 36);
+
+    string sRedString = StringToRGBString("stripped colors.", STRING_COLOR_RED);
+    str = "This is a <cfff>test</c> of "+sRedString;
+    string strip_colors = NWNX_Util_StripColors(str);
+    report("RegexReplace", strip_colors == "This is a test of stripped colors.");
 
     WriteTimestampedLogEntry("NWNX_Util unit test end.");
 }

--- a/Plugins/Util/Util.cpp
+++ b/Plugins/Util/Util.cpp
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <stdio.h>
+#include <regex>
 #include <functional>
 
 using namespace NWNXLib;
@@ -52,6 +53,7 @@ Util::Util(const Plugin::CreateParams& params)
     REGISTER(GetCustomToken);
     REGISTER(EffectTypeCast);
     REGISTER(GenerateUUID);
+    REGISTER(StripColors);
 
 #undef REGISTER
 
@@ -160,6 +162,17 @@ ArgumentStack Util::GenerateUUID(ArgumentStack&&)
         bytes[8],bytes[9],bytes[10],bytes[11],bytes[12],bytes[13],bytes[14],bytes[15]);
 
     Services::Events::InsertArgument(stack, uuid);
+    return stack;
+}
+
+ArgumentStack Util::StripColors(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    const auto s = Services::Events::ExtractArgument<std::string>(args);
+
+    std::regex color_codes("<c.+?(?=>)>|<\\/c>");
+    std::string retVal = std::regex_replace(s, color_codes, "");
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 

--- a/Plugins/Util/Util.hpp
+++ b/Plugins/Util/Util.hpp
@@ -21,6 +21,7 @@ private:
     ArgumentStack GetCustomToken(ArgumentStack&& args);
     ArgumentStack EffectTypeCast(ArgumentStack&& args);
     ArgumentStack GenerateUUID(ArgumentStack&& args);
+    ArgumentStack StripColors(ArgumentStack&& args);
 };
 
 }


### PR DESCRIPTION
We run player chat through a `StripColors` function, not sure if this would be wanted or if a more generic `regex_replace` would be the preferred route. Sending the PR either way and we can discuss.