### PR TITLE
Events: make SpellEvents skippable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Core: Allow changing default plugin state from 'load all' to 'skip all' with the following environment variable: `NWNX_CORE_SKIP_ALL=y`. Use `NWNX_PLUGIN_SKIP=n` to enable specific plugins in this case.
 - Core: Allow passing engine structures to nwnx (Effect/Itemproperty)
 - Events: New events: SkillEvents, MapEvents
-- Events: The following events are now skippable: FeatEvents, ItemEvents, HealersKitEvents, CombatModeEvents, PartyEvents, SkillEvents, MapEvents, PolymorphEvents, DMActionEvents, ClientConnectEvents
+- Events: The following events are now skippable: FeatEvents, ItemEvents, HealersKitEvents, CombatModeEvents, PartyEvents, SkillEvents, MapEvents, PolymorphEvents, DMActionEvents, ClientConnectEvents, SpellEvents
 - Events: You can now get the current event name with a nwscript function
 - Events: Added On{Listen/Spot}Detection events to StealthEvents
 - Events: Added On{Un}Polymorph events as PolymorphEvents

--- a/Plugins/Events/Events/SpellEvents.cpp
+++ b/Plugins/Events/Events/SpellEvents.cpp
@@ -8,26 +8,16 @@ namespace Events {
 
 using namespace NWNXLib;
 
+static Hooking::FunctionHook* m_SpellCastAndImpactHook = nullptr;
+
 SpellEvents::SpellEvents(ViewPtr<Services::HooksProxy> hooker)
 {
-    hooker->RequestSharedHook<
-        NWNXLib::API::Functions::CNWSObject__SpellCastAndImpact,
-        int32_t,
-        NWNXLib::API::CNWSObject*,
-        uint32_t,
-        NWNXLib::API::Vector,
-        uint32_t,
-        int8_t,
-        uint32_t,
-        bool,
-        bool,
-        int8_t,
-        bool>(SpellEvents::CastSpellHook);
+    hooker->RequestExclusiveHook<NWNXLib::API::Functions::CNWSObject__SpellCastAndImpact>(&CastSpellHook);
+    m_SpellCastAndImpactHook = hooker->FindHookByAddress(NWNXLib::API::Functions::CNWSObject__SpellCastAndImpact);
 }
 
 void SpellEvents::CastSpellHook
 (
-    Services::Hooks::CallType type,
     NWNXLib::API::CNWSObject* thisPtr,
     uint32_t spellID,
     NWNXLib::API::Vector targetPosition,
@@ -40,22 +30,34 @@ void SpellEvents::CastSpellHook
     bool isInstantSpell
 )
 {
-    const bool before = type == Services::Hooks::CallType::BEFORE_ORIGINAL;
-    Events::PushEventData("SPELL_ID", std::to_string(spellID));
+    auto PushAndSignal = [&](std::string ev) -> bool {
+        Events::PushEventData("SPELL_ID", std::to_string(spellID));
 
-    Events::PushEventData("TARGET_POSITION_X", std::to_string(targetPosition.x));
-    Events::PushEventData("TARGET_POSITION_Y", std::to_string(targetPosition.y));
-    Events::PushEventData("TARGET_POSITION_Z", std::to_string(targetPosition.z));
+        Events::PushEventData("TARGET_POSITION_X", std::to_string(targetPosition.x));
+        Events::PushEventData("TARGET_POSITION_Y", std::to_string(targetPosition.y));
+        Events::PushEventData("TARGET_POSITION_Z", std::to_string(targetPosition.z));
 
-    Events::PushEventData("TARGET_OBJECT_ID", Utils::ObjectIDToString(oidTarget));
-    Events::PushEventData("MULTI_CLASS", std::to_string(multiClass));
-    Events::PushEventData("ITEM_OBJECT_ID", Utils::ObjectIDToString(oidItem));
-    Events::PushEventData("SPELL_COUNTERED", std::to_string(spellCountered));
-    Events::PushEventData("COUNTERING_SPELL", std::to_string(counteringSpell));
-    Events::PushEventData("PROJECTILE_PATH_TYPE", std::to_string(projectilePathType));
-    Events::PushEventData("IS_INSTANT_SPELL", std::to_string(isInstantSpell));
+        Events::PushEventData("TARGET_OBJECT_ID", Utils::ObjectIDToString(oidTarget));
+        Events::PushEventData("MULTI_CLASS", std::to_string(multiClass));
+        Events::PushEventData("ITEM_OBJECT_ID", Utils::ObjectIDToString(oidItem));
+        Events::PushEventData("SPELL_COUNTERED", std::to_string(spellCountered));
+        Events::PushEventData("COUNTERING_SPELL", std::to_string(counteringSpell));
+        Events::PushEventData("PROJECTILE_PATH_TYPE", std::to_string(projectilePathType));
+        Events::PushEventData("IS_INSTANT_SPELL", std::to_string(isInstantSpell));
+        return Events::SignalEvent(ev, thisPtr->m_idSelf);
+    };
 
-    Events::SignalEvent(before ? "NWNX_ON_CAST_SPELL_BEFORE" : "NWNX_ON_CAST_SPELL_AFTER", thisPtr->m_idSelf);
+    if (PushAndSignal("NWNX_ON_CAST_SPELL_BEFORE"))
+    {
+        m_SpellCastAndImpactHook->CallOriginal<void>(thisPtr, spellID, targetPosition, oidTarget, multiClass, oidItem,
+                spellCountered, counteringSpell, projectilePathType, isInstantSpell);
+    }
+    else
+    {
+        thisPtr->m_bLastSpellCast = true;
+    }
+
+    PushAndSignal("NWNX_ON_CAST_SPELL_AFTER");
 }
 
 }

--- a/Plugins/Events/Events/SpellEvents.hpp
+++ b/Plugins/Events/Events/SpellEvents.hpp
@@ -16,7 +16,6 @@ public:
 private:
     static void CastSpellHook
     (
-        NWNXLib::Services::Hooks::CallType,
         NWNXLib::API::CNWSObject*,
         uint32_t,
         NWNXLib::API::Vector,

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -512,6 +512,7 @@ string NWNX_Events_GetEventData(string tag);
 // - Polymorph events
 // - DMAction events
 // - Client connect event
+// - Spell events
 void NWNX_Events_SkipEvent();
 
 // Set the return value of the event.


### PR DESCRIPTION
Resolves #357 

SpellEvents are now skippable.

Example / Test

```
#include "nwnx_events"
#include "nwnx_object"

void main()
{
    object oCaster = OBJECT_SELF;
    string sEvent = NWNX_Events_GetCurrentEvent();
    int bBefore = FindSubString(sEvent, "_BEFORE") != -1;

    if (FindSubString(sEvent, "NWNX_ON_CAST_SPELL") != -1)
    {
        int nSpell = StringToInt(NWNX_Events_GetEventData("SPELL_ID"));

        SendMessageToPC(oCaster, (bBefore ? "BEFORE: " : "AFTER: '") + GetName(oCaster) + "' cast spell: '" + IntToString(nSpell) + "'");

        if(bBefore)
        {
            if (nSpell == SPELL_LIGHT)
            {
                NWNX_Events_SkipEvent();
            }
        }
    }
}
```