### PR TITLE
[Deprecated] added NWNX_ON_ATTACK event and functions to modify damage dealt

### DIFF
--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -81,7 +81,7 @@ Events::Events(const Plugin::CreateParams& params)
 
     m_associateEvents   = std::make_unique<AssociateEvents>(GetServices()->m_hooks);
     m_clientEvents      = std::make_unique<ClientEvents>(GetServices()->m_hooks);
-    m_combatEvents      = std::make_unique<CombatEvents>(GetServices()->m_hooks, GetServices()->m_events);
+    m_combatEvents      = std::make_unique<CombatEvents>(GetServices()->m_hooks);
     m_dmActionEvents    = std::make_unique<DMActionEvents>(GetServices()->m_hooks);
     m_examineEvents     = std::make_unique<ExamineEvents>(GetServices()->m_hooks);
     m_itemEvents        = std::make_unique<ItemEvents>(GetServices()->m_hooks);

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -81,7 +81,7 @@ Events::Events(const Plugin::CreateParams& params)
 
     m_associateEvents   = std::make_unique<AssociateEvents>(GetServices()->m_hooks);
     m_clientEvents      = std::make_unique<ClientEvents>(GetServices()->m_hooks);
-    m_combatEvents      = std::make_unique<CombatEvents>(GetServices()->m_hooks);
+    m_combatEvents      = std::make_unique<CombatEvents>(GetServices()->m_hooks, GetServices()->m_events);
     m_dmActionEvents    = std::make_unique<DMActionEvents>(GetServices()->m_hooks);
     m_examineEvents     = std::make_unique<ExamineEvents>(GetServices()->m_hooks);
     m_itemEvents        = std::make_unique<ItemEvents>(GetServices()->m_hooks);

--- a/Plugins/Events/Events/CombatEvents.cpp
+++ b/Plugins/Events/Events/CombatEvents.cpp
@@ -44,7 +44,7 @@ CombatEvents::CombatEvents(ViewPtr<HooksProxy> hooker, ViewPtr<EventsProxy> eve)
             API::Functions::CNWSCombatRound__SetCurrentAttack,
             int32_t,
             API::CNWSCombatRound*,
-            unsigned char>
+            uint8_t>
             (
                 &AttackHook
             );
@@ -66,14 +66,14 @@ void CombatEvents::StartCombatRoundHook(
 void CombatEvents::AttackHook(
     Hooks::CallType type,
     API::CNWSCombatRound* thisPtr,
-    unsigned char attackNumber)
+    uint8_t attackNumber)
 {
     if ( type == Hooks::CallType::AFTER_ORIGINAL )
     {
         // SetCurrentAttack is 1-based, GetAttack is 0-based
         CNWSCombatAttackData* combatAttackData = g_combatEvents->m_combatAttackData = thisPtr->GetAttack(attackNumber - 1);
         Events::PushEventData("TARGET_OBJECT_ID", Utils::ObjectIDToString(thisPtr->m_pBaseCreature->m_oidAttackTarget));
-        Events::PushEventData("ATTACK_NUMBER", std::to_string(static_cast<int>(attackNumber)));
+        Events::PushEventData("ATTACK_NUMBER", std::to_string(attackNumber));
         for ( int i = 0; i < 13; i++ )
         {
             int16_t nDamage = combatAttackData->m_nDamage[i];

--- a/Plugins/Events/Events/CombatEvents.cpp
+++ b/Plugins/Events/Events/CombatEvents.cpp
@@ -8,16 +8,27 @@
 #include "Utils.hpp"
 #include "ViewPtr.hpp"
 
+static NWNXLib::ViewPtr<Events::CombatEvents> g_combatEvents;
+
 namespace Events {
 
 using namespace NWNXLib;
 using namespace NWNXLib::API;
 using namespace NWNXLib::Services;
 
-NWNXLib::ViewPtr<NWNXLib::Hooking::FunctionHook> CombatEvents::m_hook;
-
-CombatEvents::CombatEvents(ViewPtr<HooksProxy> hooker)
+CombatEvents::CombatEvents(ViewPtr<HooksProxy> hooker, ViewPtr<EventsProxy> eve)
 {
+    if (g_combatEvents == nullptr)
+        g_combatEvents = this;
+
+#define REGISTER(func) \
+    eve->RegisterEvent(#func, std::bind(&CombatEvents::func, this, std::placeholders::_1))
+
+    REGISTER(AddAttackDamage);
+    REGISTER(SetAttackDamage);
+
+#undef REGISTER
+
     Events::InitOnFirstSubscribe("NWNX_ON_START_COMBAT_ROUND_.*", [hooker]() {
         hooker->RequestSharedHook<
             API::Functions::CNWSCombatRound__StartCombatRound,
@@ -26,6 +37,16 @@ CombatEvents::CombatEvents(ViewPtr<HooksProxy> hooker)
             uint32_t>
             (
                 &StartCombatRoundHook
+            );
+    });
+    Events::InitOnFirstSubscribe("NWNX_ON_ATTACK", [hooker]() {
+        hooker->RequestSharedHook<
+            API::Functions::CNWSCombatRound__SetCurrentAttack,
+            int32_t,
+            API::CNWSCombatRound*,
+            unsigned char>
+            (
+                &AttackHook
             );
     });
 }
@@ -40,6 +61,58 @@ void CombatEvents::StartCombatRoundHook(
 
     Events::PushEventData("TARGET_OBJECT_ID", Utils::ObjectIDToString(oidTarget));
     Events::SignalEvent(before ? "NWNX_ON_START_COMBAT_ROUND_BEFORE" : "NWNX_ON_START_COMBAT_ROUND_AFTER" , thisPtr->m_pBaseCreature->m_idSelf);
+}
+
+void CombatEvents::AttackHook(
+    Hooks::CallType type,
+    API::CNWSCombatRound* thisPtr,
+    unsigned char attackNumber)
+{
+    if ( type == Hooks::CallType::AFTER_ORIGINAL )
+    {
+        // SetCurrentAttack is 1-based, GetAttack is 0-based
+        CNWSCombatAttackData* combatAttackData = g_combatEvents->m_combatAttackData = thisPtr->GetAttack(attackNumber - 1);
+        Events::PushEventData("TARGET_OBJECT_ID", Utils::ObjectIDToString(thisPtr->m_pBaseCreature->m_oidAttackTarget));
+        Events::PushEventData("ATTACK_NUMBER", std::to_string(static_cast<int>(attackNumber)));
+        for ( int i = 0; i < 13; i++ )
+        {
+            int16_t nDamage = combatAttackData->m_nDamage[i];
+            Events::PushEventData("ATTACK_DAMAGE_" + std::to_string(i), std::to_string(nDamage));
+        }
+        Events::PushEventData("ATTACK_RESULT", std::to_string(combatAttackData->m_nAttackResult));
+        Events::PushEventData("IS_SNEAK_ATTACK", std::to_string(combatAttackData->m_bSneakAttack || combatAttackData->m_bDeathAttack));
+        Events::PushEventData("IS_OFFHAND_ATTACK", std::to_string(combatAttackData->m_nWeaponAttackType == 2));
+        Events::SignalEvent("NWNX_ON_ATTACK", thisPtr->m_pBaseCreature->m_idSelf);
+        g_combatEvents->m_combatAttackData = nullptr;
+    }
+}
+
+ArgumentStack CombatEvents::AddAttackDamage(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+
+    if ( g_combatEvents->m_combatAttackData )
+    {
+        uint16_t damageType = Services::Events::ExtractArgument<int32_t>(args);
+        int32_t damageAmount = Services::Events::ExtractArgument<int32_t>(args);
+        g_combatEvents->m_combatAttackData->AddDamage(damageType, damageAmount);
+    }
+
+    return stack;
+}
+
+ArgumentStack CombatEvents::SetAttackDamage(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+
+    if ( g_combatEvents->m_combatAttackData )
+    {
+        uint16_t damageType = Services::Events::ExtractArgument<int32_t>(args);
+        int32_t damageAmount = Services::Events::ExtractArgument<int32_t>(args);
+        g_combatEvents->m_combatAttackData->SetDamage(damageType, damageAmount);
+    }
+
+    return stack;
 }
 
 }

--- a/Plugins/Events/Events/CombatEvents.cpp
+++ b/Plugins/Events/Events/CombatEvents.cpp
@@ -8,27 +8,14 @@
 #include "Utils.hpp"
 #include "ViewPtr.hpp"
 
-static NWNXLib::ViewPtr<Events::CombatEvents> g_combatEvents;
-
 namespace Events {
 
 using namespace NWNXLib;
 using namespace NWNXLib::API;
 using namespace NWNXLib::Services;
 
-CombatEvents::CombatEvents(ViewPtr<HooksProxy> hooker, ViewPtr<EventsProxy> eve)
+CombatEvents::CombatEvents(ViewPtr<HooksProxy> hooker)
 {
-    if (g_combatEvents == nullptr)
-        g_combatEvents = this;
-
-#define REGISTER(func) \
-    eve->RegisterEvent(#func, std::bind(&CombatEvents::func, this, std::placeholders::_1))
-
-    REGISTER(AddAttackDamage);
-    REGISTER(SetAttackDamage);
-
-#undef REGISTER
-
     Events::InitOnFirstSubscribe("NWNX_ON_START_COMBAT_ROUND_.*", [hooker]() {
         hooker->RequestSharedHook<
             API::Functions::CNWSCombatRound__StartCombatRound,
@@ -69,48 +56,23 @@ void CombatEvents::AttackHook(
     uint8_t attackNumber)
 {
     const bool before = type == Hooks::CallType::BEFORE_ORIGINAL;
+    std::string sEventResult;
+
     // SetCurrentAttack is 1-based, GetAttack is 0-based
-    CNWSCombatAttackData* combatAttackData = g_combatEvents->m_combatAttackData = thisPtr->GetAttack(attackNumber - 1);
+    CNWSCombatAttackData* combatAttackData = thisPtr->GetAttack(attackNumber - 1);
     Events::PushEventData("TARGET_OBJECT_ID", Utils::ObjectIDToString(thisPtr->m_pBaseCreature->m_oidAttackTarget));
     Events::PushEventData("ATTACK_NUMBER", std::to_string(attackNumber));
-    for ( int i = 0; i < 13; i++ )
-    {
-        int16_t nDamage = combatAttackData->m_nDamage[i];
-        Events::PushEventData("ATTACK_DAMAGE_" + std::to_string(i), std::to_string(nDamage));
-    }
+    Events::PushEventData("ATTACK_BASE_DAMAGE", std::to_string(combatAttackData->m_nDamage[12]));
     Events::PushEventData("ATTACK_RESULT", std::to_string(combatAttackData->m_nAttackResult));
     Events::PushEventData("IS_SNEAK_ATTACK", std::to_string(combatAttackData->m_bSneakAttack || combatAttackData->m_bDeathAttack));
     Events::PushEventData("IS_OFFHAND_ATTACK", std::to_string(combatAttackData->m_nWeaponAttackType == 2));
-    Events::SignalEvent(before ? "NWNX_ON_ATTACK_BEFORE" : "NWNX_ON_ATTACK_AFTER", thisPtr->m_pBaseCreature->m_idSelf);
-    g_combatEvents->m_combatAttackData = nullptr;
-}
 
-ArgumentStack CombatEvents::AddAttackDamage(ArgumentStack&& args)
-{
-    ArgumentStack stack;
-
-    if ( g_combatEvents->m_combatAttackData )
+    Events::SignalEvent(before ? "NWNX_ON_ATTACK_BEFORE" : "NWNX_ON_ATTACK_AFTER", thisPtr->m_pBaseCreature->m_idSelf, &sEventResult);
+    if ( !sEventResult.empty() )
     {
-        uint16_t damageType = Services::Events::ExtractArgument<int32_t>(args);
-        int32_t damageAmount = Services::Events::ExtractArgument<int32_t>(args);
-        g_combatEvents->m_combatAttackData->AddDamage(damageType, damageAmount);
+        int32_t result = stoi(sEventResult);
+        combatAttackData->SetBaseDamage(result);
     }
-
-    return stack;
-}
-
-ArgumentStack CombatEvents::SetAttackDamage(ArgumentStack&& args)
-{
-    ArgumentStack stack;
-
-    if ( g_combatEvents->m_combatAttackData )
-    {
-        uint16_t damageType = Services::Events::ExtractArgument<int32_t>(args);
-        int32_t damageAmount = Services::Events::ExtractArgument<int32_t>(args);
-        g_combatEvents->m_combatAttackData->SetDamage(damageType, damageAmount);
-    }
-
-    return stack;
 }
 
 }

--- a/Plugins/Events/Events/CombatEvents.hpp
+++ b/Plugins/Events/Events/CombatEvents.hpp
@@ -4,14 +4,17 @@
 #include "API/Types.hpp"
 #include "Common.hpp"
 #include "Services/Hooks/Hooks.hpp"
+#include "Services/Events/Events.hpp"
 #include "ViewPtr.hpp"
 
 namespace Events {
 
+using ArgumentStack = NWNXLib::Services::Events::ArgumentStack;
+
 class CombatEvents
 {
 public:
-    CombatEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
+    CombatEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker, NWNXLib::ViewPtr<NWNXLib::Services::EventsProxy> eve);
 
 private:
     static void StartCombatRoundHook
@@ -20,7 +23,17 @@ private:
         NWNXLib::API::CNWSCombatRound*,
         uint32_t
     );
-    static NWNXLib::ViewPtr<NWNXLib::Hooking::FunctionHook> m_hook;
+    static void AttackHook
+    (
+        NWNXLib::Services::Hooks::CallType,
+        NWNXLib::API::CNWSCombatRound*,
+        unsigned char
+    );
+
+    ArgumentStack AddAttackDamage(ArgumentStack&& args);
+    ArgumentStack SetAttackDamage(ArgumentStack&& args);
+    // current attack data (used with ON_ATTACK hook)
+    NWNXLib::API::CNWSCombatAttackData* m_combatAttackData;
 };
 
 }

--- a/Plugins/Events/Events/CombatEvents.hpp
+++ b/Plugins/Events/Events/CombatEvents.hpp
@@ -27,7 +27,7 @@ private:
     (
         NWNXLib::Services::Hooks::CallType,
         NWNXLib::API::CNWSCombatRound*,
-        unsigned char
+        uint8_t
     );
 
     ArgumentStack AddAttackDamage(ArgumentStack&& args);

--- a/Plugins/Events/Events/CombatEvents.hpp
+++ b/Plugins/Events/Events/CombatEvents.hpp
@@ -14,7 +14,7 @@ using ArgumentStack = NWNXLib::Services::Events::ArgumentStack;
 class CombatEvents
 {
 public:
-    CombatEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker, NWNXLib::ViewPtr<NWNXLib::Services::EventsProxy> eve);
+    CombatEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
 
 private:
     static void StartCombatRoundHook
@@ -29,11 +29,6 @@ private:
         NWNXLib::API::CNWSCombatRound*,
         uint8_t
     );
-
-    ArgumentStack AddAttackDamage(ArgumentStack&& args);
-    ArgumentStack SetAttackDamage(ArgumentStack&& args);
-    // current attack data (used with ON_ATTACK hook)
-    NWNXLib::API::CNWSCombatAttackData* m_combatAttackData;
 };
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Events = "NWNX_Events";
+
 ////////////////////////////////////////////////////////////////////////////////
 /* The following events are exposed by this plugin:
 ////////////////////////////////////////////////////////////////////////////////
@@ -316,6 +318,20 @@
     Event data:
         Variable Name           Type        Notes
         TARGET_OBJECT_ID        object      Convert to object with NWNX_Object_StringToObject()
+////////////////////////////////////////////////////////////////////////////////
+    NWNX_ON_ATTACK
+
+    Usage:
+        OBJECT_SELF = The creature making the attack
+
+    Event data:
+        Variable Name           Type        Notes
+        TARGET_OBJECT_ID        object      Convert to object with NWNX_Object_StringToObject()
+        ATTACK_NUMBER           int         Number of attack in current combat round (1st, 2nd, 3rd, ...)
+        ATTACK_DAMAGE_*         int         amount of damage dealt by type (*=0..12)
+        ATTACK_RESULT           int         1=hit, 3=critical, 4=miss, 8=concealed
+        IS_SNEAK_ATTACK         int         whether attack is a sneak (or death) attack
+        IS_OFFHAND_ATTACK       int         whether attack is made with off-hand weapon
 ////////////////////////////////////////////////////////////////////////////////
     NWNX_ON_CAST_SPELL_BEFORE
     NWNX_ON_CAST_SPELL_AFTER
@@ -688,4 +704,33 @@ string NWNX_Events_GetCurrentEvent()
 {
     NWNX_CallFunction("NWNX_Events", "GET_CURRENT_EVENT");
     return NWNX_GetReturnValueString("NWNX_Events", "GET_CURRENT_EVENT");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Functions only available while processing certain events
+////////////////////////////////////////////////////////////////////////////////
+
+// Increase damage by given amount
+void NWNX_Events_OnAttack_AddDamage(int damageAmount, int damageType = DAMAGE_TYPE_BASE_WEAPON);
+// Set damage of particular type to given amount
+void NWNX_Events_OnAttack_SetDamage(int damageAmount, int damageType);
+
+void NWNX_Events_OnAttack_AddDamage(int damageAmount, int damageType)
+{
+    string sFunc = "AddAttackDamage";
+
+    NWNX_PushArgumentInt(NWNX_Events, sFunc, damageAmount);
+    NWNX_PushArgumentInt(NWNX_Events, sFunc, damageType);
+
+    NWNX_CallFunction(NWNX_Events, sFunc);
+}
+
+void NWNX_Events_OnAttack_SetDamage(int damageAmount, int damageType)
+{
+    string sFunc = "SetAttackDamage";
+
+    NWNX_PushArgumentInt(NWNX_Events, sFunc, damageAmount);
+    NWNX_PushArgumentInt(NWNX_Events, sFunc, damageType);
+
+    NWNX_CallFunction(NWNX_Events, sFunc);
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -653,6 +653,7 @@ void NWNX_Events_SkipEvent();
 // - Listen/Spot Detection events -> "1" or "0"
 // - OnClientConnectBefore -> Reason for disconnect if skipped
 // - Ammo Reload event -> Forced ammunition returned
+// - OnAttack event -> Set base damage dealt
 void NWNX_Events_SetEventResult(string data);
 
 // Returns the current event name
@@ -705,33 +706,4 @@ string NWNX_Events_GetCurrentEvent()
 {
     NWNX_CallFunction("NWNX_Events", "GET_CURRENT_EVENT");
     return NWNX_GetReturnValueString("NWNX_Events", "GET_CURRENT_EVENT");
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Functions only available while processing certain events
-////////////////////////////////////////////////////////////////////////////////
-
-// Increase damage by given amount
-void NWNX_Events_OnAttack_AddDamage(int damageAmount, int damageType = DAMAGE_TYPE_BASE_WEAPON);
-// Set damage of particular type to given amount
-void NWNX_Events_OnAttack_SetDamage(int damageAmount, int damageType);
-
-void NWNX_Events_OnAttack_AddDamage(int damageAmount, int damageType)
-{
-    string sFunc = "AddAttackDamage";
-
-    NWNX_PushArgumentInt(NWNX_Events, sFunc, damageAmount);
-    NWNX_PushArgumentInt(NWNX_Events, sFunc, damageType);
-
-    NWNX_CallFunction(NWNX_Events, sFunc);
-}
-
-void NWNX_Events_OnAttack_SetDamage(int damageAmount, int damageType)
-{
-    string sFunc = "SetAttackDamage";
-
-    NWNX_PushArgumentInt(NWNX_Events, sFunc, damageAmount);
-    NWNX_PushArgumentInt(NWNX_Events, sFunc, damageType);
-
-    NWNX_CallFunction(NWNX_Events, sFunc);
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -319,7 +319,8 @@ const string NWNX_Events = "NWNX_Events";
         Variable Name           Type        Notes
         TARGET_OBJECT_ID        object      Convert to object with NWNX_Object_StringToObject()
 ////////////////////////////////////////////////////////////////////////////////
-    NWNX_ON_ATTACK
+    NWNX_ON_ATTACK_BEFORE
+    NWNX_ON_ATTACK_AFTER
 
     Usage:
         OBJECT_SELF = The creature making the attack


### PR DESCRIPTION
Example usage:

```
#include "nwnx_events"
...
NWNX_Events_SubscribeEvent("NWNX_ON_ATTACK", "on_attack");
```
triggering
```
#include "nwnx_events"
#include "nwnx_object"

void main()
{
    object oAttacker = OBJECT_SELF;
    object oTarget = NWNX_Object_StringToObject(NWNX_Events_GetEventData("TARGET_OBJECT_ID"));
    string sAttackNr = NWNX_Events_GetEventData("ATTACK_NUMBER");
    string sDamage = NWNX_Events_GetEventData("ATTACK_DAMAGE_0");
    int nDamType;
    for ( nDamType = 1; nDamType < 13; nDamType++ )
    {
        sDamage += "/" + NWNX_Events_GetEventData("ATTACK_DAMAGE_" + IntToString(nDamType));
    }
    string sSneak = NWNX_Events_GetEventData("IS_SNEAK_ATTACK");
    string sOffhand = NWNX_Events_GetEventData("IS_OFFHAND_ATTACK");
    string sMessage = "Original damage = " + sDamage + " (Sneak=" + sSneak + ", Offhand=" + sOffhand + ")";

    SendMessageToPC(oAttacker, "You attack " + GetName(oTarget) + " (#" + sAttackNr + ").");
    SendMessageToPC(oAttacker, sMessage);
    SendMessageToPC(oTarget, GetName(oAttacker) + " attacks you (#" + sAttackNr + ").");
    SendMessageToPC(oTarget, sMessage);

    // increase damage if no sneak attack damage was dealt
    if ( sSneak == "0" && GetHasFeat(FEAT_SNEAK_ATTACK, oAttacker) )
        NWNX_Events_OnAttack_AddDamage(2);
}
```