### PR TITLE
Localization support (cyrillic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 ### Added
 - Added support to skip building certain plugins by setting an environment variable, for example: `NWNX_SKIP_PLUGINS="JVM;Lua;Mono;Ruby;SpellChecker"`
 - Added support to build out of tree plugins with the following environment variable: `NWNX_ADDITIONAL_PLUGINS=/path/to/Plugin1;/path/to/Plugin2`
+- Added string localization support. Only Russian/Cyrillic supported at the moment. Use environment variable `NWNX_CORE_LOCALE=ru`
 - Core: Allow changing default plugin state from 'load all' to 'skip all' with the following environment variable: `NWNX_CORE_SKIP_ALL=y`. Use `NWNX_PLUGIN_SKIP=n` to enable specific plugins in this case.
 - Core: Allow passing engine structures to nwnx (Effect/Itemproperty)
 - Events: New events: SkillEvents, MapEvents

--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -17,6 +17,7 @@
 #include "Services/PerObjectStorage/PerObjectStorage.hpp"
 #include "Services/Commands/Commands.hpp"
 #include "Utils.hpp"
+#include "Encoding.hpp"
 
 #include <csignal>
 
@@ -310,6 +311,11 @@ void NWNXCore::CreateServerHandler(API::CAppManager* app)
 
     // We need to set the NWNXLib log level (separate from Core now) to match the core log level.
     Log::SetLogLevel("NWNXLib", Log::GetLogLevel(NWNX_CORE_PLUGIN_NAME));
+
+    if (auto locale = g_core->m_coreServices->m_config->Get<std::string>("LOCALE"))
+    {
+        Encoding::SetDefaultLocale(*locale);
+    }
 
     Maybe<bool> crashOnAssertFailure = g_core->m_coreServices->m_config->Get<bool>("CRASH_ON_ASSERT_FAILURE");
     if (crashOnAssertFailure)

--- a/NWNXLib/CMakeLists.txt
+++ b/NWNXLib/CMakeLists.txt
@@ -16,7 +16,7 @@ macro(nwnxlib_add)
     endif()
 endmacro()
 
-nwnxlib_add("Assert.cpp" "Log.cpp" "Plugin.cpp" "Serialize.cpp" "Utils.cpp")
+nwnxlib_add("Assert.cpp" "Log.cpp" "Plugin.cpp" "Serialize.cpp" "Utils.cpp" "Encoding.cpp")
 
 add_subdirectory(API)
 add_subdirectory(External)

--- a/NWNXLib/Encoding.cpp
+++ b/NWNXLib/Encoding.cpp
@@ -154,4 +154,62 @@ std::string FromUTF8(const char *str, Locale locale)
 }
 
 
+static const char base64_key[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+std::string ToBase64(const std::vector<uint8_t>& in)
+{
+    std::string out;
+    out.reserve(4*in.size()/3 + 4);
+
+    int val = 0, valb = -6;
+    for (uint8_t c : in)
+    {
+        val = (val << 8) + c;
+        valb += 8;
+        while (valb >= 0)
+        {
+            out.push_back(base64_key[(val>>valb)&0x3F]);
+            valb-=6;
+        }
+    }
+
+    if (valb > -6)
+    {
+        out.push_back(base64_key[((val<<8)>>(valb+8))&0x3F]);
+    }
+    while (out.size()%4)
+    {
+        out.push_back('=');
+    }
+    return std::move(out);
+}
+
+std::vector<uint8_t> FromBase64(const std::string &in)
+{
+    std::vector<uint8_t> out;
+    out.reserve(3*in.length()/4 + 4);
+
+    static int Table[256];
+    if (Table['+'] == 0)
+    {
+        memset(Table, 0xFF, sizeof(Table));
+        for (int i = 0; i < 64; i++)
+            Table[(uint8_t)(base64_key[i])] = i;
+    }
+
+    int val = 0, valb = -8;
+    for (char c : in)
+    {
+        if (Table[(uint8_t)c] == -1)
+            break;
+        val = (val<<6) + Table[(uint8_t)c];
+        valb += 6;
+        if (valb>=0)
+        {
+            out.push_back(uint8_t((val>>valb)&0xFF));
+            valb -= 8;
+        }
+    }
+    return std::move(out);
+}
+
 }

--- a/NWNXLib/Encoding.cpp
+++ b/NWNXLib/Encoding.cpp
@@ -1,0 +1,157 @@
+#include "Encoding.hpp"
+#include "Assert.hpp"
+#include "Log.hpp"
+
+#include <string>
+#include <string.h>
+#include <algorithm>
+
+namespace NWNXLib::Encoding {
+
+Locale g_DefaultLocale = Western;
+
+Locale GetDefaultLocale()
+{
+    return g_DefaultLocale;
+}
+void SetDefaultLocale(Locale locale)
+{
+    if (locale == Default)
+        locale = Western;
+
+    g_DefaultLocale = locale;
+}
+void SetDefaultLocale(const std::string& locale)
+{
+    if (locale.empty())
+        return;
+
+    std::string sub = locale.substr(0, 2);
+    std::transform(sub.begin(), sub.end(), sub.begin(), ::tolower);
+
+    if (sub == "ru")
+        SetDefaultLocale(Russian);
+    else
+    {
+        LOG_WARNING("Unknown locale %s", locale.c_str());
+        SetDefaultLocale(Default);
+    }
+}
+
+std::string ToUTF8(const char *str, Locale locale)
+{
+    if (str == nullptr || *str == 0)
+        return std::string("");
+
+    std::string utf8("");
+    utf8.reserve(2*strlen(str) + 1);
+
+    if (locale == Default)
+        locale = GetDefaultLocale();
+
+    const char *tmp = str;
+
+    for (; *str; ++str)
+    {
+        if (!(*str & 0x80))
+        {
+            utf8.push_back(*str);
+        }
+        else
+        {
+            int codepoint = static_cast<uint8_t>(*str);
+            switch (locale)
+            {
+                case Western:
+                    utf8.push_back(0xc2 | static_cast<char>(codepoint >> 6));
+                    utf8.push_back(0xbf & static_cast<char>(codepoint & 0xFF));
+                    break;
+                case Russian:
+                    if (codepoint == 168)
+                        codepoint = 177;
+                    if (codepoint > 176 && codepoint < 256)
+                    {
+                        codepoint += 848;
+                    }
+                    utf8.push_back(0xc0 | static_cast<char>(codepoint >> 6));
+                    utf8.push_back((0xbf & static_cast<char>(codepoint & 0xFF)) | 0x80);
+                    break;
+                default:
+                    utf8.push_back('?');
+                    ASSERT_FAIL_MSG("Unknown locale");
+                    break;
+            }
+        }
+    }
+    LOG_DEBUG("ToUTF: \"%s\" -> \"%s\"", tmp, utf8.c_str());
+    return utf8;
+}
+
+// Adapted from https://stackoverflow.com/a/23690194/2771245
+std::string FromUTF8(const char *str, Locale locale)
+{
+    if (str == nullptr || *str == 0)
+        return std::string("");
+
+    std::string iso8859("");
+    iso8859.reserve(strlen(str) + 1);
+
+    if (locale == Default)
+        locale = GetDefaultLocale();
+
+    const char *tmp = str;
+    uint32_t codepoint = 0;
+    for (; *str; ++str)
+    {
+        uint8_t ch = static_cast<uint8_t>(*str);
+        if (ch <= 0x7f)
+            codepoint = ch;
+        else if (ch <= 0xbf)
+            codepoint = (codepoint << 6) | (ch & 0x3f);
+        else if (ch <= 0xdf)
+            codepoint = ch & 0x1f;
+        else if (ch <= 0xef)
+            codepoint = ch & 0x0f;
+        else
+            codepoint = ch & 0x07;
+
+        if (((str[1] & 0xc0) != 0x80) && (codepoint <= 0x10ffff))
+        {
+            if (codepoint <= 0xFF)
+            {
+                iso8859.push_back(static_cast<char>(codepoint));
+            }
+            else // Special character out of bounds
+            {
+                switch (locale)
+                {
+                    case Western:
+                        iso8859.push_back('?');
+                        break;
+                    case Russian:
+                        if (codepoint > 1024 && codepoint < 1106)
+                        {
+                            if (codepoint == 1025)
+                                codepoint = 1016;
+
+                            iso8859.push_back(static_cast<char>(codepoint - 848));
+                        }
+                        else
+                        {
+                            iso8859.push_back('?');
+                        }
+                        break;
+                    default:
+                        iso8859.push_back('?');
+                        ASSERT_FAIL_MSG("Unknown locale");
+                        break;
+                }
+            }
+        }
+    }
+    LOG_DEBUG("FromUTF: \"%s\" -> \"%s\"", tmp, iso8859.c_str());
+    return iso8859;
+}
+
+
+}

--- a/NWNXLib/Encoding.hpp
+++ b/NWNXLib/Encoding.hpp
@@ -3,6 +3,7 @@
 //
 
 #include <string>
+#include <vector>
 
 namespace NWNXLib::Encoding {
 
@@ -19,6 +20,10 @@ void SetDefaultLocale(const std::string& locale);
 
 std::string ToUTF8(const char *str, Locale locale = Default);
 std::string FromUTF8(const char *str, Locale locale = Default);
+
+std::string ToBase64(const std::vector<uint8_t>& in);
+std::vector<uint8_t> FromBase64(const std::string &in);
+
 
 //
 // Convenience wrappers

--- a/NWNXLib/Encoding.hpp
+++ b/NWNXLib/Encoding.hpp
@@ -1,0 +1,36 @@
+//
+// Helper library to encode/decode various streams
+//
+
+#include <string>
+
+namespace NWNXLib::Encoding {
+
+enum Locale
+{
+    Default,
+    Western,
+    Russian,
+};
+
+Locale GetDefaultLocale();
+void SetDefaultLocale(Locale locale);
+void SetDefaultLocale(const std::string& locale);
+
+std::string ToUTF8(const char *str, Locale locale = Default);
+std::string FromUTF8(const char *str, Locale locale = Default);
+
+//
+// Convenience wrappers
+//
+static inline std::string ToUTF8(const std::string& str, Locale locale = Default)
+{
+    return std::move(ToUTF8(str.c_str(), locale));
+}
+static inline std::string FromUTF8(const std::string& str, Locale locale = Default)
+{
+    return std::move(FromUTF8(str.c_str(), locale));
+}
+
+
+}

--- a/Plugins/Mono/Mono_Handlers.cpp
+++ b/Plugins/Mono/Mono_Handlers.cpp
@@ -10,6 +10,7 @@
 #include "API/CWorldTimer.hpp"
 #include "API/Globals.hpp"
 
+#include "Encoding.hpp"
 #include "Log.hpp"
 
 using namespace NWNXLib;
@@ -131,7 +132,7 @@ void StackPushString(MonoString* value)
 
     char* valueAsCStr = mono_string_to_utf8(value);
     LOG_DEBUG("Pushing string '%s'.", valueAsCStr);
-    CExoString str(UTF8ToISO8859(valueAsCStr).c_str());
+    CExoString str(Encoding::FromUTF8(valueAsCStr).c_str());
     mono_free(valueAsCStr);
 
     if (GetVm()->StackPushString(str))
@@ -245,7 +246,7 @@ MonoString* StackPopString()
 
     LOG_DEBUG("Popped string '%s'.", value.m_sString);
 
-    return mono_string_new(g_Domain, ISO8859ToUTF8(value.CStr()).c_str());
+    return mono_string_new(g_Domain, Encoding::ToUTF8(value.CStr()).c_str());
 }
 
 uint32_t StackPopObject()
@@ -395,60 +396,6 @@ int32_t ClosureActionDoCommand(uint32_t oid, uint64_t eventId)
     }
 
     return 0;
-}
-
-std::string ISO8859ToUTF8(const char *str)
-{
-    if (str == nullptr || *str == 0)
-        return std::string("");
-
-    std::string utf8("");
-    utf8.reserve(2*strlen(str) + 1);
-
-    for (; *str; ++str)
-    {
-        if (!(*str & 0x80))
-        {
-            utf8.push_back(*str);
-        } else
-        {
-            utf8.push_back(0xc2 | ((unsigned char)(*str) >> 6));
-            utf8.push_back(0xbf & *str);
-        }
-    }
-    return utf8;
-}
-
-// Adapted from https://stackoverflow.com/a/23690194/2771245
-std::string UTF8ToISO8859(const char *str)
-{
-    if (str == nullptr || *str == 0)
-        return std::string("");
-
-    std::string iso8859("");
-    iso8859.reserve(strlen(str) + 1);
-
-    uint32_t codepoint = 0;
-    for (; *str; ++str)
-    {
-        uint8_t ch = static_cast<uint8_t>(*str);
-        if (ch <= 0x7f)
-            codepoint = ch;
-        else if (ch <= 0xbf)
-            codepoint = (codepoint << 6) | (ch & 0x3f);
-        else if (ch <= 0xdf)
-            codepoint = ch & 0x1f;
-        else if (ch <= 0xef)
-            codepoint = ch & 0x0f;
-        else
-            codepoint = ch & 0x07;
-
-        if (((str[1] & 0xc0) != 0x80) && (codepoint <= 0x10ffff))
-        {
-            iso8859.push_back(codepoint <= 0xFF ? static_cast<char>(codepoint) : '?');
-        }
-    }
-    return iso8859;
 }
 
 }

--- a/Plugins/Mono/Mono_Handlers.hpp
+++ b/Plugins/Mono/Mono_Handlers.hpp
@@ -54,7 +54,4 @@ int32_t ClosureAssignCommand(uint32_t oid, uint64_t eventId);
 int32_t ClosureDelayCommand(uint32_t oid, float duration, uint64_t eventId);
 int32_t ClosureActionDoCommand(uint32_t oid, uint64_t eventId);
 
-std::string ISO8859ToUTF8(const char *str);
-std::string UTF8ToISO8859(const char *str);
-
 }

--- a/Plugins/SQL/Documentation/README.md
+++ b/Plugins/SQL/Documentation/README.md
@@ -8,11 +8,11 @@ General data access, storage and manipulation of persistent data in a database.
 
 ### NWNX_SQL_TYPE
 
-Controls the target database type used at runtime.  
+Controls the target database type used at runtime.
 
 Possible values (case insensitive):
 
-* ``MYSQL`` 
+* ``MYSQL``
 * ``POSTGRESQL``
 * ``SQLITE``
 
@@ -72,7 +72,7 @@ export NWNX_SQL_DATABASE=mymodulename
 
 ### NWNX_SQL_QUERY_METRICS
 
-Export query execution metrics. 
+Export query execution metrics.
 
 The Metrics_InfluxDB plugin and a visualizer like Grafana are required to view these metrics.
 
@@ -80,4 +80,29 @@ __Example__
 
 ```
 export NWNX_SQL_QUERY_METRICS=true
+```
+
+### NWNX_SQL_USE_UTF8
+
+Convert all strings going between the database and game to/from UTF8
+
+This takes into account the core locale as well.
+
+__Example__
+
+```
+export NWNX_SQL_USE_UTF8=true
+```
+
+### NWNX_SQL_CHARACTER_SET
+
+Set the connection's character set to be used.
+
+Only supported on mysql. For pgsql and sqlite this can be achieved with a query.
+
+__Examples__
+
+```
+export NWNX_SQL_CHARACTER_SET=utf8
+export NWNX_SQL_CHARACTER_SET=cp1251
 ```

--- a/Plugins/SQL/SQL.hpp
+++ b/Plugins/SQL/SQL.hpp
@@ -40,6 +40,7 @@ private:
     int32_t m_nextQueryId;
     bool m_queryMetrics;
     bool m_queryPrepared;
+    bool m_utf8;
 };
 
 }

--- a/Plugins/SQL/Targets/MySQL.cpp
+++ b/Plugins/SQL/Targets/MySQL.cpp
@@ -38,6 +38,13 @@ void MySQL::Connect(NWNXLib::ViewPtr<NWNXLib::Services::ConfigProxy> config)
     {
         throw std::runtime_error(std::string(mysql_error(&m_mysql)));
     }
+
+    if (auto charset = config->Get<std::string>("CHARACTER_SET"))
+    {
+        LOG_INFO("Connection character set is '%s'", charset->c_str());
+        if (mysql_set_character_set(&m_mysql, charset->c_str()))
+            LOG_ERROR("Unable to set the character set");
+    }
 }
 
 bool MySQL::IsConnected()

--- a/Plugins/WebHook/WebHook.cpp
+++ b/Plugins/WebHook/WebHook.cpp
@@ -3,6 +3,7 @@
 #include "External/httplib.h"
 #include "Services/Config/Config.hpp"
 #include "Services/Tasks/Tasks.hpp"
+#include "Encoding.hpp"
 #include <memory>
 #include <unordered_map>
 
@@ -37,8 +38,6 @@ WebHook::WebHook(const Plugin::CreateParams& params)
     : Plugin(params)
 {
     GetServices()->m_events->RegisterEvent("SEND_WEBHOOK_HTTPS", &OnSendWebhookHTTPS);
-
-    m_bIso_8859_1 = GetServices()->m_config->Get<int>("ISO_8859_1", 0);
 }
 
 WebHook::~WebHook()
@@ -64,7 +63,7 @@ Events::ArgumentStack WebHook::OnSendWebhookHTTPS(Events::ArgumentStack&& args)
          pos += s_Replace.length();
     }
 
-    message= plugin.m_bIso_8859_1 ? iso_8859_1_to_utf8(message) : message;
+    message = Encoding::ToUTF8(message);
 
     if(mrkdwn==0)
     {
@@ -78,7 +77,7 @@ Events::ArgumentStack WebHook::OnSendWebhookHTTPS(Events::ArgumentStack&& args)
     }
     else
     {
-        username=plugin.m_bIso_8859_1 ? iso_8859_1_to_utf8(username) : username;
+        username = Encoding::ToUTF8(username);
         message = "{\"text\":\"" + message + "\", \"username\":\"" + username + "\"}";
     }
 
@@ -117,25 +116,6 @@ Events::ArgumentStack WebHook::OnSendWebhookHTTPS(Events::ArgumentStack&& args)
     });
 
     return Events::ArgumentStack();
-}
-
-std::string WebHook::iso_8859_1_to_utf8(std::string &str)
-{
-    std::string strOut;
-    for (std::string::iterator it = str.begin(); it != str.end(); ++it)
-    {
-        uint8_t ch = *it;
-        if (ch < 0x80)
-        {
-            strOut.push_back(ch);
-        }
-        else
-        {
-            strOut.push_back(0xc0 | ch >> 6);
-            strOut.push_back(0x80 | (ch & 0x3f));
-        }
-    }
-    return strOut;
 }
 
 }

--- a/Plugins/WebHook/WebHook.hpp
+++ b/Plugins/WebHook/WebHook.hpp
@@ -13,10 +13,6 @@ public:
     virtual ~WebHook();
 
     static NWNXLib::Services::Events::ArgumentStack OnSendWebhookHTTPS(NWNXLib::Services::Events::ArgumentStack&&);
-
-    static std::string iso_8859_1_to_utf8(std::string &str);
-
-    bool m_bIso_8859_1;
 };
 
 }


### PR DESCRIPTION
Also misc cleanup and optimizations.

You can now specify `NWNX_CORE_LOCALE=ru` and any time the translation between game encoding and UTF happens, it'll take into account Cyrillic. This makes it possible to send Cyrillic messages to discord via webhook.

SQL can also optionally use UTF encoding, so you can store Cyrillic UTF8 in the database. Alternatively, for MySQL, you can just set the character set to cp1251 and store data as in-game.

Also misc optimizations for the base64 functions.

Resolves #300 and #349 