### PR TITLE
Reveal Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The following plugins were added:
 - **Feedback**: Allows combatlog and feedback messages to be hidden globally or per player
 - **ItemProperty**: Provides various utility functions to manipulate builtin itemproperty types
 - **Rename**: Adds functions to facilitate renaming, overriding and customization of player names
+- **Reveal**: Adds functions to allow the selective revealing of a stealthed character to another character or their party.
 - **Visibility**: Allows the visibility of objects to be overridden globally or per player
 ##### New NWScript Functions
 - Administration: GetPlayOption()
@@ -102,6 +103,8 @@ The following plugins were added:
 - Player: SetRestDuration()
 - Player: ApplyInstantVisualEffectToObject()
 - Rename: SetPCNameOverride()
+- Reveal: RevealTo()
+- Reveal: SetRevealToParty()
 - Util: GenerateUUID()
 - Util: GetCustomToken()
 - Util: EffectToItemProperty()

--- a/Plugins/Reveal/CMakeLists.txt
+++ b/Plugins/Reveal/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_plugin(Reveal
+    "Reveal.cpp")

--- a/Plugins/Reveal/Documentation/README.md
+++ b/Plugins/Reveal/Documentation/README.md
@@ -11,5 +11,5 @@ This plugin allows the selective revealing of a stealthing character to another 
 
 Script function | Description  
 ----------------|-------------
-NWNX_Reveal_RevealTo | Selectively reveals the character oHiding to the character oObserver, until the next time oHiding stealths out of sight.
-NWNX_Reveal_SetRevealToParty | Sets whether oHiding remains visible to the character's party through stealth.
+NWNX_Reveal_RevealTo | Selectively reveals the character oHiding to the character oObserver, until the next time oHiding stealths out of sight. iDetectionMethod can be specified to determine whether oHiding is seen or heard.
+NWNX_Reveal_SetRevealToParty | Sets whether oHiding remains visible to the character's party through stealth. iDetectionMethod can be specified to determine whether oHiding is seen or heard.

--- a/Plugins/Reveal/Documentation/README.md
+++ b/Plugins/Reveal/Documentation/README.md
@@ -1,0 +1,15 @@
+# Reveal Plugin Reference
+
+## Environment Variables
+
+None
+
+## Description
+
+
+This plugin allows the selective revealing of a stealthing character to another character or their party.
+
+Script function | Description  
+----------------|-------------
+NWNX_Reveal_RevealTo | Selectively reveals the character oHiding to the character oObserver, until the next time oHiding stealths out of sight.
+NWNX_Reveal_SetRevealToParty | Sets whether oHiding remains visible to the character's party through stealth.

--- a/Plugins/Reveal/NWScript/nwnx_reveal.nss
+++ b/Plugins/Reveal/NWScript/nwnx_reveal.nss
@@ -2,27 +2,36 @@
 
 const string NWNX_Reveal = "NWNX_Reveal";
 
+//Detection method constants
+
+const int NWNX_REVEAL_SEEN = 1;
+const int NWNX_REVEAL_HEARD = 0;
+
 //Selectively reveals the character oHiding to the character oObserver, until the next time oHiding stealths out of sight.
-void NWNX_Reveal_RevealTo(object oHiding, object oObserver);
+//iDetectionMethod can be specified to determine whether oHiding is seen or heard. 
+void NWNX_Reveal_RevealTo(object oHiding, object oObserver, int iDetectionMethod = NWNX_REVEAL_HEARD);
 
-//Sets whether oHiding remains visible to the character's party through stealth. 
-void NWNX_Reveal_SetRevealToParty(object oHiding, int bReveal); 
+//Sets whether oHiding remains visible to the character's party through stealth.
+//iDetectionMethod can be specified to determine whether oHiding is seen or heard. 
+void NWNX_Reveal_SetRevealToParty(object oHiding, int bReveal, int iDetectionMethod = NWNX_REVEAL_HEARD); 
 
 
-void NWNX_Reveal_RevealTo(object oHiding, object oObserver)
+void NWNX_Reveal_RevealTo(object oHiding, object oObserverint, iDetectionMethod = NWNX_REVEAL_HEARD)
 {
     string sFunc = "RevealTo";
     
+    NWNX_PushArgumentInt(NWNX_Reveal, sFunc, iDetectionMethod);
     NWNX_PushArgumentObject(NWNX_Reveal, sFunc, oObserver);
     NWNX_PushArgumentObject(NWNX_Reveal, sFunc, oHiding);
 
     NWNX_CallFunction(NWNX_Reveal, sFunc);
 }
 
-void NWNX_Reveal_SetRevealToParty(object oHiding, int bReveal)
+void NWNX_Reveal_SetRevealToParty(object oHiding, int bReveal, int iDetectionMethod = NWNX_REVEAL_HEARD)
 {
     string sFunc = "SetRevealToParty";
     
+    NWNX_PushArgumentInt(NWNX_Reveal, sFunc, iDetectionMethod);
     NWNX_PushArgumentInt(NWNX_Reveal, sFunc, bReveal);
     NWNX_PushArgumentObject(NWNX_Reveal, sFunc, oHiding);
 

--- a/Plugins/Reveal/NWScript/nwnx_reveal.nss
+++ b/Plugins/Reveal/NWScript/nwnx_reveal.nss
@@ -1,0 +1,30 @@
+#include "nwnx"
+
+const string NWNX_Reveal = "NWNX_Reveal";
+
+//Selectively reveals the character oHiding to the character oObserver, until the next time oHiding stealths out of sight.
+void NWNX_Reveal_RevealTo(object oHiding, object oObserver);
+
+//Sets whether oHiding remains visible to the character's party through stealth. 
+void NWNX_Reveal_SetRevealToParty(object oHiding, int bReveal); 
+
+
+void NWNX_Reveal_RevealTo(object oHiding, object oObserver)
+{
+    string sFunc = "RevealTo";
+    
+    NWNX_PushArgumentObject(NWNX_Reveal, sFunc, oObserver);
+    NWNX_PushArgumentObject(NWNX_Reveal, sFunc, oHiding);
+
+    NWNX_CallFunction(NWNX_Reveal, sFunc);
+}
+
+void NWNX_Reveal_SetRevealToParty(object oHiding, int bReveal)
+{
+    string sFunc = "SetRevealToParty";
+    
+    NWNX_PushArgumentInt(NWNX_Reveal, sFunc, bReveal);
+    NWNX_PushArgumentObject(NWNX_Reveal, sFunc, oHiding);
+
+    NWNX_CallFunction(NWNX_Reveal, sFunc);
+}

--- a/Plugins/Reveal/Reveal.cpp
+++ b/Plugins/Reveal/Reveal.cpp
@@ -1,0 +1,111 @@
+#include "Reveal.hpp"
+#include <string>
+#include "API/CNWSCreature.hpp"
+#include "API/CNWSFaction.hpp"
+#include "API/Functions.hpp"
+#include "Services/PerObjectStorage/PerObjectStorage.hpp"
+#include "ViewPtr.hpp"
+
+
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+static ViewPtr<Reveal::Reveal> g_plugin;
+
+//key names for Per Object Storage
+const std::string revealKey = "REVEAL";
+
+
+
+NWNX_PLUGIN_ENTRY Plugin::Info* PluginInfo()
+{
+    return new Plugin::Info
+    {
+        "Reveal",
+        "Functions to allow the selective revealing of a stealthing character to another character or their party.",
+        "Silvard",
+        "jusenkyo at gmail.com",
+        1,
+        true
+    };
+}
+
+NWNX_PLUGIN_ENTRY Plugin* PluginLoad(Plugin::CreateParams params)
+{
+    g_plugin = new Reveal::Reveal(params);
+    return g_plugin;
+}
+
+namespace Reveal {
+
+Reveal::Reveal(const Plugin::CreateParams& params)
+  : Plugin(params)
+{
+#define REGISTER(func)              \
+    GetServices()->m_events->RegisterEvent(#func, std::bind(&Reveal::func, this, std::placeholders::_1))
+
+    REGISTER(RevealTo);
+    REGISTER(SetRevealToParty);
+
+#undef REGISTER
+
+    GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWSCreature__DoStealthDetection, int32_t,CNWSCreature*,CNWSCreature*, int32_t, int32_t*, int32_t*, int32_t>(&HookStealthDetection);
+
+    m_DoStealthDetection = GetServices()->m_hooks->FindHookByAddress(Functions::CNWSCreature__DoStealthDetection);
+}   
+
+Reveal::~Reveal()
+{
+}
+int32_t Reveal::HookStealthDetection(NWNXLib::API::CNWSCreature* pObserverCreature, NWNXLib::API::CNWSCreature* pHidingCreature, int32_t bClearLOS, int32_t* bSeen, int32_t* bHeard, int32_t bTargetInvisible)
+{
+    if (pObserverCreature->m_bPlayerCharacter && pHidingCreature->m_bPlayerCharacter && pHidingCreature->m_nStealthMode)
+    {
+        if (pObserverCreature->GetArea() == pHidingCreature->GetArea())
+        {
+            if (static_cast<bool>(*g_plugin->GetServices()->m_perObjectStorage->Get<int>(pHidingCreature->m_idSelf, revealKey + "PARTY")))
+            {
+                if (pObserverCreature->GetFaction()->GetLeader() == pHidingCreature->GetFaction()->GetLeader())
+                {
+                    *bHeard = true;
+                    return true;
+                }
+            }
+            if (static_cast<bool>(*g_plugin->GetServices()->m_perObjectStorage->Get<int>(pHidingCreature->m_idSelf, revealKey + Utils::ObjectIDToString(pObserverCreature->m_idSelf))))
+            {
+                g_plugin->GetServices()->m_perObjectStorage->Remove(pHidingCreature->m_idSelf, revealKey + Utils::ObjectIDToString(pObserverCreature->m_idSelf));
+                *bHeard = true;
+                return true;
+            }
+        }
+    }
+    return g_plugin->m_DoStealthDetection->CallOriginal<int32_t>(pObserverCreature, pHidingCreature, bClearLOS, bSeen, bHeard, bTargetInvisible);
+    
+}
+
+
+ArgumentStack Reveal::RevealTo(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    auto stealtherID = Services::Events::ExtractArgument<Types::ObjectID>(args);
+    auto observerID = Services::Events::ExtractArgument<Types::ObjectID>(args);
+    
+    Services::PerObjectStorageProxy* pPOS = g_plugin->GetServices()->m_perObjectStorage.get();
+    
+    pPOS->Set(stealtherID, revealKey + Utils::ObjectIDToString(observerID), true); //store affix-less override
+    return stack;
+}
+
+ArgumentStack Reveal::SetRevealToParty(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    auto stealtherID = Services::Events::ExtractArgument<Types::ObjectID>(args);
+    auto revealToPartyState = Services::Events::ExtractArgument<int>(args);
+    Services::PerObjectStorageProxy* pPOS = g_plugin->GetServices()->m_perObjectStorage.get();
+    
+    pPOS->Set(stealtherID, revealKey + "PARTY", revealToPartyState); //store affix-less override
+    return stack;
+}
+
+}

--- a/Plugins/Reveal/Reveal.hpp
+++ b/Plugins/Reveal/Reveal.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "Plugin.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include "Services/Events/Events.hpp"
+#include "API/Types.hpp"
+#include "Common.hpp"
+#include "ViewPtr.hpp"
+
+using ArgumentStack = NWNXLib::Services::Events::ArgumentStack;
+
+namespace Reveal {
+
+class Reveal : public NWNXLib::Plugin
+{
+public:
+    Reveal(const Plugin::CreateParams& params);
+    virtual ~Reveal();
+
+private:
+
+    NWNXLib::Hooking::FunctionHook* m_DoStealthDetection;
+    
+    static int32_t HookStealthDetection(NWNXLib::API::CNWSCreature* thisCreature, NWNXLib::API::CNWSCreature* pHidingCreature, int32_t bClearLOS, int32_t* bSeen, int32_t* bHeard, int32_t bTargetInvisible);
+
+    ArgumentStack RevealTo(ArgumentStack&& args);
+    ArgumentStack SetRevealToParty(ArgumentStack&& args);
+};
+
+}

--- a/Plugins/Reveal/Reveal.hpp
+++ b/Plugins/Reveal/Reveal.hpp
@@ -18,7 +18,6 @@ public:
     virtual ~Reveal();
 
 private:
-
     NWNXLib::Hooking::FunctionHook* m_DoStealthDetection;
     
     static int32_t HookStealthDetection(NWNXLib::API::CNWSCreature* thisCreature, NWNXLib::API::CNWSCreature* pHidingCreature, int32_t bClearLOS, int32_t* bSeen, int32_t* bHeard, int32_t bTargetInvisible);


### PR DESCRIPTION
This plugin has functions to selectively reveal a stealthed character to another character (for the next detection check), or to toggle whether the stealthed character will always be revealed to members of their party. 