### PR TITLE
Feedback: Add ability to suppress quest journal updated message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The following plugins were added:
 - **Effect**: Provides various utility functions to manipulate builtin effect types
 - **Experimental**: Adds experimental functionality that's not really useful for the general user. The following environmental variable needs to be true for the plugin to load: `NWNX_CORE_LOAD_EXPERIMENTAL_PLUGIN=y`
 - **Encounter**: Adds functions exposing additional encounter properties
-- **Feedback**: Allows combatlog and feedback messages to be hidden globally or per player
+- **Feedback**: Allows combatlog, feedback and 'quest journal updated' messages to be hidden globally or per player
 - **ItemProperty**: Provides various utility functions to manipulate builtin itemproperty types
 - **Rename**: Adds functions to facilitate renaming, overriding and customization of player names
 - **Reveal**: Adds functions to allow the selective revealing of a stealthed character to another character or their party.

--- a/Plugins/Feedback/Feedback.hpp
+++ b/Plugins/Feedback/Feedback.hpp
@@ -32,6 +32,13 @@ private:
         NWNXLib::API::CNWCCMessageData* pMessageData,
         NWNXLib::API::CNWSCombatAttackData* pAttackData);
 
+    static int32_t SendServerToPlayerJournalUpdatedHook(
+        NWNXLib::API::CNWSMessage* pMessage,
+        NWNXLib::API::CNWSPlayer* pPlayer,
+        int32_t bQuest,
+        int32_t bCompleted,
+        NWNXLib::API::CExoLocString* p_locName);
+
     bool GetGlobalState(int32_t messageType, int32_t messageId);
     int32_t GetPersonalState(NWNXLib::API::Types::ObjectID playerId, int32_t messageType, int32_t messageId);
 
@@ -40,6 +47,9 @@ private:
 
     NWNXLib::Hooking::FunctionHook* m_SendServerToPlayerCCMessageHook;
     std::set<int32_t> m_GlobalHiddenCombatLogMessageSet;
+
+    NWNXLib::Hooking::FunctionHook* m_SendServerToPlayerJournalUpdatedHook;
+    std::set<int32_t> m_GlobalHiddenJournalUpdatedMessageSet;
 };
 
 }

--- a/Plugins/Feedback/NWScript/nwnx_feedback.nss
+++ b/Plugins/Feedback/NWScript/nwnx_feedback.nss
@@ -52,6 +52,31 @@ int NWNX_Feedback_GetCombatLogMessageHidden(int nMessage, object oPC = OBJECT_IN
 // to TRUE but the personal state is set to FALSE, the message will be shown to oPC
 void NWNX_Feedback_SetCombatLogMessageHidden(int nMessage, int nState, object oPC = OBJECT_INVALID);
 
+// Gets if journal updated message nMessage is hidden.
+// Notes:
+// If oPC == OBJECT_INVALID it will return the global state:
+//    TRUE      nMessage is globally hidden
+//    FALSE     nMessage is not globally hidden
+// If oPC is a valid player it will return the personal state:
+//    TRUE      nMessage is hidden for oPC
+//    FALSE     nMessage is not hidden for oPC
+//    -1        Personal state is not set
+int NWNX_Feedback_GetJournalUpdatedMessageHidden(object oPC = OBJECT_INVALID);
+
+// Sets if journal updated message nMessage is hidden.
+// Notes:
+// If oPC == OBJECT_INVALID it will set the global state:
+//    TRUE      nMessage is globally hidden
+//    FALSE     nMessage is not globally hidden
+// If oPC is a valid player it will set the personal state:
+//    TRUE      nMessage is hidden for oPC
+//    FALSE     nMessage is not hidden for oPC
+//    -1        Remove the personal state
+//
+// Personal state overrides the global state which means if a global state is set
+// to TRUE but the personal state is set to FALSE, the message will be shown to oPC
+void NWNX_Feedback_SetJournalUpdatedMessageHidden(int nState, object oPC = OBJECT_INVALID);
+
 // ***
 // For a list of the various combatlog / feedback messages see below.
 // ***
@@ -104,6 +129,31 @@ void NWNX_Feedback_SetCombatLogMessageHidden(int nMessage, int nState, object oP
 
     NWNX_PushArgumentInt(NWNX_Feedback, sFunc, nState);
     NWNX_PushArgumentInt(NWNX_Feedback, sFunc, nMessage);
+    NWNX_PushArgumentInt(NWNX_Feedback, sFunc, nMessageType);
+    NWNX_PushArgumentObject(NWNX_Feedback, sFunc, oPC);
+    NWNX_CallFunction(NWNX_Feedback, sFunc);
+}
+
+int NWNX_Feedback_GetJournalUpdatedMessageHidden(object oPC = OBJECT_INVALID)
+{
+    string sFunc = "GetMessageHidden";
+    int nMessageType = 2;
+
+    NWNX_PushArgumentInt(NWNX_Feedback, sFunc, 0);
+    NWNX_PushArgumentInt(NWNX_Feedback, sFunc, nMessageType);
+    NWNX_PushArgumentObject(NWNX_Feedback, sFunc, oPC);
+    NWNX_CallFunction(NWNX_Feedback, sFunc);
+
+    return NWNX_GetReturnValueInt(NWNX_Feedback, sFunc);
+}
+
+void NWNX_Feedback_SetJournalUpdatedMessageHidden(int nState, object oPC = OBJECT_INVALID)
+{
+    string sFunc = "SetMessageHidden";
+    int nMessageType = 2;
+
+    NWNX_PushArgumentInt(NWNX_Feedback, sFunc, nState);
+    NWNX_PushArgumentInt(NWNX_Feedback, sFunc, 0);
     NWNX_PushArgumentInt(NWNX_Feedback, sFunc, nMessageType);
     NWNX_PushArgumentObject(NWNX_Feedback, sFunc, oPC);
     NWNX_CallFunction(NWNX_Feedback, sFunc);


### PR DESCRIPTION
This can be handy for persistent worlds when the journal first gets set when the players logs in helping to avoid spam as illustrated below:
![screenshot-20190224004200-320x579](https://user-images.githubusercontent.com/11622375/53297589-6eabae80-37ee-11e9-83ea-a4187642cc28.png)
