### PR TITLE
Bypass any player/DM logged in info when at account screen

### DIFF
--- a/Plugins/Experimental/Experimentals/SuppressPlayerLoginInfo.cpp
+++ b/Plugins/Experimental/Experimentals/SuppressPlayerLoginInfo.cpp
@@ -27,6 +27,9 @@ SuppressPlayerLoginInfo::SuppressPlayerLoginInfo(ViewPtr<Services::HooksProxy> h
 
     hooker->RequestExclusiveHook<API::Functions::CNWSMessage__SendServerToPlayerPlayerList_Delete, int32_t>(&SendServerToPlayerPlayerList_DeleteHook);
     m_SendServerToPlayerPlayerList_DeleteHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__SendServerToPlayerPlayerList_Delete);
+
+    hooker->RequestExclusiveHook<API::Functions::CNWSMessage__HandlePlayerToServerPlayModuleCharacterList_Start>
+        (&HandlePlayerToServerPlayModuleCharacterList_StartHook);
 }
 
 int32_t SuppressPlayerLoginInfo::SendServerToPlayerPlayerList_AddHook(CNWSMessage *pThis, uint32_t nPlayerId, CNWSPlayer *pNewPlayer)
@@ -49,5 +52,13 @@ int32_t SuppressPlayerLoginInfo::SendServerToPlayerPlayerList_DeleteHook(CNWSMes
            m_SendServerToPlayerPlayerList_DeleteHook->CallOriginal<int32_t>(pThis, nPlayerId, pNewPlayer) :
            false;
 }
+int32_t SuppressPlayerLoginInfo::HandlePlayerToServerPlayModuleCharacterList_StartHook(
+    CNWSMessage* pThis, CNWSPlayer* pPlayer)
+{
+    if (pThis->MessageReadOverflow(true) || pThis->MessageReadUnderflow(true))
+        return false;
 
+    pPlayer->m_bPlayModuleListingCharacters = true;
+    return true;
+}
 }

--- a/Plugins/Experimental/Experimentals/SuppressPlayerLoginInfo.hpp
+++ b/Plugins/Experimental/Experimentals/SuppressPlayerLoginInfo.hpp
@@ -15,6 +15,7 @@ private:
     static int32_t SendServerToPlayerPlayerList_AddHook(NWNXLib::API::CNWSMessage*, uint32_t, NWNXLib::API::CNWSPlayer*);
     static int32_t SendServerToPlayerPlayerList_AllHook(NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*);
     static int32_t SendServerToPlayerPlayerList_DeleteHook(NWNXLib::API::CNWSMessage*, uint32_t, NWNXLib::API::CNWSPlayer*);
+    static int32_t HandlePlayerToServerPlayModuleCharacterList_StartHook(NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*);
 };
 
 }


### PR DESCRIPTION
Requires `NWNX_TWEAKS_HIDE_DMS_ON_CHAR_LIST=false`