### PR TITLE
Events: add InventoryEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Added string localization support. Only Russian/Cyrillic supported at the moment. Use environment variable `NWNX_CORE_LOCALE=ru`
 - Core: Allow changing default plugin state from 'load all' to 'skip all' with the following environment variable: `NWNX_CORE_SKIP_ALL=y`. Use `NWNX_PLUGIN_SKIP=n` to enable specific plugins in this case.
 - Core: Allow passing engine structures to nwnx (Effect/Itemproperty)
-- Events: New events: SkillEvents, MapEvents, EffectEvents, QuickChatEvents
-- Events: The following events are now skippable: FeatEvents, ItemEvents, HealersKitEvents, CombatModeEvents, PartyEvents, SkillEvents, MapEvents, PolymorphEvents, DMActionEvents, ClientConnectEvents, SpellEvents, QuickChatEvents
+- Events: New events: SkillEvents, MapEvents, EffectEvents, QuickChatEvents, InventoryEvents
+- Events: The following events are now skippable: FeatEvents, ItemEvents, HealersKitEvents, CombatModeEvents, PartyEvents, SkillEvents, MapEvents, PolymorphEvents, DMActionEvents, ClientConnectEvents, SpellEvents, QuickChatEvents, InventoryEvents
 - Events: You can now get the current event name with a nwscript function
 - Events: Added On{Listen/Spot}Detection events to StealthEvents
 - Events: Added On{Un}Polymorph events as PolymorphEvents
-- Events: Added Event Data for SpawnObject, GiveItem and GiveAlignment, Heal, Kill, ToggleInvulnerabilty, ForceRest, Limbo, ToggleAI, ToggleImmortal, Goto, Possess, PossessFullPower, ToggleLock, DisableTrap, JumpToPoint, JumpTargetToPoint, JumpAllPlayersToPoint, ChangeDifficulty, ViewInventory, SpawnTrapOnObject events in DMActionEvents
+- Events: Added Event Data for SpawnObject, GiveItem, GiveAlignment, Heal, Kill, ToggleInvulnerabilty, ForceRest, Limbo, ToggleAI, ToggleImmortal, Goto, Possess, PossessFullPower, ToggleLock, DisableTrap, JumpToPoint, JumpTargetToPoint, JumpAllPlayersToPoint, ChangeDifficulty, ViewInventory, SpawnTrapOnObject events in DMActionEvents
 - Events: Added OnClientConnect events that fire before the player sees the server vault.
 - Events: Added ItemInventory{Open/Close} and ItemInventory{Add/Remove}Item events to ItemEvents
 - Events: Added {Set|Clear}MemorizedSpellSlot events to SpellEvents

--- a/Plugins/Events/CMakeLists.txt
+++ b/Plugins/Events/CMakeLists.txt
@@ -15,4 +15,5 @@ add_plugin(Events
     "Events/SkillEvents.cpp"
     "Events/PolymorphEvents.cpp"
     "Events/EffectEvents.cpp"
-    "Events/QuickChatEvents.cpp")
+    "Events/QuickChatEvents.cpp"
+    "Events/InventoryEvents.cpp")

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -19,6 +19,7 @@
 #include "Events/PolymorphEvents.hpp"
 #include "Events/EffectEvents.hpp"
 #include "Events/QuickChatEvents.hpp"
+#include "Events/InventoryEvents.hpp"
 #include "Services/Config/Config.hpp"
 #include "Services/Messaging/Messaging.hpp"
 #include "ViewPtr.hpp"
@@ -94,6 +95,7 @@ Events::Events(const Plugin::CreateParams& params)
     m_polymorphEvents   = std::make_unique<PolymorphEvents>(GetServices()->m_hooks);
     m_effectEvents      = std::make_unique<EffectEvents>(GetServices()->m_hooks);
     m_quickChatEvents   = std::make_unique<QuickChatEvents>(GetServices()->m_hooks);
+    m_inventoryEvents   = std::make_unique<InventoryEvents>(GetServices()->m_hooks);
 }
 
 Events::~Events()

--- a/Plugins/Events/Events.hpp
+++ b/Plugins/Events/Events.hpp
@@ -26,6 +26,7 @@ class SkillEvents;
 class PolymorphEvents;
 class EffectEvents;
 class QuickChatEvents;
+class InventoryEvents;
 
 class Events : public NWNXLib::Plugin
 {
@@ -100,6 +101,7 @@ private:
     std::unique_ptr<PolymorphEvents> m_polymorphEvents;
     std::unique_ptr<EffectEvents> m_effectEvents;
     std::unique_ptr<QuickChatEvents> m_quickChatEvents;
+    std::unique_ptr<InventoryEvents> m_inventoryEvents;
 };
 
 }

--- a/Plugins/Events/Events/InventoryEvents.cpp
+++ b/Plugins/Events/Events/InventoryEvents.cpp
@@ -1,0 +1,93 @@
+#include "Events/InventoryEvents.hpp"
+#include "API/CNWSPlayer.hpp"
+#include "API/CNWSMessage.hpp"
+#include "API/CNWSPlayerInventoryGUI.hpp"
+#include "API/Functions.hpp"
+#include "API/Constants.hpp"
+#include "Events.hpp"
+#include "Utils.hpp"
+
+
+namespace Events {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+using namespace NWNXLib::API::Constants;
+
+static NWNXLib::Hooking::FunctionHook* m_HandlePlayerToServerGuiInventoryMessageHook = nullptr;
+
+InventoryEvents::InventoryEvents(ViewPtr<Services::HooksProxy> hooker)
+{
+    Events::InitOnFirstSubscribe("NWNX_ON_INVENTORY_.*", [hooker]()
+    {
+        hooker->RequestExclusiveHook<API::Functions::CNWSMessage__HandlePlayerToServerGuiInventoryMessage>(
+                &HandlePlayerToServerGuiInventoryMessageHook);
+        m_HandlePlayerToServerGuiInventoryMessageHook = hooker->FindHookByAddress(
+                API::Functions::CNWSMessage__HandlePlayerToServerGuiInventoryMessage);
+    });
+}
+
+int32_t InventoryEvents::HandlePlayerToServerGuiInventoryMessageHook(CNWSMessage *thisPtr, CNWSPlayer *pPlayer, uint8_t nMinor)
+{
+    int32_t retVal;
+    Types::ObjectID oidPlayer = pPlayer ? pPlayer->m_oidNWSObject : OBJECT_INVALID;
+
+    switch (nMinor)
+    {
+        case MessageGuiInventoryMinor::Status:
+        {
+            std::string open = std::to_string(Utils::PeekMessage<int32_t>(thisPtr, 0));
+
+            auto PushAndSignal = [&](std::string ev) -> bool
+            {
+                Events::PushEventData("OPEN", open);
+
+                return Events::SignalEvent(ev, oidPlayer);
+            };
+
+            if (PushAndSignal("NWNX_ON_INVENTORY_OPEN_BEFORE"))
+            {
+                retVal = m_HandlePlayerToServerGuiInventoryMessageHook->CallOriginal<int32_t>(thisPtr, pPlayer, nMinor);
+            }
+            else
+            {
+                retVal = false;
+            }
+
+            PushAndSignal("NWNX_ON_INVENTORY_OPEN_AFTER");
+            break;
+        }
+
+        case MessageGuiInventoryMinor::SelectPanel:
+        {
+            std::string panel = std::to_string(Utils::PeekMessage<uint8_t>(thisPtr, 0));
+
+            auto PushAndSignal = [&](std::string ev) -> bool
+            {
+                Events::PushEventData("PAGE", panel);
+
+                return Events::SignalEvent(ev, oidPlayer);
+            };
+
+            if (PushAndSignal("NWNX_ON_INVENTORY_SELECT_PAGE_BEFORE"))
+            {
+                retVal = m_HandlePlayerToServerGuiInventoryMessageHook->CallOriginal<int32_t>(thisPtr, pPlayer, nMinor);
+            }
+            else
+            {
+                retVal = false;
+            }
+
+            PushAndSignal("NWNX_ON_INVENTORY_SELECT_PAGE_AFTER");
+            break;
+        }
+
+        default:
+            retVal = m_HandlePlayerToServerGuiInventoryMessageHook->CallOriginal<int32_t>(thisPtr, pPlayer, nMinor);
+            break;
+    }
+
+    return retVal;
+}
+
+}

--- a/Plugins/Events/Events/InventoryEvents.cpp
+++ b/Plugins/Events/Events/InventoryEvents.cpp
@@ -61,7 +61,7 @@ int32_t InventoryEvents::HandlePlayerToServerGuiInventoryMessageHook(CNWSMessage
                     CNWSPlayerInventoryGUI *pInventory = pPlayer->m_oidNWSObject == target ? pPlayer->m_pInventoryGUI :
                                                          pPlayer->m_pOtherInventoryGUI;
 
-                    auto *pMessage = static_cast<CNWSMessage *>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
+                    auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
                     if (pMessage)
                     {
                         pMessage->SendPlayerToServerGuiInventory_Status(pPlayer, false, target);
@@ -104,7 +104,7 @@ int32_t InventoryEvents::HandlePlayerToServerGuiInventoryMessageHook(CNWSMessage
                 }
                 else
                 {
-                    auto *pMessage = static_cast<CNWSMessage *>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
+                    auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
                     if (pMessage)
                     {
                         pMessage->SendServerToPlayerInventory_SelectPanel(pPlayer->m_nPlayerID, currentPanel);

--- a/Plugins/Events/Events/InventoryEvents.hpp
+++ b/Plugins/Events/Events/InventoryEvents.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "API/Vector.hpp"
+#include "Common.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include "ViewPtr.hpp"
+
+namespace Events {
+
+class InventoryEvents
+{
+public:
+    InventoryEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
+
+private:
+    static int32_t HandlePlayerToServerGuiInventoryMessageHook(NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*, uint8_t);
+};
+
+}

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -563,7 +563,7 @@
     Event data:
         Variable Name           Type        Notes
         CURRENT_PANEL           int         The current panel, index starts at 0
-        SELECTED_PANE           int         The selected panel, index starts at 0
+        SELECTED_PANEL          int         The selected panel, index starts at 0
 *///////////////////////////////////////////////////////////////////////////////
 
 /*

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -543,6 +543,27 @@
     Event data:
         Variable Name           Type        Notes
         QUICKCHAT_COMMAND       int
+////////////////////////////////////////////////////////////////////////////////
+    NWNX_ON_INVENTORY_OPEN_BEFORE
+    NWNX_ON_INVENTORY_OPEN_AFTER
+
+    Usage:
+        OBJECT_SELF = The player opening the inventory
+
+    Event data:
+        Variable Name           Type        Notes
+        TARGET_INVENTORY        object      Pretty sure this is always the player
+
+    NWNX_ON_INVENTORY_SELECT_PANEL_BEFORE
+    NWNX_ON_INVENTORY_SELECT_PANEL_AFTER
+
+    Usage:
+        OBJECT_SELF = The player changing inventory panels
+
+    Event data:
+        Variable Name           Type        Notes
+        CURRENT_PANEL           int         The current panel, index starts at 0
+        SELECTED_PANE           int         The selected panel, index starts at 0
 *///////////////////////////////////////////////////////////////////////////////
 
 /*


### PR DESCRIPTION
Resolves #365

Adds the following events:

```
NWNX_ON_INVENTORY_OPEN_BEFORE
NWNX_ON_INVENTORY_OPEN_AFTER
NWNX_ON_INVENTORY_SELECT_PANEL_BEFORE
NWNX_ON_INVENTORY_SELECT_PANEL_AFTER
```

Skipping INVENTORY_OPEN will briefly flash the inventory panel on the player's screen.

Skipping SELECT_PANEL is also a bit wonky, it'll put you back to the previous panel but its contents won't be visible until you reopen the inventory panel. I haven't figured out how to refresh the inventory panel. :D