### PR TITLE
FindItemWithBaseItemID event, used by out of ammo search for next stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Events: Added Event Data for SpawnObject, GiveItem and GiveAlignment, Heal, Kill, ToggleInvulnerabilty, ForceRest, Limbo, ToggleAI, ToggleImmortal, Goto, Possess, PossessFullPower, ToggleLock, DisableTrap, JumpToPoint, JumpTargetToPoint, JumpAllPlayersToPoint, ChangeDifficulty, ViewInventory, SpawnTrapOnObject events in DMActionEvents
 - Events: Added OnClientConnect events that fire before the player sees the server vault.
 - Events: Added ItemInventory{Open/Close} and ItemInventory{Add/Remove}Item events to ItemEvents
-- Events: Added FindItemWithBaseItemId events that are used when the engine is looking for ammunition to reload
+- Events: Added AmmoReload events that are used when the engine is looking for ammunition to reload
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite
 - Tweaks: DisableQuickSave

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Events: Added Event Data for SpawnObject, GiveItem and GiveAlignment, Heal, Kill, ToggleInvulnerabilty, ForceRest, Limbo, ToggleAI, ToggleImmortal, Goto, Possess, PossessFullPower, ToggleLock, DisableTrap, JumpToPoint, JumpTargetToPoint, JumpAllPlayersToPoint, ChangeDifficulty, ViewInventory, SpawnTrapOnObject events in DMActionEvents
 - Events: Added OnClientConnect events that fire before the player sees the server vault.
 - Events: Added ItemInventory{Open/Close} and ItemInventory{Add/Remove}Item events to ItemEvents
+- Events: Added FindItemWithBaseItemId events that are used when the engine is looking for ammunition to reload
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite
 - Tweaks: DisableQuickSave

--- a/Plugins/Events/Events/ItemEvents.cpp
+++ b/Plugins/Events/Events/ItemEvents.cpp
@@ -229,13 +229,9 @@ uint32_t ItemEvents::FindItemWithBaseItemIdHook(CItemRepository* thisPtr, uint32
 
     if (Events::SignalEvent("NWNX_ON_ITEM_AMMO_RELOAD_AFTER", thisPtr->m_oidParent, &sAfterEventResult))
     {
-        retVal = m_FindItemWithBaseItemIdHook->CallOriginal<uint32_t>(thisPtr, baseItem, nTh);
-    }
-    else
-    {
-        retVal = stoul(sAfterEventResult, nullptr, 16);
-        if (ItemSanityCheck(retVal))
-            return retVal;
+        uint32_t result = stoul(sAfterEventResult, nullptr, 16);
+        if (ItemSanityCheck(result))
+            return result;
     }
 
     return retVal;

--- a/Plugins/Events/Events/ItemEvents.cpp
+++ b/Plugins/Events/Events/ItemEvents.cpp
@@ -177,9 +177,7 @@ uint32_t ItemEvents::FindItemWithBaseItemIdHook(CItemRepository* thisPtr, uint32
     // unless the player has > 255 stacks of ammo they can't equip
     // Suppose I could set this to a higher value but I think this is safe
     if(nTh > 255)
-    {
         return OBJECT_INVALID;
-    }
 
     auto ItemSanityCheck = [&](uint32_t objectId) -> bool {
         if (static_cast<Types::ObjectID>(objectId) == Constants::OBJECT_INVALID)
@@ -212,7 +210,7 @@ uint32_t ItemEvents::FindItemWithBaseItemIdHook(CItemRepository* thisPtr, uint32
     Events::PushEventData("BASE_ITEM_ID", std::to_string(baseItem));
     Events::PushEventData("BASE_ITEM_NTH", std::to_string(nTh));
 
-    if (Events::SignalEvent("NWNX_ON_ITEM_FIND_ITEM_WITH_BASE_ITEMID_BEFORE", thisPtr->m_oidParent, &sBeforeEventResult))
+    if (Events::SignalEvent("NWNX_ON_ITEM_AMMO_RELOAD_BEFORE", thisPtr->m_oidParent, &sBeforeEventResult))
     {
         retVal = m_FindItemWithBaseItemIdHook->CallOriginal<uint32_t>(thisPtr, baseItem, nTh);
     }
@@ -229,7 +227,7 @@ uint32_t ItemEvents::FindItemWithBaseItemIdHook(CItemRepository* thisPtr, uint32
     Events::PushEventData("BASE_ITEM_NTH", std::to_string(nTh));
     Events::PushEventData("ACTION_RESULT", Utils::ObjectIDToString(retVal));
 
-    if (Events::SignalEvent("NWNX_ON_ITEM_FIND_ITEM_WITH_BASE_ITEMID_AFTER", thisPtr->m_oidParent, &sAfterEventResult))
+    if (Events::SignalEvent("NWNX_ON_ITEM_AMMO_RELOAD_AFTER", thisPtr->m_oidParent, &sAfterEventResult))
     {
         retVal = m_FindItemWithBaseItemIdHook->CallOriginal<uint32_t>(thisPtr, baseItem, nTh);
     }

--- a/Plugins/Events/Events/ItemEvents.cpp
+++ b/Plugins/Events/Events/ItemEvents.cpp
@@ -156,6 +156,15 @@ void ItemEvents::RemoveItemHook(Services::Hooks::CallType type, CItemRepository*
 
 uint32_t ItemEvents::FindItemWithBaseItemIdHook(CItemRepository* thisPtr, uint32_t baseItem, int32_t nTh)
 {
+
+    // This event hook is currently only used for Ammunition Reloading but could in the future be used for more
+    if ((baseItem != Constants::BaseItem::Arrow &&
+         baseItem != Constants::BaseItem::Bolt &&
+         baseItem != Constants::BaseItem::Bullet))
+    {
+        return m_FindItemWithBaseItemIdHook->CallOriginal<int32_t>(thisPtr, baseItem, nTh);
+    }
+
     auto *pItemHolder = Utils::AsNWSCreature(Globals::AppManager()->m_pServerExoApp->GetGameObject(thisPtr->m_oidParent));
 
     if(!pItemHolder)

--- a/Plugins/Events/Events/ItemEvents.cpp
+++ b/Plugins/Events/Events/ItemEvents.cpp
@@ -187,7 +187,7 @@ uint32_t ItemEvents::FindItemWithBaseItemIdHook(CItemRepository* thisPtr, uint32
             LOG_WARNING("Base Item ID of returned item does not match, falling back to original call.");
             objectId = m_FindItemWithBaseItemIdHook->CallOriginal<uint32_t>(thisPtr, baseItem, nTh);
         }
-        else if (pItem->m_pItemRepository != thisPtr)
+        else if (pItem->m_oidPossessor != thisPtr->m_oidParent)
         {
             LOG_WARNING("Item does not belong to that creature, falling back to original call.");
             objectId = m_FindItemWithBaseItemIdHook->CallOriginal<uint32_t>(thisPtr, baseItem, nTh);

--- a/Plugins/Events/Events/ItemEvents.cpp
+++ b/Plugins/Events/Events/ItemEvents.cpp
@@ -164,6 +164,14 @@ uint32_t ItemEvents::FindItemWithBaseItemIdHook(CItemRepository* thisPtr, uint32
         return m_FindItemWithBaseItemIdHook->CallOriginal<int32_t>(thisPtr, baseItem, nTh);
     }
 
+    // We're most assuredly in an infinite loop here caused by the scripting end
+    // unless the player has > 255 stacks of ammo they can't equip
+    // Suppose I could set this to a higher value but I think this is safe
+    if(nTh > 255)
+    {
+        return OBJECT_INVALID;
+    }
+
     auto ItemSanityCheck = [&](uint32_t objectId) -> uint32_t {
         if (static_cast<Types::ObjectID>(objectId) == Constants::OBJECT_INVALID)
             return objectId;

--- a/Plugins/Events/Events/ItemEvents.hpp
+++ b/Plugins/Events/Events/ItemEvents.hpp
@@ -20,6 +20,7 @@ private:
     static void CloseInventoryHook(NWNXLib::API::CNWSItem*, NWNXLib::API::Types::ObjectID, int32_t);
     static int32_t AddItemHook(NWNXLib::API::CItemRepository*, NWNXLib::API::CNWSItem**, uint8_t, uint8_t, int32_t, int32_t);
     static void RemoveItemHook(NWNXLib::Services::Hooks::CallType, NWNXLib::API::CItemRepository*, NWNXLib::API::CNWSItem*);
+    static uint32_t FindItemWithBaseItemIdHook(NWNXLib::API::CItemRepository*, uint32_t, int32_t);
 };
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -74,6 +74,20 @@
     Event data:
         Variable Name           Type        Notes
         ITEM                    object      Convert to object with NWNX_Object_StringToObject()
+
+    NWNX_ON_ITEM_FIND_ITEM_WITH_BASE_ITEMID_BEFORE
+    NWNX_ON_ITEM_FIND_ITEM_WITH_BASE_ITEMID_AFTER
+
+    Note: This is mainly used by NWN to search for the next available ammunition to autoequip
+
+    Usage:
+        OBJECT_SELF = The creature whose inventory we're searching for the item type
+
+    Event data:
+        Variable Name           Type        Notes
+        BASE_ITEM_ID            int
+        BASE_ITEM_NTH           int         Find the Nth instance of this item
+        ACTION_RESULT           int         The object that was determined in BEFORE (only in after)
 ////////////////////////////////////////////////////////////////////////////////
     NWNX_ON_USE_FEAT_BEFORE
     NWNX_ON_USE_FEAT_AFTER
@@ -521,6 +535,7 @@ void NWNX_Events_SkipEvent();
 // - Healer's Kit event
 // - Listen/Spot Detection events -> "1" or "0"
 // - OnClientConnectBefore -> Reason for disconnect if skipped
+// - FindItemByBaseItemID -> Forced item found
 void NWNX_Events_SetEventResult(string data);
 
 // Returns the current event name

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -75,10 +75,10 @@
         Variable Name           Type        Notes
         ITEM                    object      Convert to object with NWNX_Object_StringToObject()
 
-    NWNX_ON_ITEM_FIND_ITEM_WITH_BASE_ITEMID_BEFORE
-    NWNX_ON_ITEM_FIND_ITEM_WITH_BASE_ITEMID_AFTER
+    NWNX_ON_ITEM_AMMO_RELOAD_BEFORE
+    NWNX_ON_ITEM_AMMO_RELOAD_AFTER
 
-    Note: This is mainly used by NWN to search for the next available ammunition to autoequip
+    Note: Search for the next available ammunition to autoequip
 
     Usage:
         OBJECT_SELF = The creature whose inventory we're searching for the item type
@@ -535,7 +535,7 @@ void NWNX_Events_SkipEvent();
 // - Healer's Kit event
 // - Listen/Spot Detection events -> "1" or "0"
 // - OnClientConnectBefore -> Reason for disconnect if skipped
-// - FindItemByBaseItemID -> Forced item found
+// - Ammo Reload event -> Forced ammunition returned
 void NWNX_Events_SetEventResult(string data);
 
 // Returns the current event name


### PR DESCRIPTION
This function is used by the engine to search for the next stack of ammunition when the creature runs out of its existing stack. Resolves #225 

Does there need to be more sanity checking on the engine side?
* Make sure the item belongs to the creature
* Make sure the item still matches the base item
* Make sure they're allowed to equip the item

I'm not really sure the nTh instant of the baseitem is ever anything but 0 in its current state but should this function be used for more in the future it's there for completeness.