### PR TITLE
Initial implementation of a regex plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The following plugins were added:
 - **Encounter**: Adds functions exposing additional encounter properties
 - **Feedback**: Allows combatlog, feedback and 'quest journal updated' messages to be hidden globally or per player
 - **ItemProperty**: Provides various utility functions to manipulate builtin itemproperty types
+- **Regex**: Adds functions to search and replace strings using regular expressions.
 - **Rename**: Adds functions to facilitate renaming, overriding and customization of player names
 - **Reveal**: Adds functions to allow the selective revealing of a stealthed character to another character or their party.
 - **Visibility**: Allows the visibility of objects to be overridden globally or per player
@@ -110,6 +111,8 @@ The following plugins were added:
 - Player: ApplyInstantVisualEffectToObject()
 - Player: UpdateCharacterSheet()
 - Player: OpenInventory()
+- Regex: Search()
+- Regex: Replace()
 - Rename: SetPCNameOverride()
 - Reveal: RevealTo()
 - Reveal: SetRevealToParty()

--- a/Plugins/Regex/CMakeLists.txt
+++ b/Plugins/Regex/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_plugin(Regex
+    "Regex.cpp")

--- a/Plugins/Regex/Documentation/README.md
+++ b/Plugins/Regex/Documentation/README.md
@@ -1,0 +1,11 @@
+# Regex Plugin Reference
+
+## Description
+
+Provide regular expression functions. Due to the complications with using backslashes in nwscript, a configurable substring to use instead of backslashes is available. The default is a double exclamation point.
+
+## Environment Variables
+
+| Variable Name     |  Type                   | Default Value                      |
+| ----------------- | :---------------------: | ---------------------------------- |
+| `BACKSLASH_SUBSTRING`      | string                  | !!             |

--- a/Plugins/Regex/Documentation/README.md
+++ b/Plugins/Regex/Documentation/README.md
@@ -2,10 +2,6 @@
 
 ## Description
 
-Provide regular expression functions. Due to the complications with using backslashes in nwscript, a configurable substring to use instead of backslashes is available. The default is a double exclamation point.
+Provide regular expression functions.
 
 ## Environment Variables
-
-| Variable Name     |  Type                   | Default Value                      |
-| ----------------- | :---------------------: | ---------------------------------- |
-| `BACKSLASH_SUBSTRING`      | string                  | !!             |

--- a/Plugins/Regex/NWScript/nwnx_regex.nss
+++ b/Plugins/Regex/NWScript/nwnx_regex.nss
@@ -1,0 +1,30 @@
+#include "nwnx"
+
+// Returns whether the string matches the regular expression
+int NWNX_Regex_Search(string str, string regex);
+
+// Replaces any matches of the regular expression with a string
+string NWNX_Regex_Replace(string str, string regex, string replace="", int firstOnly=0);
+
+
+const string NWNX_Regex = "NWNX_Regex";
+
+int NWNX_Regex_Search(string str, string regex)
+{
+    string sFunc = "Search";
+    NWNX_PushArgumentString(NWNX_Regex, sFunc, regex);
+    NWNX_PushArgumentString(NWNX_Regex, sFunc, str);
+    NWNX_CallFunction(NWNX_Regex, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Regex, sFunc);
+}
+
+string NWNX_Regex_Replace(string str, string regex, string replace="", int firstOnly=0)
+{
+    string sFunc = "Replace";
+    NWNX_PushArgumentInt(NWNX_Regex, sFunc, firstOnly);
+    NWNX_PushArgumentString(NWNX_Regex, sFunc, replace);
+    NWNX_PushArgumentString(NWNX_Regex, sFunc, regex);
+    NWNX_PushArgumentString(NWNX_Regex, sFunc, str);
+    NWNX_CallFunction(NWNX_Regex, sFunc);
+    return NWNX_GetReturnValueString(NWNX_Regex, sFunc);
+}

--- a/Plugins/Regex/NWScript/nwnx_regex_t.nss
+++ b/Plugins/Regex/NWScript/nwnx_regex_t.nss
@@ -1,0 +1,35 @@
+#include "nwnx_regex"
+
+void report(string func, int bSuccess)
+{
+    if (bSuccess)
+        WriteTimestampedLogEntry("NWNX_Regex: " + func + "() success");
+    else
+        WriteTimestampedLogEntry("NWNX_Regex: " + func + "() failed");
+}
+
+void main()
+{
+    WriteTimestampedLogEntry("NWNX_Regex unit test begin..");
+
+    string str = "This string has a <cDDD>color</c> code.";
+    int regex_search = NWNX_Regex_Search(str,"<c.+?(?=>)>");
+    report("RegexSearch", regex_search == 1);
+    str = "This string has \na new line.";
+    regex_search = NWNX_Regex_Search(str,"!!n");
+    report("RegexSearch", regex_search == 1);
+    str = "This string does not have any non-ASCII characters.";
+    regex_search = NWNX_Regex_Search(str,"[^!!x01-!!x7E]");
+    report("RegexSearch", regex_search == 0);
+
+
+    string sRedString = StringToRGBString("stripped colors.", STRING_COLOR_RED);
+    str = "This is a <cfff>test</c> of "+sRedString;
+    string strip_colors = NWNX_Regex_Replace(str,"<c.+?(?=>)>|</c>");
+    report("RegexReplace", strip_colors == "This is a test of stripped colors.");
+    str = "This is a “test” of stripping to just ascii printable and new lines.";
+    string strip_non_ascii = NWNX_Regex_Replace(str,"[^!!n!!r!!x20-!!x7E]");
+    report("RegexReplace", strip_non_ascii == "This is a test of stripping to just ascii printable and new lines.");
+
+    WriteTimestampedLogEntry("NWNX_Regex unit test end.");
+}

--- a/Plugins/Regex/NWScript/nwnx_regex_t.nss
+++ b/Plugins/Regex/NWScript/nwnx_regex_t.nss
@@ -1,4 +1,5 @@
 #include "nwnx_regex"
+#include "x3_inc_string"
 
 void report(string func, int bSuccess)
 {

--- a/Plugins/Regex/NWScript/nwnx_regex_t.nss
+++ b/Plugins/Regex/NWScript/nwnx_regex_t.nss
@@ -17,10 +17,10 @@ void main()
     int regex_search = NWNX_Regex_Search(str,"<c.+?(?=>)>");
     report("RegexSearch", regex_search == 1);
     str = "This string has \na new line.";
-    regex_search = NWNX_Regex_Search(str,"!!n");
+    regex_search = NWNX_Regex_Search(str,"\\n");
     report("RegexSearch", regex_search == 1);
     str = "This string does not have any non-ASCII characters.";
-    regex_search = NWNX_Regex_Search(str,"[^!!x01-!!x7E]");
+    regex_search = NWNX_Regex_Search(str,"[^\\x01-\\x7E]");
     report("RegexSearch", regex_search == 0);
 
 
@@ -29,7 +29,7 @@ void main()
     string strip_colors = NWNX_Regex_Replace(str,"<c.+?(?=>)>|</c>");
     report("RegexReplace", strip_colors == "This is a test of stripped colors.");
     str = "This is a “test” of stripping to just ascii printable and new lines.";
-    string strip_non_ascii = NWNX_Regex_Replace(str,"[^!!n!!r!!x20-!!x7E]");
+    string strip_non_ascii = NWNX_Regex_Replace(str,"[^\\n\\r\\x20-\\x7E]");
     report("RegexReplace", strip_non_ascii == "This is a test of stripping to just ascii printable and new lines.");
 
     WriteTimestampedLogEntry("NWNX_Regex unit test end.");

--- a/Plugins/Regex/Regex.cpp
+++ b/Plugins/Regex/Regex.cpp
@@ -36,7 +36,6 @@ namespace Regex {
 Regex::Regex(const Plugin::CreateParams& params)
     : Plugin(params)
 {
-    m_backslashSubstring = GetServices()->m_config->Get<std::string>("BACKSLASH_SUBSTRING", "!!");
 
 #define REGISTER(func) \
     GetServices()->m_events->RegisterEvent(#func, std::bind(&Regex::func, this, std::placeholders::_1))
@@ -52,24 +51,13 @@ Regex::~Regex()
 {
 }
 
-std::regex Regex::ConvertToBackslash(std::string beforeRegex)
-{
-    // First replace all double exclamation marks in the string to backslashes
-    std::regex backslashes(m_backslashSubstring);
-    std::string clean_regex = std::regex_replace(beforeRegex, backslashes, "\\");
-
-    std::regex afterRegex(clean_regex);
-
-    return afterRegex;
-}
-
 ArgumentStack Regex::Search(ArgumentStack&& args)
 {
     ArgumentStack stack;
     const auto str = Services::Events::ExtractArgument<std::string>(args);
     const auto regex = Services::Events::ExtractArgument<std::string>(args);
 
-    const auto rgx = ConvertToBackslash(regex);
+    std::regex rgx(regex);
     const auto retVal = std::regex_search(str, rgx);
 
     Services::Events::InsertArgument(stack, retVal);
@@ -84,7 +72,7 @@ ArgumentStack Regex::Replace(ArgumentStack&& args)
     const auto rpl = Services::Events::ExtractArgument<std::string>(args);
     const auto firstOnly = Services::Events::ExtractArgument<int32_t>(args);
 
-    const auto rgx = ConvertToBackslash(regex);
+    std::regex rgx(regex);
     std::string retVal;
     if (firstOnly)
         retVal = std::regex_replace(str, rgx, rpl, std::regex_constants::format_first_only);

--- a/Plugins/Regex/Regex.cpp
+++ b/Plugins/Regex/Regex.cpp
@@ -1,0 +1,98 @@
+#include "Regex.hpp"
+
+#include "Services/Config/Config.hpp"
+#include "ViewPtr.hpp"
+
+#include <string>
+#include <stdio.h>
+#include <regex>
+
+using namespace NWNXLib;
+using namespace NWNXLib::Services;
+
+static ViewPtr<Regex::Regex> g_plugin;
+
+NWNX_PLUGIN_ENTRY Plugin::Info* PluginInfo()
+{
+    return new Plugin::Info
+    {
+        "Regex",
+        "Regular expression functions",
+        "orth",
+        "plenarius@gmail.com",
+        1,
+        true
+    };
+}
+
+NWNX_PLUGIN_ENTRY Plugin* PluginLoad(Plugin::CreateParams params)
+{
+    g_plugin = new Regex::Regex(params);
+    return g_plugin;
+}
+
+namespace Regex {
+
+Regex::Regex(const Plugin::CreateParams& params)
+    : Plugin(params)
+{
+    m_backslashSubstring = GetServices()->m_config->Get<std::string>("BACKSLASH_SUBSTRING", "!!");
+
+#define REGISTER(func) \
+    GetServices()->m_events->RegisterEvent(#func, std::bind(&Regex::func, this, std::placeholders::_1))
+
+    REGISTER(Search);
+    REGISTER(Replace);
+
+#undef REGISTER
+
+}
+
+Regex::~Regex()
+{
+}
+
+std::regex Regex::ConvertToBackslash(std::string beforeRegex)
+{
+    // First replace all double exclamation marks in the string to backslashes
+    std::regex backslashes(m_backslashSubstring);
+    std::string clean_regex = std::regex_replace(beforeRegex, backslashes, "\\");
+
+    std::regex afterRegex(clean_regex);
+
+    return afterRegex;
+}
+
+ArgumentStack Regex::Search(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    const auto str = Services::Events::ExtractArgument<std::string>(args);
+    const auto regex = Services::Events::ExtractArgument<std::string>(args);
+
+    const auto rgx = ConvertToBackslash(regex);
+    const auto retVal = std::regex_search(str, rgx);
+
+    Services::Events::InsertArgument(stack, retVal);
+    return stack;
+}
+
+ArgumentStack Regex::Replace(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    const auto str = Services::Events::ExtractArgument<std::string>(args);
+    const auto regex = Services::Events::ExtractArgument<std::string>(args);
+    const auto rpl = Services::Events::ExtractArgument<std::string>(args);
+    const auto firstOnly = Services::Events::ExtractArgument<int32_t>(args);
+
+    const auto rgx = ConvertToBackslash(regex);
+    std::string retVal;
+    if (firstOnly)
+        retVal = std::regex_replace(str, rgx, rpl, std::regex_constants::format_first_only);
+    else
+        retVal = std::regex_replace(str, rgx, rpl);
+
+    Services::Events::InsertArgument(stack, retVal);
+    return stack;
+}
+
+}

--- a/Plugins/Regex/Regex.hpp
+++ b/Plugins/Regex/Regex.hpp
@@ -17,8 +17,6 @@ public:
     virtual ~Regex();
 
 private:
-    std::string m_backslashSubstring;
-    std::regex ConvertToBackslash(std::string beforeRegex);
     ArgumentStack Search(ArgumentStack&& args);
     ArgumentStack Replace(ArgumentStack&& args);
 };

--- a/Plugins/Regex/Regex.hpp
+++ b/Plugins/Regex/Regex.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Plugin.hpp"
+#include "Services/Events/Events.hpp"
+#include "API/Types.hpp"
+
+#include <regex>
+
+using ArgumentStack = NWNXLib::Services::Events::ArgumentStack;
+
+namespace Regex {
+
+class Regex : public NWNXLib::Plugin
+{
+public:
+    Regex(const Plugin::CreateParams& params);
+    virtual ~Regex();
+
+private:
+    std::string m_backslashSubstring;
+    std::regex ConvertToBackslash(std::string beforeRegex);
+    ArgumentStack Search(ArgumentStack&& args);
+    ArgumentStack Replace(ArgumentStack&& args);
+};
+
+}


### PR DESCRIPTION
Provides `Search()` and `Replace() `

Due to the complications with using backslashes in nwscript, a configurable substring to use instead of backslashes is available. The default is a double exclamation point.