### PR TITLE
Item: GetBaseArmorClass()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The following plugins were added:
 - Events: GetCurrentEvent()
 - Feedback: GetMessageHidden()
 - Feedback: SetMessageHidden()
+- Item: GetBaseArmorClass()
 - ItemProperty: PackIP()
 - ItemProperty: UnpackIP()
 - Object: GetHasVisualEffect()

--- a/Plugins/Item/Item.cpp
+++ b/Plugins/Item/Item.cpp
@@ -49,6 +49,7 @@ Item::Item(const Plugin::CreateParams& params)
     REGISTER(SetItemAppearance);
     REGISTER(GetEntireItemAppearance);
     REGISTER(RestoreItemAppearance);
+    REGISTER(GetBaseArmorClass);
 
 #undef REGISTER
 }
@@ -288,6 +289,18 @@ ArgumentStack Item::RestoreItemAppearance(ArgumentStack&& args)
     {
         LOG_NOTICE("RestoreItemAppearance: invalid string length, must be 284");
     }
+    return stack;
+}
+
+ArgumentStack Item::GetBaseArmorClass(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    int32_t retval = -1;
+    if (auto *pItem = item(args))
+    {
+        retval = pItem->m_nArmorValue;
+    }
+    Services::Events::InsertArgument(stack, retval);
     return stack;
 }
 

--- a/Plugins/Item/Item.hpp
+++ b/Plugins/Item/Item.hpp
@@ -25,6 +25,7 @@ private:
     ArgumentStack SetItemAppearance       (ArgumentStack&& args);
     ArgumentStack GetEntireItemAppearance (ArgumentStack&& args);
     ArgumentStack RestoreItemAppearance   (ArgumentStack&& args);
+    ArgumentStack GetBaseArmorClass       (ArgumentStack&& args);
 
     NWNXLib::API::CNWSItem *item(ArgumentStack& args);
 };

--- a/Plugins/Item/NWScript/nwnx_item.nss
+++ b/Plugins/Item/NWScript/nwnx_item.nss
@@ -55,42 +55,45 @@ string NWNX_Item_GetEntireItemAppearance (object oItem);
 /* Restore an item's appearance with the value returned by GetEntireItemAppearance(). */
 void NWNX_Item_RestoreItemAppearance (object oItem, string sApp);
 
+// Get oItem's base armor class
+int NWNX_Item_GetBaseArmorClass(object oItem);
+
 void NWNX_Item_SetWeight(object oItem, int w)
 {
     string sFunc = "SetWeight";
-    
+
     NWNX_PushArgumentInt(NWNX_Item, sFunc, w);
     NWNX_PushArgumentObject(NWNX_Item, sFunc, oItem);
-    
+
     NWNX_CallFunction(NWNX_Item, sFunc);
 }
 
 void NWNX_Item_SetBaseGoldPieceValue(object oItem, int g)
 {
     string sFunc = "SetBaseGoldPieceValue";
-    
+
     NWNX_PushArgumentInt(NWNX_Item, sFunc, g);
     NWNX_PushArgumentObject(NWNX_Item, sFunc, oItem);
-    
+
     NWNX_CallFunction(NWNX_Item, sFunc);
 }
 
 void NWNX_Item_SetAddGoldPieceValue(object oItem, int g)
 {
     string sFunc = "SetAddGoldPieceValue";
-    
+
     NWNX_PushArgumentInt(NWNX_Item, sFunc, g);
     NWNX_PushArgumentObject(NWNX_Item, sFunc, oItem);
-    
+
     NWNX_CallFunction(NWNX_Item, sFunc);
 }
 
 int NWNX_Item_GetBaseGoldPieceValue(object oItem)
 {
     string sFunc = "GetBaseGoldPieceValue";
-    
+
     NWNX_PushArgumentObject(NWNX_Item, sFunc, oItem);
-    
+
     NWNX_CallFunction(NWNX_Item, sFunc);
     return NWNX_GetReturnValueInt(NWNX_Item, sFunc);
 }
@@ -98,27 +101,27 @@ int NWNX_Item_GetBaseGoldPieceValue(object oItem)
 int NWNX_Item_GetAddGoldPieceValue(object oItem)
 {
     string sFunc = "GetAddGoldPieceValue";
-    
+
     NWNX_PushArgumentObject(NWNX_Item, sFunc, oItem);
-    
+
     NWNX_CallFunction(NWNX_Item, sFunc);
     return NWNX_GetReturnValueInt(NWNX_Item, sFunc);
 }
-				
+
 void NWNX_Item_SetBaseItemType(object oItem, int nBaseItem)
 {
     string sFunc = "SetBaseItemType";
-    
+
     NWNX_PushArgumentInt(NWNX_Item, sFunc, nBaseItem);
     NWNX_PushArgumentObject(NWNX_Item, sFunc, oItem);
-    
+
     NWNX_CallFunction(NWNX_Item, sFunc);
 }
 
 void NWNX_Item_SetItemAppearance(object oItem, int nType, int nIndex, int nValue)
 {
     string sFunc = "SetItemAppearance";
-  
+
     NWNX_PushArgumentInt(NWNX_Item, sFunc, nValue);
     NWNX_PushArgumentInt(NWNX_Item, sFunc, nIndex);
     NWNX_PushArgumentInt(NWNX_Item, sFunc, nType);
@@ -147,4 +150,13 @@ void NWNX_Item_RestoreItemAppearance(object oItem, string sApp)
 
     NWNX_CallFunction(NWNX_Item, sFunc);
 }
-		
+
+int NWNX_Item_GetBaseArmorClass(object oItem)
+{
+    string sFunc = "GetBaseArmorClass";
+
+    NWNX_PushArgumentObject(NWNX_Item, sFunc, oItem);
+
+    NWNX_CallFunction(NWNX_Item, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Item, sFunc);
+}


### PR DESCRIPTION
This is to replace something like this we'd have to do for example to check whether a player can rest in the armor they're wearing.

```
int GetArmorType(object oItem)
{
    // Make sure the item is valid and is an armor.
    if (!GetIsObjectValid(oItem))
        return -1;
    if (GetBaseItemType(oItem) != BASE_ITEM_ARMOR)
        return -1;
 
    // Get the identified flag for safe keeping.
    int bIdentified = GetIdentified(oItem);
    SetIdentified(oItem,FALSE);
 
    int nType = -1;
    switch (GetGoldPieceValue(oItem))
    {
        case    1: nType = 0; break; // None
        case    5: nType = 1; break; // Padded
        case   10: nType = 2; break; // Leather
        case   15: nType = 3; break; // Studded Leather / Hide
        case  100: nType = 4; break; // Chain Shirt / Scale Mail
        case  150: nType = 5; break; // Chainmail / Breastplate
        case  200: nType = 6; break; // Splint Mail / Banded Mail
        case  600: nType = 7; break; // Half-Plate
        case 1500: nType = 8; break; // Full Plate
    }
    // Restore the identified flag, and return armor type.
    SetIdentified(oItem,bIdentified);
    return nType;
}
```