### PR TITLE
Catch other exception types in plugin functions

### DIFF
--- a/NWNXLib/Services/Events/Events.cpp
+++ b/NWNXLib/Services/Events/Events.cpp
@@ -38,11 +38,11 @@ void Events::Call(const std::string& pluginName, const std::string& eventName)
     {
         LOG_DEBUG("Calling event handler. Event '%s', Plugin: '%s'.",
             eventName.c_str(), pluginName.c_str());
-        try 
+        try
         {
             event->m_returns = event->m_callback(std::move(event->m_arguments));
         }
-        catch (const std::runtime_error& err)
+        catch (const std::exception& err)
         {
             LOG_ERROR("Plugin '%s' failed event '%s'. Error: %s", pluginName.c_str(), eventName.c_str(), err.what());
         }

--- a/Plugins/Object/NWScript/nwnx_object_t.nss
+++ b/Plugins/Object/NWScript/nwnx_object_t.nss
@@ -30,6 +30,7 @@ void main()
 
     string sObj = ObjectToString(o);
     report("StringToObject", NWNX_Object_StringToObject(sObj) == o);
+    report("Negative: StringToObject", NWNX_Object_StringToObject("!@#!@#!@#!") == OBJECT_INVALID);
 
 
     string sHandler = NWNX_Object_GetEventHandler(o, 0);


### PR DESCRIPTION
`strtoul` for example throws `std::invalid_argument` for some reason, even when it clearly states it won't:

http://www.cplusplus.com/reference/cstdlib/strtoul/
**Exceptions (C++)**
No-throw guarantee: this function never throws exceptions.

Regardless, better not crash the server in this case.