### PR TITLE
ItemProperty: set bExpose to 1 when packing

### DIFF
--- a/Plugins/ItemProperty/ItemProperty.cpp
+++ b/Plugins/ItemProperty/ItemProperty.cpp
@@ -79,6 +79,7 @@ ArgumentStack ItemProperty::PackIP(ArgumentStack&& args)
 
     ip->SetNumIntegersInitializeToNegativeOne(9);
     ip->m_nID = ipId;
+    ip->m_bExpose = 1;
     ip->m_nType = API::Constants::EffectTrueType::ItemProperty;
     ip->m_nSubType = API::Constants::EffectDurationType::Permanent;
     ip->m_oidCreator = creator;


### PR DESCRIPTION
Fixes #412