### PR TITLE
events: only set up the hooks when needed

### DIFF
--- a/Plugins/Events/Documentation/README.md
+++ b/Plugins/Events/Documentation/README.md
@@ -3,23 +3,3 @@
 ## Description
 
 Provides an interface for plugins to create event-based systems, and exposes some events through that interface.
-
-## Environment Variables
-
-| Variable Name                         | Type   | Default Value |
-| ------------------------------------- | :----: | ------------- |
-| NWNX_EVENTS_ENABLE_ASSOCIATE_EVENTS   | bool   | true          |
-| NWNX_EVENTS_ENABLE_CLIENT_EVENTS      | bool   | true          |
-| NWNX_EVENTS_ENABLE_COMBAT_EVENTS      | bool   | true          |
-| NWNX_EVENTS_ENABLE_DM_ACTION_EVENTS   | bool   | true          |
-| NWNX_EVENTS_ENABLE_EXAMINE_EVENTS     | bool   | true          |
-| NWNX_EVENTS_ENABLE_ITEM_EVENTS        | bool   | true          |
-| NWNX_EVENTS_ENABLE_FEAT_EVENTS        | bool   | true          |
-| NWNX_EVENTS_ENABLE_STEALTH_EVENTS     | bool   | true          |
-| NWNX_EVENTS_ENABLE_SPELL_EVENTS       | bool   | true          |
-| NWNX_EVENTS_ENABLE_PARTY_EVENTS       | bool   | true          |
-| NWNX_EVENTS_ENABLE_HEALER_KIT_EVENTS  | bool   | true          |
-| NWNX_EVENTS_ENABLE_SKILL_EVENTS       | bool   | true          |
-| NWNX_EVENTS_ENABLE_POLYMORPH_EVENTS   | bool   | true          |
-| NWNX_EVENTS_ENABLE_EFFECT_EVENTS      | bool   | true          |
-| NWNX_EVENTS_ENABLE_QUICKCHAT_EVENTS   | bool   | true          |

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -23,6 +23,7 @@
 #include "Services/Messaging/Messaging.hpp"
 #include "ViewPtr.hpp"
 #include <algorithm>
+#include <regex>
 
 using namespace NWNXLib;
 
@@ -52,6 +53,9 @@ namespace Events {
 Events::Events(const Plugin::CreateParams& params)
     : Plugin(params), m_eventDepth(0)
 {
+    if (g_plugin == nullptr) // :(
+        g_plugin = this;
+
     GetServices()->m_events->RegisterEvent("SUBSCRIBE_EVENT", std::bind(&Events::OnSubscribeEvent, this, std::placeholders::_1));
     GetServices()->m_events->RegisterEvent("PUSH_EVENT_DATA", std::bind(&Events::OnPushEventData, this, std::placeholders::_1));
     GetServices()->m_events->RegisterEvent("SIGNAL_EVENT", std::bind(&Events::OnSignalEvent, this, std::placeholders::_1));
@@ -74,85 +78,22 @@ Events::Events(const Plugin::CreateParams& params)
             PushEventData(message[0], message[1]);
         });
 
-    if (GetServices()->m_config->Get<bool>("ENABLE_ASSOCIATE_EVENTS", true))
-    {
-        m_associateEvents = std::make_unique<AssociateEvents>(GetServices()->m_hooks);
-    }
-
-    if (GetServices()->m_config->Get<bool>("ENABLE_CLIENT_EVENTS", true))
-    {
-        m_clientEvents = std::make_unique<ClientEvents>(GetServices()->m_hooks);
-    }
-
-    if (GetServices()->m_config->Get<bool>("ENABLE_COMBAT_EVENTS", true))
-    {
-        m_combatEvents = std::make_unique<CombatEvents>(GetServices()->m_hooks);
-    }
-
-    if (GetServices()->m_config->Get<bool>("ENABLE_DM_ACTION_EVENTS", true))
-    {
-        m_dmActionEvents = std::make_unique<DMActionEvents>(GetServices()->m_hooks);
-    }
-
-    if (GetServices()->m_config->Get<bool>("ENABLE_EXAMINE_EVENTS", true))
-    {
-        m_examineEvents = std::make_unique<ExamineEvents>(GetServices()->m_hooks);
-    }
-
-    if (GetServices()->m_config->Get<bool>("ENABLE_ITEM_EVENTS", true))
-    {
-        m_itemEvents = std::make_unique<ItemEvents>(GetServices()->m_hooks);
-    }
-
-    if (GetServices()->m_config->Get<bool>("ENABLE_FEAT_EVENTS", true))
-    {
-        m_featEvents = std::make_unique<FeatEvents>(GetServices()->m_hooks);
-    }
-
-    if (GetServices()->m_config->Get<bool>("ENABLE_STEALTH_EVENTS", true))
-    {
-        m_stealthEvents = std::make_unique<StealthEvents>(GetServices()->m_hooks);
-    }
-
-    if (GetServices()->m_config->Get<bool>("ENABLE_SPELL_EVENTS", true))
-    {
-        m_spellEvents = std::make_unique<SpellEvents>(GetServices()->m_hooks);
-    }
-
-    if (GetServices()->m_config->Get<bool>("ENABLE_PARTY_EVENTS", true))
-    {
-        m_partyEvents = std::make_unique<PartyEvents>(GetServices()->m_hooks);
-    }
-
-    if (GetServices()->m_config->Get<bool>("ENABLE_HEALER_KIT_EVENTS", true))
-    {
-        m_healerKitEvents = std::make_unique<HealerKitEvents>(GetServices()->m_hooks);
-    }
-
-    if (GetServices()->m_config->Get<bool>("ENABLE_SKILL_EVENTS", true))
-    {
-        m_skillEvents = std::make_unique<SkillEvents>(GetServices()->m_hooks);
-    }
-
-    if (GetServices()->m_config->Get<bool>("ENABLE_MAP_EVENTS", true))
-    {
-        m_mapEvents = std::make_unique<MapEvents>(GetServices()->m_hooks);
-    }
-
-    if (GetServices()->m_config->Get<bool>("ENABLE_POLYMORPH_EVENTS", true))
-    {
-        m_polymorphEvents = std::make_unique<PolymorphEvents>(GetServices()->m_hooks);
-    }
-
-    if (GetServices()->m_config->Get<bool>("ENABLE_EFFECT_EVENTS", true))
-    {
-        m_effectEvents = std::make_unique<EffectEvents>(GetServices()->m_hooks);
-    }
-
-    if (GetServices()->m_config->Get<bool>("ENABLE_QUICKCHAT_EVENTS", true))
-    {
-        m_quickChatEvents = std::make_unique<QuickChatEvents>(GetServices()->m_hooks);
-    }
+    m_associateEvents   = std::make_unique<AssociateEvents>(GetServices()->m_hooks);
+    m_clientEvents      = std::make_unique<ClientEvents>(GetServices()->m_hooks);
+    m_combatEvents      = std::make_unique<CombatEvents>(GetServices()->m_hooks);
+    m_dmActionEvents    = std::make_unique<DMActionEvents>(GetServices()->m_hooks);
+    m_examineEvents     = std::make_unique<ExamineEvents>(GetServices()->m_hooks);
+    m_itemEvents        = std::make_unique<ItemEvents>(GetServices()->m_hooks);
+    m_featEvents        = std::make_unique<FeatEvents>(GetServices()->m_hooks);
+    m_stealthEvents     = std::make_unique<StealthEvents>(GetServices()->m_hooks);
+    m_spellEvents       = std::make_unique<SpellEvents>(GetServices()->m_hooks);
+    m_partyEvents       = std::make_unique<PartyEvents>(GetServices()->m_hooks);
+    m_healerKitEvents   = std::make_unique<HealerKitEvents>(GetServices()->m_hooks);
+    m_skillEvents       = std::make_unique<SkillEvents>(GetServices()->m_hooks);
+    m_mapEvents         = std::make_unique<MapEvents>(GetServices()->m_hooks);
+    m_polymorphEvents   = std::make_unique<PolymorphEvents>(GetServices()->m_hooks);
+    m_effectEvents      = std::make_unique<EffectEvents>(GetServices()->m_hooks);
+    m_quickChatEvents   = std::make_unique<QuickChatEvents>(GetServices()->m_hooks);
 }
 
 Events::~Events()
@@ -224,11 +165,31 @@ bool Events::SignalEvent(const std::string& eventName, const API::Types::ObjectI
     return !skipped;
 }
 
+void Events::InitOnFirstSubscribe(const std::string& eventName, std::function<void(void)> init)
+{
+    g_plugin->m_initList[eventName] = init;
+}
+
+void Events::RunEventInit(const std::string& eventName)
+{
+    for (auto it: m_initList)
+    {
+        if (std::regex_search(eventName, std::regex(it.first)))
+        {
+            LOG_DEBUG("Running init function for events '%s' (requested by event '%s')",
+                        it.first.c_str(), eventName.c_str());
+            it.second();
+            m_initList.erase(it.first);
+        }
+    }
+}
+
 Services::Events::ArgumentStack Events::OnSubscribeEvent(Services::Events::ArgumentStack&& args)
 {
     const auto event = Services::Events::ExtractArgument<std::string>(args);
     auto script = Services::Events::ExtractArgument<std::string>(args);
 
+    RunEventInit(event);
     auto& eventVector = m_eventMap[event];
 
     if (std::find(std::begin(eventVector), std::end(eventVector), script) != std::end(eventVector))

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -172,6 +172,7 @@ void Events::InitOnFirstSubscribe(const std::string& eventName, std::function<vo
 
 void Events::RunEventInit(const std::string& eventName)
 {
+    std::vector<std::string> erase;
     for (auto it: m_initList)
     {
         if (std::regex_search(eventName, std::regex(it.first)))
@@ -179,9 +180,14 @@ void Events::RunEventInit(const std::string& eventName)
             LOG_DEBUG("Running init function for events '%s' (requested by event '%s')",
                         it.first.c_str(), eventName.c_str());
             it.second();
-            m_initList.erase(it.first);
+            erase.push_back(it.first);
         }
     }
+    for (auto e: erase)
+    {
+        m_initList.erase(e);
+    }
+
 }
 
 Services::Events::ArgumentStack Events::OnSubscribeEvent(Services::Events::ArgumentStack&& args)

--- a/Plugins/Events/Events.hpp
+++ b/Plugins/Events/Events.hpp
@@ -58,6 +58,8 @@ public:
     // Returns true if the event can proceed, or false if the event has been skipped.
     static bool SignalEvent(const std::string& eventName, const NWNXLib::API::Types::ObjectID target, std::string *result=nullptr);
 
+    static void InitOnFirstSubscribe(const std::string& eventName, std::function<void(void)> init);
+
 private: // Structures
     using EventMapType = std::unordered_map<std::string, std::vector<std::string>>;
 
@@ -74,9 +76,13 @@ private:
     // Only does it if needed though, based on the current event depth!
     void CreateNewEventDataIfNeeded();
 
+    void RunEventInit(const std::string& eventName);
+
     EventMapType m_eventMap; // Event name -> subscribers.
     std::stack<EventParams> m_eventData; // Data tag -> data for currently executing event.
     uint8_t m_eventDepth;
+
+    std::unordered_map<std::string, std::function<void(void)>> m_initList;
 
     std::unique_ptr<AssociateEvents> m_associateEvents;
     std::unique_ptr<ClientEvents> m_clientEvents;

--- a/Plugins/Events/Events/AssociateEvents.cpp
+++ b/Plugins/Events/Events/AssociateEvents.cpp
@@ -10,11 +10,15 @@ using namespace NWNXLib;
 
 AssociateEvents::AssociateEvents(ViewPtr<Services::HooksProxy> hooker)
 {
-    hooker->RequestSharedHook<API::Functions::CNWSCreature__AddAssociate, void,
-        API::CNWSCreature*, API::Types::ObjectID, uint16_t>(&AddAssociateHook);
+    Events::InitOnFirstSubscribe("NWNX_ON_ADD_ASSOCIATE_.*", [hooker]() {
+        hooker->RequestSharedHook<API::Functions::CNWSCreature__AddAssociate, void,
+            API::CNWSCreature*, API::Types::ObjectID, uint16_t>(&AddAssociateHook);
+    });
 
-    hooker->RequestSharedHook<API::Functions::CNWSCreature__RemoveAssociate, void,
-        API::CNWSCreature*, API::Types::ObjectID>(&RemoveAssociateHook);
+    Events::InitOnFirstSubscribe("NWNX_ON_REMOVE_ASSOCIATE_.*", [hooker]() {
+        hooker->RequestSharedHook<API::Functions::CNWSCreature__RemoveAssociate, void,
+            API::CNWSCreature*, API::Types::ObjectID>(&RemoveAssociateHook);
+    });
 }
 
 void AssociateEvents::AddAssociateHook(Services::Hooks::CallType type, API::CNWSCreature* thisPtr, API::Types::ObjectID assocId, uint16_t)

--- a/Plugins/Events/Events/ClientEvents.cpp
+++ b/Plugins/Events/Events/ClientEvents.cpp
@@ -23,12 +23,16 @@ static NWNXLib::Hooking::FunctionHook* m_SendServerToPlayerCharListHook;
 
 ClientEvents::ClientEvents(ViewPtr<HooksProxy> hooker)
 {
-    hooker->RequestSharedHook<API::Functions::CServerExoAppInternal__RemovePCFromWorld, void,
-        CServerExoAppInternal*, CNWSPlayer*>(&RemovePCFromWorldHook);
+    Events::InitOnFirstSubscribe("NWNX_ON_CLIENT_DISCONNECT_.*", [hooker]() {
+        hooker->RequestSharedHook<API::Functions::CServerExoAppInternal__RemovePCFromWorld, void,
+            CServerExoAppInternal*, CNWSPlayer*>(&RemovePCFromWorldHook);
+    });
 
-    hooker->RequestExclusiveHook<API::Functions::CNWSMessage__SendServerToPlayerCharList, int32_t,
-        CNWSMessage*, CNWSPlayer*>(&SendServerToPlayerCharListHook);
-    m_SendServerToPlayerCharListHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__SendServerToPlayerCharList);
+    Events::InitOnFirstSubscribe("NWNX_ON_CLIENT_CONNECT_.*", [hooker]() {
+        hooker->RequestExclusiveHook<API::Functions::CNWSMessage__SendServerToPlayerCharList, int32_t,
+            CNWSMessage*, CNWSPlayer*>(&SendServerToPlayerCharListHook);
+        m_SendServerToPlayerCharListHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__SendServerToPlayerCharList);
+    });
 }
 
 void ClientEvents::RemovePCFromWorldHook(Hooks::CallType type, CServerExoAppInternal*, CNWSPlayer* player)

--- a/Plugins/Events/Events/CombatEvents.cpp
+++ b/Plugins/Events/Events/CombatEvents.cpp
@@ -18,14 +18,16 @@ NWNXLib::ViewPtr<NWNXLib::Hooking::FunctionHook> CombatEvents::m_hook;
 
 CombatEvents::CombatEvents(ViewPtr<HooksProxy> hooker)
 {
-    hooker->RequestSharedHook<
-        API::Functions::CNWSCombatRound__StartCombatRound,
-        int32_t,
-        API::CNWSCombatRound*,
-        uint32_t>
-        (
-            &StartCombatRoundHook
-        );
+    Events::InitOnFirstSubscribe("NWNX_ON_START_COMBAT_ROUND_.*", [hooker]() {
+        hooker->RequestSharedHook<
+            API::Functions::CNWSCombatRound__StartCombatRound,
+            int32_t,
+            API::CNWSCombatRound*,
+            uint32_t>
+            (
+                &StartCombatRoundHook
+            );
+    });
 }
 
 void CombatEvents::StartCombatRoundHook(

--- a/Plugins/Events/Events/DMActionEvents.cpp
+++ b/Plugins/Events/Events/DMActionEvents.cpp
@@ -25,9 +25,10 @@ static NWNXLib::Hooking::FunctionHook* m_HandlePlayerToServerDungeonMasterMessag
 
 DMActionEvents::DMActionEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker)
 {
-    hooker->RequestExclusiveHook<Functions::CNWSMessage__HandlePlayerToServerDungeonMasterMessage>(&HandleDMMessageHook);
-
-    m_HandlePlayerToServerDungeonMasterMessageHook = hooker->FindHookByAddress(Functions::CNWSMessage__HandlePlayerToServerDungeonMasterMessage);
+    Events::InitOnFirstSubscribe("NWNX_ON_DM_.*", [hooker]() {
+        hooker->RequestExclusiveHook<Functions::CNWSMessage__HandlePlayerToServerDungeonMasterMessage>(&HandleDMMessageHook);
+        m_HandlePlayerToServerDungeonMasterMessageHook = hooker->FindHookByAddress(Functions::CNWSMessage__HandlePlayerToServerDungeonMasterMessage);
+    });
 }
 
 int32_t DMActionEvents::HandleGiveEvent(CNWSMessage *pMessage, CNWSPlayer *pPlayer, uint8_t nMinor, int32_t bGroup,

--- a/Plugins/Events/Events/EffectEvents.cpp
+++ b/Plugins/Events/Events/EffectEvents.cpp
@@ -15,8 +15,12 @@ using namespace NWNXLib::API::Constants;
 
 EffectEvents::EffectEvents(ViewPtr<Services::HooksProxy> hooker)
 {
-    hooker->RequestSharedHook<NWNXLib::API::Functions::CNWSEffectListHandler__OnEffectApplied, int32_t>(&OnEffectAppliedHook);
-    hooker->RequestSharedHook<NWNXLib::API::Functions::CNWSEffectListHandler__OnEffectRemoved, int32_t>(&OnEffectRemovedHook);
+    Events::InitOnFirstSubscribe("NWNX_ON_EFFECT_APPLIED_.*", [hooker]() {
+       hooker->RequestSharedHook<NWNXLib::API::Functions::CNWSEffectListHandler__OnEffectApplied, int32_t>(&OnEffectAppliedHook);
+    });
+    Events::InitOnFirstSubscribe("NWNX_ON_EFFECT_REMOVED_.*", [hooker]() {
+        hooker->RequestSharedHook<NWNXLib::API::Functions::CNWSEffectListHandler__OnEffectRemoved, int32_t>(&OnEffectRemovedHook);
+    });
 }
 
 void EffectEvents::HandleEffectHook(const std::string& event, Services::Hooks::CallType type, CNWSObject* pObject, CGameEffect* pEffect)

--- a/Plugins/Events/Events/ExamineEvents.cpp
+++ b/Plugins/Events/Events/ExamineEvents.cpp
@@ -10,14 +10,16 @@ using namespace NWNXLib;
 
 ExamineEvents::ExamineEvents(ViewPtr<Services::HooksProxy> hooker)
 {
-    hooker->RequestSharedHook<API::Functions::CNWSMessage__SendServerToPlayerExamineGui_CreatureData, int32_t,
-        API::CNWSMessage*, API::CNWSPlayer*, API::Types::ObjectID>(&ExamineCreatureHook);
-    hooker->RequestSharedHook<API::Functions::CNWSMessage__SendServerToPlayerExamineGui_DoorData, int32_t,
-        API::CNWSMessage*, API::CNWSPlayer*, API::Types::ObjectID>(&ExamineDoorHook);
-    hooker->RequestSharedHook<API::Functions::CNWSMessage__SendServerToPlayerExamineGui_ItemData, int32_t,
-        API::CNWSMessage*, API::CNWSPlayer*, API::Types::ObjectID>(&ExamineItemHook);
-    hooker->RequestSharedHook<API::Functions::CNWSMessage__SendServerToPlayerExamineGui_PlaceableData, int32_t,
-        API::CNWSMessage*, API::CNWSPlayer*, API::Types::ObjectID>(&ExaminePlaceableHook);
+    Events::InitOnFirstSubscribe("NWNX_ON_EXAMINE_OBJECT_.*", [hooker]() {
+        hooker->RequestSharedHook<API::Functions::CNWSMessage__SendServerToPlayerExamineGui_CreatureData, int32_t,
+            API::CNWSMessage*, API::CNWSPlayer*, API::Types::ObjectID>(&ExamineCreatureHook);
+        hooker->RequestSharedHook<API::Functions::CNWSMessage__SendServerToPlayerExamineGui_DoorData, int32_t,
+            API::CNWSMessage*, API::CNWSPlayer*, API::Types::ObjectID>(&ExamineDoorHook);
+        hooker->RequestSharedHook<API::Functions::CNWSMessage__SendServerToPlayerExamineGui_ItemData, int32_t,
+            API::CNWSMessage*, API::CNWSPlayer*, API::Types::ObjectID>(&ExamineItemHook);
+        hooker->RequestSharedHook<API::Functions::CNWSMessage__SendServerToPlayerExamineGui_PlaceableData, int32_t,
+            API::CNWSMessage*, API::CNWSPlayer*, API::Types::ObjectID>(&ExaminePlaceableHook);
+    });
 }
 
 void ExamineEvents::HandleExamine(Services::Hooks::CallType type, API::Types::ObjectID examiner,

--- a/Plugins/Events/Events/FeatEvents.cpp
+++ b/Plugins/Events/Events/FeatEvents.cpp
@@ -17,17 +17,19 @@ static Hooking::FunctionHook* m_UseFeatHook = nullptr;
 
 FeatEvents::FeatEvents(ViewPtr<Services::HooksProxy> hooker)
 {
-    hooker->RequestExclusiveHook<
-        NWNXLib::API::Functions::CNWSCreature__UseFeat,
-        int32_t,
-        NWNXLib::API::CNWSCreature*,
-        uint16_t,
-        uint16_t,
-        NWNXLib::API::Types::ObjectID,
-        NWNXLib::API::Types::ObjectID,
-        NWNXLib::API::Vector*>(FeatEvents::UseFeatHook);
+    Events::InitOnFirstSubscribe("NWNX_ON_USE_FEAT_.*", [hooker]() {
+        hooker->RequestExclusiveHook<
+            NWNXLib::API::Functions::CNWSCreature__UseFeat,
+            int32_t,
+            NWNXLib::API::CNWSCreature*,
+            uint16_t,
+            uint16_t,
+            NWNXLib::API::Types::ObjectID,
+            NWNXLib::API::Types::ObjectID,
+            NWNXLib::API::Vector*>(FeatEvents::UseFeatHook);
 
-    m_UseFeatHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__UseFeat);
+        m_UseFeatHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__UseFeat);
+    });
 }
 
 int32_t FeatEvents::UseFeatHook(

--- a/Plugins/Events/Events/HealerKitEvents.cpp
+++ b/Plugins/Events/Events/HealerKitEvents.cpp
@@ -15,9 +15,10 @@ static NWNXLib::Hooking::FunctionHook* m_AIActionHealHook=nullptr;
 
 HealerKitEvents::HealerKitEvents(ViewPtr<Services::HooksProxy> hooker)
 {
-
-    hooker->RequestExclusiveHook<API::Functions::CNWSCreature__AIActionHeal, uint32_t, API::CNWSCreature*, API::CNWSObjectActionNode*>(&AIActionHealHook);
-    m_AIActionHealHook =  hooker->FindHookByAddress(API::Functions::CNWSCreature__AIActionHeal);
+    Events::InitOnFirstSubscribe("NWNX_ON_HEALER_KIT_.*", [hooker]() {
+        hooker->RequestExclusiveHook<API::Functions::CNWSCreature__AIActionHeal, uint32_t, API::CNWSCreature*, API::CNWSObjectActionNode*>(&AIActionHealHook);
+        m_AIActionHealHook =  hooker->FindHookByAddress(API::Functions::CNWSCreature__AIActionHeal);
+    });
 }
 
 uint32_t HealerKitEvents::AIActionHealHook(

--- a/Plugins/Events/Events/ItemEvents.cpp
+++ b/Plugins/Events/Events/ItemEvents.cpp
@@ -24,22 +24,34 @@ static Hooking::FunctionHook* m_FindItemWithBaseItemIdHook = nullptr;
 
 ItemEvents::ItemEvents(ViewPtr<Services::HooksProxy> hooker)
 {
-    hooker->RequestExclusiveHook<API::Functions::CNWSCreature__UseItem>(&UseItemHook);
-    m_UseItemHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__UseItem);
+    Events::InitOnFirstSubscribe("NWNX_ON_USE_ITEM_.*", [hooker]() {
+        hooker->RequestExclusiveHook<API::Functions::CNWSCreature__UseItem>(&UseItemHook);
+        m_UseItemHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__UseItem);
+    });
 
-    hooker->RequestExclusiveHook<API::Functions::CNWSItem__OpenInventory>(&OpenInventoryHook);
-    m_OpenInventoryHook = hooker->FindHookByAddress(API::Functions::CNWSItem__OpenInventory);
+    Events::InitOnFirstSubscribe("NWNX_ON_ITEM_INVENTORY_OPEN_.*", [hooker]() {
+        hooker->RequestExclusiveHook<API::Functions::CNWSItem__OpenInventory>(&OpenInventoryHook);
+        m_OpenInventoryHook = hooker->FindHookByAddress(API::Functions::CNWSItem__OpenInventory);
+    });
 
-    hooker->RequestExclusiveHook<API::Functions::CNWSItem__CloseInventory>(&CloseInventoryHook);
-    m_CloseInventoryHook = hooker->FindHookByAddress(API::Functions::CNWSItem__CloseInventory);
+    Events::InitOnFirstSubscribe("NWNX_ON_ITEM_INVENTORY_CLOSE_.*", [hooker]() {
+        hooker->RequestExclusiveHook<API::Functions::CNWSItem__CloseInventory>(&CloseInventoryHook);
+        m_CloseInventoryHook = hooker->FindHookByAddress(API::Functions::CNWSItem__CloseInventory);
+    });
 
-    hooker->RequestExclusiveHook<API::Functions::CItemRepository__AddItem>(&AddItemHook);
-    m_AddItemHook = hooker->FindHookByAddress(API::Functions::CItemRepository__AddItem);
+    Events::InitOnFirstSubscribe("NWNX_ON_ITEM_INVENTORY_ADD_ITEM_.*", [hooker]() {
+        hooker->RequestExclusiveHook<API::Functions::CItemRepository__AddItem>(&AddItemHook);
+        m_AddItemHook = hooker->FindHookByAddress(API::Functions::CItemRepository__AddItem);
+    });
 
-    hooker->RequestSharedHook<API::Functions::CItemRepository__RemoveItem, int32_t>(&RemoveItemHook);
+    Events::InitOnFirstSubscribe("NWNX_ON_ITEM_INVENTORY_REMOVE_ITEM_.*", [hooker]() {
+        hooker->RequestSharedHook<API::Functions::CItemRepository__RemoveItem, int32_t>(&RemoveItemHook);
+    });
 
-    hooker->RequestExclusiveHook<API::Functions::CItemRepository__FindItemWithBaseItemId>(&FindItemWithBaseItemIdHook);
-    m_FindItemWithBaseItemIdHook = hooker->FindHookByAddress(API::Functions::CItemRepository__FindItemWithBaseItemId);
+    Events::InitOnFirstSubscribe("NWNX_ON_ITEM_AMMO_RELOAD_.*", [hooker]() {
+        hooker->RequestExclusiveHook<API::Functions::CItemRepository__FindItemWithBaseItemId>(&FindItemWithBaseItemIdHook);
+        m_FindItemWithBaseItemIdHook = hooker->FindHookByAddress(API::Functions::CItemRepository__FindItemWithBaseItemId);
+    });
 
 }
 

--- a/Plugins/Events/Events/MapEvents.cpp
+++ b/Plugins/Events/Events/MapEvents.cpp
@@ -19,17 +19,23 @@ static NWNXLib::Hooking::FunctionHook* m_HandlePlayerToServerMapPinDestroyMapPin
 
 MapEvents::MapEvents(ViewPtr<Services::HooksProxy> hooker)
 {
-    hooker->RequestExclusiveHook<Functions::CNWSMessage__HandlePlayerToServerMapPinSetMapPinAt, int32_t,
-        CNWSMessage*, CNWSPlayer*>(&HandleMapPinSetMapPinAtMessageHook);
-    m_HandlePlayerToServerMapPinSetMapPinAtHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__HandlePlayerToServerMapPinSetMapPinAt);
+    Events::InitOnFirstSubscribe("NWNX_ON_MAP_PIN_ADD_PIN_.*", [hooker]() {
+        hooker->RequestExclusiveHook<Functions::CNWSMessage__HandlePlayerToServerMapPinSetMapPinAt, int32_t,
+            CNWSMessage*, CNWSPlayer*>(&HandleMapPinSetMapPinAtMessageHook);
+        m_HandlePlayerToServerMapPinSetMapPinAtHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__HandlePlayerToServerMapPinSetMapPinAt);
+    });
 
-    hooker->RequestExclusiveHook<Functions::CNWSMessage__HandlePlayerToServerMapPinChangePin, int32_t,
-        CNWSMessage*, CNWSPlayer*>(&HandleMapPinChangePinMessageHook);
-    m_HandlePlayerToServerMapPinChangePinHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__HandlePlayerToServerMapPinChangePin);
+    Events::InitOnFirstSubscribe("NWNX_ON_MAP_PIN_CHANGE_PIN_.*", [hooker]() {
+        hooker->RequestExclusiveHook<Functions::CNWSMessage__HandlePlayerToServerMapPinChangePin, int32_t,
+            CNWSMessage*, CNWSPlayer*>(&HandleMapPinChangePinMessageHook);
+        m_HandlePlayerToServerMapPinChangePinHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__HandlePlayerToServerMapPinChangePin);
+    });
 
-    hooker->RequestExclusiveHook<Functions::CNWSMessage__HandlePlayerToServerMapPinDestroyMapPin, int32_t,
-        CNWSMessage*, CNWSPlayer*>(&HandleMapPinDestroyMapPinMessageHook);
-    m_HandlePlayerToServerMapPinDestroyMapPinHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__HandlePlayerToServerMapPinDestroyMapPin);
+    Events::InitOnFirstSubscribe("NWNX_ON_MAP_PIN_DESTROY_PIN_.*", [hooker]() {
+        hooker->RequestExclusiveHook<Functions::CNWSMessage__HandlePlayerToServerMapPinDestroyMapPin, int32_t,
+            CNWSMessage*, CNWSPlayer*>(&HandleMapPinDestroyMapPinMessageHook);
+        m_HandlePlayerToServerMapPinDestroyMapPinHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__HandlePlayerToServerMapPinDestroyMapPin);
+    });
 
 }
 

--- a/Plugins/Events/Events/PartyEvents.cpp
+++ b/Plugins/Events/Events/PartyEvents.cpp
@@ -17,9 +17,11 @@ static NWNXLib::Hooking::FunctionHook* m_HandlePlayerToServerPartyHook = nullptr
 
 PartyEvents::PartyEvents(ViewPtr<Services::HooksProxy> hooker)
 {
-    hooker->RequestExclusiveHook<Functions::CNWSMessage__HandlePlayerToServerParty, int32_t,
-        CNWSMessage*, CNWSPlayer*, uint8_t>(&HandlePartyMessageHook);
-    m_HandlePlayerToServerPartyHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__HandlePlayerToServerParty);
+    Events::InitOnFirstSubscribe("NWNX_ON_PARTY_.*", [hooker]() {
+        hooker->RequestExclusiveHook<Functions::CNWSMessage__HandlePlayerToServerParty, int32_t,
+            CNWSMessage*, CNWSPlayer*, uint8_t>(&HandlePartyMessageHook);
+        m_HandlePlayerToServerPartyHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__HandlePlayerToServerParty);
+    });
 }
 
 int32_t PartyEvents::HandlePartyMessageHook(CNWSMessage *thisPtr, CNWSPlayer *pPlayer, uint8_t nMinor)

--- a/Plugins/Events/Events/PolymorphEvents.cpp
+++ b/Plugins/Events/Events/PolymorphEvents.cpp
@@ -15,15 +15,19 @@ static Hooking::FunctionHook* m_OnRemovePolymorphHook = nullptr;
 
 PolymorphEvents::PolymorphEvents(ViewPtr<Services::HooksProxy> hooker)
 {
-    hooker->RequestExclusiveHook<Functions::CNWSEffectListHandler__OnApplyPolymorph,
-        int32_t, CNWSEffectListHandler*, CNWSObject*, CGameEffect*, int32_t>
-        (PolymorphEvents::OnApplyPolymorphHook);
-    hooker->RequestExclusiveHook<Functions::CNWSEffectListHandler__OnRemovePolymorph,
-        int32_t, CNWSEffectListHandler*, CNWSObject*, CGameEffect*>
-        (PolymorphEvents::OnRemovePolymorphHook);
+    Events::InitOnFirstSubscribe("NWNX_ON_POLYMORPH_.*", [hooker]() {
+        hooker->RequestExclusiveHook<Functions::CNWSEffectListHandler__OnApplyPolymorph,
+            int32_t, CNWSEffectListHandler*, CNWSObject*, CGameEffect*, int32_t>
+            (PolymorphEvents::OnApplyPolymorphHook);
+        m_OnApplyPolymorphHook = hooker->FindHookByAddress(Functions::CNWSEffectListHandler__OnApplyPolymorph);
+    });
+    Events::InitOnFirstSubscribe("NWNX_ON_UNPOLYMORPH_.*", [hooker]() {
+        hooker->RequestExclusiveHook<Functions::CNWSEffectListHandler__OnRemovePolymorph,
+            int32_t, CNWSEffectListHandler*, CNWSObject*, CGameEffect*>
+            (PolymorphEvents::OnRemovePolymorphHook);
+        m_OnRemovePolymorphHook = hooker->FindHookByAddress(Functions::CNWSEffectListHandler__OnRemovePolymorph);
+    });
 
-    m_OnApplyPolymorphHook = hooker->FindHookByAddress(Functions::CNWSEffectListHandler__OnApplyPolymorph);
-    m_OnRemovePolymorphHook = hooker->FindHookByAddress(Functions::CNWSEffectListHandler__OnRemovePolymorph);
 }
 
 int32_t PolymorphEvents::OnApplyPolymorphHook

--- a/Plugins/Events/Events/QuickChatEvents.cpp
+++ b/Plugins/Events/Events/QuickChatEvents.cpp
@@ -18,8 +18,10 @@ static NWNXLib::Hooking::FunctionHook* m_HandlePlayerToServerQuickChatMessageHoo
 
 QuickChatEvents::QuickChatEvents(ViewPtr<Services::HooksProxy> hooker)
 {
-    hooker->RequestExclusiveHook<API::Functions::CNWSMessage__HandlePlayerToServerQuickChatMessage>(&HandlePlayerToServerQuickChatMessageHook);
-    m_HandlePlayerToServerQuickChatMessageHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__HandlePlayerToServerQuickChatMessage);
+    Events::InitOnFirstSubscribe("NWNX_ON_QUICKCHAT_.*", [hooker]() {
+        hooker->RequestExclusiveHook<API::Functions::CNWSMessage__HandlePlayerToServerQuickChatMessage>(&HandlePlayerToServerQuickChatMessageHook);
+        m_HandlePlayerToServerQuickChatMessageHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__HandlePlayerToServerQuickChatMessage);
+    });
 }
 
 int32_t QuickChatEvents::HandlePlayerToServerQuickChatMessageHook(CNWSMessage *thisPtr, CNWSPlayer *pPlayer, uint8_t nMinor)

--- a/Plugins/Events/Events/SkillEvents.cpp
+++ b/Plugins/Events/Events/SkillEvents.cpp
@@ -12,10 +12,12 @@ static Hooking::FunctionHook* m_UseSkillHook = nullptr;
 
 SkillEvents::SkillEvents(ViewPtr<Services::HooksProxy> hooker)
 {
-    hooker->RequestExclusiveHook<API::Functions::CNWSCreature__UseSkill, int32_t, API::CNWSCreature*, uint8_t, uint8_t, NWNXLib::API::Types::ObjectID,
-        NWNXLib::API::Vector, NWNXLib::API::Types::ObjectID, NWNXLib::API::Types::ObjectID, int32_t>(&UseSkillHook);
+    Events::InitOnFirstSubscribe("NWNX_ON_USE_SKILL_.*", [hooker]() {
+        hooker->RequestExclusiveHook<API::Functions::CNWSCreature__UseSkill, int32_t, API::CNWSCreature*, uint8_t, uint8_t, NWNXLib::API::Types::ObjectID,
+            NWNXLib::API::Vector, NWNXLib::API::Types::ObjectID, NWNXLib::API::Types::ObjectID, int32_t>(&UseSkillHook);
 
-    m_UseSkillHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__UseSkill);
+        m_UseSkillHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__UseSkill);
+    });
 }
 
 int32_t SkillEvents::UseSkillHook(

--- a/Plugins/Events/Events/SpellEvents.cpp
+++ b/Plugins/Events/Events/SpellEvents.cpp
@@ -12,8 +12,10 @@ static Hooking::FunctionHook* m_SpellCastAndImpactHook = nullptr;
 
 SpellEvents::SpellEvents(ViewPtr<Services::HooksProxy> hooker)
 {
-    hooker->RequestExclusiveHook<NWNXLib::API::Functions::CNWSObject__SpellCastAndImpact>(&CastSpellHook);
-    m_SpellCastAndImpactHook = hooker->FindHookByAddress(NWNXLib::API::Functions::CNWSObject__SpellCastAndImpact);
+    Events::InitOnFirstSubscribe("NWNX_ON_CAST_SPELL_.*", [hooker]() {
+        hooker->RequestExclusiveHook<NWNXLib::API::Functions::CNWSObject__SpellCastAndImpact>(&CastSpellHook);
+        m_SpellCastAndImpactHook = hooker->FindHookByAddress(NWNXLib::API::Functions::CNWSObject__SpellCastAndImpact);
+    });
 }
 
 void SpellEvents::CastSpellHook

--- a/Plugins/Events/Events/StealthEvents.cpp
+++ b/Plugins/Events/Events/StealthEvents.cpp
@@ -14,13 +14,19 @@ static NWNXLib::Hooking::FunctionHook* m_DoListenDetectionHook = nullptr;
 
 StealthEvents::StealthEvents(ViewPtr<Services::HooksProxy> hooker)
 {
-    hooker->RequestSharedHook<API::Functions::CNWSCreature__SetStealthMode, void, API::CNWSCreature*, uint8_t>(&SetStealthModeHook);
+    Events::InitOnFirstSubscribe("NWNX_ON_E.*_STEALTH_.*", [hooker]() {
+        hooker->RequestSharedHook<API::Functions::CNWSCreature__SetStealthMode, void, API::CNWSCreature*, uint8_t>(&SetStealthModeHook);
+    });
 
+    Events::InitOnFirstSubscribe("NWNX_ON_DO_LISTEN_DETECTION_.*", [hooker]() {
     hooker->RequestExclusiveHook<API::Functions::CNWSCreature__DoListenDetection, int32_t>(&DoListenDetectionHook);
     m_DoListenDetectionHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__DoListenDetection);
+    });
 
+    Events::InitOnFirstSubscribe("NWNX_ON_DO_SPOT_DETECTION.*", [hooker]() {
     hooker->RequestExclusiveHook<API::Functions::CNWSCreature__DoSpotDetection, int32_t>(&DoSpotDetectionHook);
     m_DoSpotDetectionHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__DoSpotDetection);
+    });
 }
 
 void StealthEvents::SetStealthModeHook(Services::Hooks::CallType type, API::CNWSCreature* thisPtr, uint8_t mode)

--- a/Plugins/Events/Events/StealthEvents.cpp
+++ b/Plugins/Events/Events/StealthEvents.cpp
@@ -19,13 +19,13 @@ StealthEvents::StealthEvents(ViewPtr<Services::HooksProxy> hooker)
     });
 
     Events::InitOnFirstSubscribe("NWNX_ON_DO_LISTEN_DETECTION_.*", [hooker]() {
-    hooker->RequestExclusiveHook<API::Functions::CNWSCreature__DoListenDetection, int32_t>(&DoListenDetectionHook);
-    m_DoListenDetectionHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__DoListenDetection);
+        hooker->RequestExclusiveHook<API::Functions::CNWSCreature__DoListenDetection, int32_t>(&DoListenDetectionHook);
+        m_DoListenDetectionHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__DoListenDetection);
     });
 
     Events::InitOnFirstSubscribe("NWNX_ON_DO_SPOT_DETECTION.*", [hooker]() {
-    hooker->RequestExclusiveHook<API::Functions::CNWSCreature__DoSpotDetection, int32_t>(&DoSpotDetectionHook);
-    m_DoSpotDetectionHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__DoSpotDetection);
+        hooker->RequestExclusiveHook<API::Functions::CNWSCreature__DoSpotDetection, int32_t>(&DoSpotDetectionHook);
+        m_DoSpotDetectionHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__DoSpotDetection);
     });
 }
 


### PR DESCRIPTION
Resolves #364 

When hooking for a new event, you can specify a regex of event names that it fires. The hooks will then only be applied if you subscribe to one of those events. This moves our events to a pay-for-what-you-use model where no code fires if you didn't subscribe to something.

As a side effect, all the configuration of the events plugin is now useless, and thus removed.