### PR TITLE
Player: UpdateCharacterSheet() 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ The following plugins were added:
 - Player: SetPlaceableUsable()
 - Player: SetRestDuration()
 - Player: ApplyInstantVisualEffectToObject()
+- Player: UpdateCharacterSheet()
 - Rename: SetPCNameOverride()
 - Reveal: RevealTo()
 - Reveal: SetRevealToParty()

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -112,6 +112,11 @@ void NWNX_Player_SetRestDuration(object player, int duration);
 // Note: Only works with instant effects: VFX_COM_*, VFX_FNF_*, VFX_IMP_*
 void NWNX_Player_ApplyInstantVisualEffectToObject(object player, object target, int visualeffect);
 
+// Refreshes the players character sheet
+// Note: You may need to use DelayCommand if you're manipulating values
+// through nwnx and forcing a UI refresh, 0.5s seemed to be fine
+void NWNX_Player_UpdateCharacterSheet(object player);
+
 
 const string NWNX_Player = "NWNX_Player";
 
@@ -419,6 +424,14 @@ void NWNX_Player_ApplyInstantVisualEffectToObject(object player, object target, 
     string sFunc = "ApplyInstantVisualEffectToObject";
     NWNX_PushArgumentInt(NWNX_Player, sFunc, visualeffect);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, target);
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
+
+    NWNX_CallFunction(NWNX_Player, sFunc);
+}
+
+void NWNX_Player_UpdateCharacterSheet(object player)
+{
+    string sFunc = "UpdateCharacterSheet";
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
     NWNX_CallFunction(NWNX_Player, sFunc);

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -8,6 +8,7 @@
 #include "API/CGameObject.hpp"
 #include "API/CNWSScriptVar.hpp"
 #include "API/CNWSScriptVarTable.hpp"
+#include "API/CServerExoAppInternal.hpp"
 #include "API/CExoArrayListTemplatedCNWSScriptVar.hpp"
 #include "API/CNWSCreature.hpp"
 #include "API/CNWSQuickbarButton.hpp"
@@ -17,6 +18,7 @@
 #include "API/CNWSItem.hpp"
 #include "API/CNWRules.hpp"
 #include "API/CNWSCreatureStats.hpp"
+#include "API/CNWSPlayerCharSheetGUI.hpp"
 #include "API/CTwoDimArrays.hpp"
 #include "API/CNWSModule.hpp"
 #include "API/C2DA.hpp"
@@ -77,6 +79,7 @@ Player::Player(const Plugin::CreateParams& params)
     REGISTER(SetPlaceableUsable);
     REGISTER(SetRestDuration);
     REGISTER(ApplyInstantVisualEffectToObject);
+    REGISTER(UpdateCharacterSheet);
 
 #undef REGISTER
 
@@ -579,6 +582,23 @@ ArgumentStack Player::ApplyInstantVisualEffectToObject(ArgumentStack&& args)
                     0,                            // nTargetNode
                     vTargetPosition,              // vTargetPosition
                     0.0f);                        // fDuration
+        }
+    }
+    return stack;
+}
+
+ArgumentStack Player::UpdateCharacterSheet(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pPlayer = player(args))
+    {
+        const auto charSheet = pPlayer->m_pCharSheetGUI;
+        uint32_t msg = charSheet->ComputeCharacterSheetUpdateRequired(pPlayer);
+        if (msg)
+        {
+            auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
+            if (pMessage)
+                pMessage->WriteGameObjUpdate_CharacterSheet(pPlayer, msg);
         }
     }
     return stack;

--- a/Plugins/Player/Player.hpp
+++ b/Plugins/Player/Player.hpp
@@ -33,6 +33,7 @@ private:
     ArgumentStack SetPlaceableUsable                (ArgumentStack&& args);
     ArgumentStack SetRestDuration                   (ArgumentStack&& args);
     ArgumentStack ApplyInstantVisualEffectToObject  (ArgumentStack&& args);
+    ArgumentStack UpdateCharacterSheet              (ArgumentStack&& args);
 
     NWNXLib::API::CNWSPlayer *player(ArgumentStack& args);
 


### PR DESCRIPTION
This is used to force a gui refresh when changing some values through NWNX. Seems to work best when run in a small DelayCommand of 0.5s for example.