### PR TITLE
SpellEvents: Set|ClearMemorizedSpell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Events: Added Event Data for SpawnObject, GiveItem and GiveAlignment, Heal, Kill, ToggleInvulnerabilty, ForceRest, Limbo, ToggleAI, ToggleImmortal, Goto, Possess, PossessFullPower, ToggleLock, DisableTrap, JumpToPoint, JumpTargetToPoint, JumpAllPlayersToPoint, ChangeDifficulty, ViewInventory, SpawnTrapOnObject events in DMActionEvents
 - Events: Added OnClientConnect events that fire before the player sees the server vault.
 - Events: Added ItemInventory{Open/Close} and ItemInventory{Add/Remove}Item events to ItemEvents
+- Events: Added {Set|Clear}MemorizedSpellSlot events to SpellEvents
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite
 - Tweaks: DisableQuickSave

--- a/Plugins/Events/Events/SpellEvents.cpp
+++ b/Plugins/Events/Events/SpellEvents.cpp
@@ -1,19 +1,33 @@
 #include "Events/SpellEvents.hpp"
 #include "API/CNWSCreature.hpp"
+#include "API/CNWSCreatureStats.hpp"
+#include "API/CNWRules.hpp"
+#include "API/CNWSpellArray.hpp"
 #include "API/Functions.hpp"
+#include "API/Globals.hpp"
 #include "Events.hpp"
 #include "Utils.hpp"
 
 namespace Events {
 
 using namespace NWNXLib;
+using namespace NWNXLib::API;
+
 
 static Hooking::FunctionHook* m_SpellCastAndImpactHook = nullptr;
+static Hooking::FunctionHook* m_SetMemorizedSpellSlotHook = nullptr;
+static Hooking::FunctionHook* m_ClearMemorizedSpellSlotHook = nullptr;
 
 SpellEvents::SpellEvents(ViewPtr<Services::HooksProxy> hooker)
 {
     hooker->RequestExclusiveHook<NWNXLib::API::Functions::CNWSObject__SpellCastAndImpact>(&CastSpellHook);
     m_SpellCastAndImpactHook = hooker->FindHookByAddress(NWNXLib::API::Functions::CNWSObject__SpellCastAndImpact);
+
+    hooker->RequestExclusiveHook<NWNXLib::API::Functions::CNWSCreatureStats__SetMemorizedSpellSlot>(&SetMemorizedSpellSlotHook);
+    m_SetMemorizedSpellSlotHook = hooker->FindHookByAddress(NWNXLib::API::Functions::CNWSCreatureStats__SetMemorizedSpellSlot);
+
+    hooker->RequestExclusiveHook<NWNXLib::API::Functions::CNWSCreatureStats__ClearMemorizedSpellSlot>(&ClearMemorizedSpellSlotHook);
+    m_ClearMemorizedSpellSlotHook = hooker->FindHookByAddress(NWNXLib::API::Functions::CNWSCreatureStats__ClearMemorizedSpellSlot);
 }
 
 void SpellEvents::CastSpellHook
@@ -60,4 +74,78 @@ void SpellEvents::CastSpellHook
     PushAndSignal("NWNX_ON_CAST_SPELL_AFTER");
 }
 
+int32_t SpellEvents::SetMemorizedSpellSlotHook
+(
+    NWNXLib::API::CNWSCreatureStats* thisPtr,
+    uint8_t multiClass,
+    uint8_t slot,
+    uint32_t spellID,
+    uint8_t domain,
+    uint8_t meta,
+    int32_t fromClient
+)
+{
+    int32_t retVal;
+    std::string sBeforeEventResult;
+    std::string sAfterEventResult;
+
+    Events::PushEventData("SPELL_CLASS", std::to_string(multiClass));
+    Events::PushEventData("SPELL_SLOT", std::to_string(slot));
+    Events::PushEventData("SPELL_ID", std::to_string(spellID));
+    Events::PushEventData("SPELL_DOMAIN", std::to_string(domain));
+    Events::PushEventData("SPELL_METAMAGIC", std::to_string(meta));
+    Events::PushEventData("SPELL_FROMCLIENT", std::to_string(fromClient));
+
+    retVal = Events::SignalEvent("NWNX_SET_MEMORIZED_SPELL_SLOT_BEFORE", thisPtr->m_pBaseCreature->m_idSelf, &sBeforeEventResult)
+             ? m_SetMemorizedSpellSlotHook->CallOriginal<int32_t>(thisPtr, multiClass, slot, spellID, domain, meta, fromClient) : 
+             sBeforeEventResult == "1";
+
+    Events::PushEventData("SPELL_CLASS", std::to_string(multiClass));
+    Events::PushEventData("SPELL_SLOT", std::to_string(slot));
+    Events::PushEventData("SPELL_ID", std::to_string(spellID));
+    Events::PushEventData("SPELL_DOMAIN", std::to_string(domain));
+    Events::PushEventData("SPELL_METAMAGIC", std::to_string(meta));
+    Events::PushEventData("SPELL_FROMCLIENT", std::to_string(fromClient));
+    Events::PushEventData("ACTION_RESULT", std::to_string(retVal));
+
+    Events::SignalEvent("NWNX_SET_MEMORIZED_SPELL_SLOT_AFTER", thisPtr->m_pBaseCreature->m_idSelf, &sAfterEventResult);
+
+    retVal = sAfterEventResult.empty() ? retVal : sAfterEventResult == "1";
+
+    uint8_t level = Globals::Rules()->m_pSpellArray->GetSpell(spellID)->GetSpellLevel(thisPtr->GetClass(multiClass));
+
+    if(!retVal)
+    {
+        m_ClearMemorizedSpellSlotHook->CallOriginal<void>(thisPtr, multiClass, level, slot);
+    }
+
+    return retVal;
+}
+
+void SpellEvents::ClearMemorizedSpellSlotHook
+(
+    NWNXLib::API::CNWSCreatureStats* thisPtr,
+    uint8_t multiClass,
+    uint8_t level,
+    uint8_t slot
+)
+{
+    auto PushAndSignal = [&](std::string ev) -> bool {
+        Events::PushEventData("SPELL_CLASS", std::to_string(multiClass));
+        Events::PushEventData("SPELL_LEVEL", std::to_string(level));
+        Events::PushEventData("SPELL_SLOT", std::to_string(slot));
+        return Events::SignalEvent(ev, thisPtr->m_pBaseCreature->m_idSelf);
+    };
+
+    if (PushAndSignal("NWNX_CLEAR_MEMORIZED_SPELL_SLOT_BEFORE"))
+    {
+        m_ClearMemorizedSpellSlotHook->CallOriginal<void>(thisPtr, multiClass, level, slot);
+    }
+    else
+    {
+        //do we need to do anything?
+    }
+
+    PushAndSignal("NWNX_CLEAR_MEMORIZED_SPELL_SLOT_AFTER");
+}
 }

--- a/Plugins/Events/Events/SpellEvents.cpp
+++ b/Plugins/Events/Events/SpellEvents.cpp
@@ -117,11 +117,9 @@ int32_t SpellEvents::SetMemorizedSpellSlotHook
 
     retVal = sAfterEventResult.empty() ? retVal : sAfterEventResult == "1";
 
-    uint8_t level = Globals::Rules()->m_pSpellArray->GetSpell(spellID)->GetSpellLevel(thisPtr->GetClass(multiClass));
-
-    if(!retVal)
+    if(retVal)
     {
-        m_ClearMemorizedSpellSlotHook->CallOriginal<void>(thisPtr, multiClass, level, slot);
+        // Do we do anything if the user bypasses but returns a value?
     }
 
     return retVal;
@@ -145,10 +143,6 @@ void SpellEvents::ClearMemorizedSpellSlotHook
     if (PushAndSignal("NWNX_CLEAR_MEMORIZED_SPELL_SLOT_BEFORE"))
     {
         m_ClearMemorizedSpellSlotHook->CallOriginal<void>(thisPtr, multiClass, level, slot);
-    }
-    else
-    {
-        //do we need to do anything?
     }
 
     PushAndSignal("NWNX_CLEAR_MEMORIZED_SPELL_SLOT_AFTER");

--- a/Plugins/Events/Events/SpellEvents.cpp
+++ b/Plugins/Events/Events/SpellEvents.cpp
@@ -13,7 +13,6 @@ namespace Events {
 using namespace NWNXLib;
 using namespace NWNXLib::API;
 
-
 static Hooking::FunctionHook* m_SpellCastAndImpactHook = nullptr;
 static Hooking::FunctionHook* m_SetMemorizedSpellSlotHook = nullptr;
 static Hooking::FunctionHook* m_ClearMemorizedSpellSlotHook = nullptr;

--- a/Plugins/Events/Events/SpellEvents.cpp
+++ b/Plugins/Events/Events/SpellEvents.cpp
@@ -117,11 +117,6 @@ int32_t SpellEvents::SetMemorizedSpellSlotHook
 
     retVal = sAfterEventResult.empty() ? retVal : sAfterEventResult == "1";
 
-    if(retVal)
-    {
-        // Do we do anything if the user bypasses but returns a value?
-    }
-
     return retVal;
 }
 

--- a/Plugins/Events/Events/SpellEvents.hpp
+++ b/Plugins/Events/Events/SpellEvents.hpp
@@ -27,6 +27,17 @@ private:
         int8_t,
         bool
     );
+    static int32_t SetMemorizedSpellSlotHook
+    (
+        NWNXLib::API::CNWSCreatureStats*,
+        uint8_t,
+        uint8_t,
+        uint32_t,
+        uint8_t,
+        uint8_t,
+        int32_t
+    );
+    static void ClearMemorizedSpellSlotHook(NWNXLib::API::CNWSCreatureStats*, uint8_t, uint8_t, uint8_t);
 };
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -342,7 +342,7 @@
         SPELL_DOMAIN            int
         SPELL_METAMAGIC         int
         SPELL_FROMCLIENT        int
-        BEFORE_RESULT           int
+        ACTION_RESULT           int
 
     NWNX_CLEAR_MEMORIZED_SPELL_SLOT_BEFORE
     NWNX_CLEAR_MEMORIZED_SPELL_SLOT_AFTER

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -331,11 +331,11 @@
     NWNX_SET_MEMORIZED_SPELL_SLOT_AFTER
 
     Usage:
-        OBJECT_SELF = The creature whose memorizing the spell
+        OBJECT_SELF = The creature who's memorizing the spell
 
     Event data:
         Variable Name           Type        Notes
-        SPELL_MULTICLASS        int
+        SPELL_MULTICLASS        int         Index of the spell casting class (0-2)
         SPELL_LEVEL             int
         SPELL_SLOT              int
         SPELL_ID                int
@@ -352,7 +352,7 @@
 
     Event data:
         Variable Name           Type        Notes
-        SPELL_MULTICLASS        int
+        SPELL_MULTICLASS        int         Index of the spell casting class (0-2)
         SPELL_LEVEL             int
         SPELL_SLOT              int
 ////////////////////////////////////////////////////////////////////////////////

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -312,6 +312,35 @@
         COUNTERING_SPELL        int         Returns TRUE if cast as counter else FALSE
         PROJECTILE_PATH_TYPE    int
         IS_INSTANT_SPELL        int         Returns TRUE if spell was instant else FALSE
+
+    NWNX_SET_MEMORIZED_SPELL_SLOT_BEFORE
+    NWNX_SET_MEMORIZED_SPELL_SLOT_AFTER
+
+    Usage:
+        OBJECT_SELF = The creature whose memorizing the spell
+
+    Event data:
+        Variable Name           Type        Notes
+        SPELL_MULTICLASS        int
+        SPELL_LEVEL             int
+        SPELL_SLOT              int
+        SPELL_ID                int
+        SPELL_DOMAIN            int
+        SPELL_METAMAGIC         int
+        SPELL_FROMCLIENT        int
+        BEFORE_RESULT           int
+
+    NWNX_CLEAR_MEMORIZED_SPELL_SLOT_BEFORE
+    NWNX_CLEAR_MEMORIZED_SPELL_SLOT_AFTER
+
+    Usage:
+        OBJECT_SELF = The creature whose spellbook is being changed
+
+    Event data:
+        Variable Name           Type        Notes
+        SPELL_MULTICLASS        int
+        SPELL_LEVEL             int
+        SPELL_SLOT              int
 ////////////////////////////////////////////////////////////////////////////////
     NWNX_ON_USE_HEALER_KIT_BEFORE
     NWNX_ON_USE_HEALER_KIT_AFTER


### PR DESCRIPTION
Resolves #366. The UI doesn't update if the event is bypassed, well it requires a refresh. Also should we do anything with the return value on the Set?