### PR TITLE
Events: add BarterEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Core: Allow changing default plugin state from 'load all' to 'skip all' with the following environment variable: `NWNX_CORE_SKIP_ALL=y`. Use `NWNX_PLUGIN_SKIP=n` to enable specific plugins in this case.
 - Core: Allow passing engine structures to nwnx (Effect/Itemproperty)
 - Events: New events: SkillEvents, MapEvents, EffectEvents, QuickChatEvents, InventoryEvents
-- Events: The following events are now skippable: FeatEvents, ItemEvents, HealersKitEvents, CombatModeEvents, PartyEvents, SkillEvents, MapEvents, PolymorphEvents, DMActionEvents, ClientConnectEvents, SpellEvents, QuickChatEvents, InventoryEvents
+- Events: The following events are now skippable: FeatEvents, ItemEvents, HealersKitEvents, CombatModeEvents, PartyEvents, SkillEvents, MapEvents, PolymorphEvents, DMActionEvents, ClientConnectEvents, SpellEvents, QuickChatEvents, InventoryEvents, BarterEvents (START only)
 - Events: You can now get the current event name with a nwscript function
 - Events: Added On{Listen/Spot}Detection events to StealthEvents
 - Events: Added On{Un}Polymorph events as PolymorphEvents
@@ -24,6 +24,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Events: Added {Set|Clear}MemorizedSpellSlot events to SpellEvents
 - Events: Added AmmoReload events that are used when the engine is looking for ammunition to reload
 - Events: Added Run{Un}Equip events to ItemEvents
+- Events: Added Barter Start/End events
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite
 - Tweaks: DisableQuickSave

--- a/Plugins/Events/CMakeLists.txt
+++ b/Plugins/Events/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_plugin(Events
     "Events.cpp"
     "Events/AssociateEvents.cpp"
+    "Events/BarterEvents.cpp"
     "Events/ClientEvents.cpp"
     "Events/CombatEvents.cpp"
     "Events/DMActionEvents.cpp"

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -4,6 +4,7 @@
 #include "API/Globals.hpp"
 #include "API/Version.hpp"
 #include "Events/AssociateEvents.hpp"
+#include "Events/BarterEvents.hpp"
 #include "Events/ClientEvents.hpp"
 #include "Events/CombatEvents.hpp"
 #include "Events/DMActionEvents.hpp"
@@ -80,6 +81,7 @@ Events::Events(const Plugin::CreateParams& params)
         });
 
     m_associateEvents   = std::make_unique<AssociateEvents>(GetServices()->m_hooks);
+    m_barterEvents      = std::make_unique<BarterEvents>(GetServices()->m_hooks);
     m_clientEvents      = std::make_unique<ClientEvents>(GetServices()->m_hooks);
     m_combatEvents      = std::make_unique<CombatEvents>(GetServices()->m_hooks);
     m_dmActionEvents    = std::make_unique<DMActionEvents>(GetServices()->m_hooks);

--- a/Plugins/Events/Events.hpp
+++ b/Plugins/Events/Events.hpp
@@ -11,6 +11,7 @@
 namespace Events {
 
 class AssociateEvents;
+class BarterEvents;
 class ClientEvents;
 class CombatEvents;
 class DMActionEvents;
@@ -86,6 +87,7 @@ private:
     std::unordered_map<std::string, std::function<void(void)>> m_initList;
 
     std::unique_ptr<AssociateEvents> m_associateEvents;
+    std::unique_ptr<BarterEvents> m_barterEvents;
     std::unique_ptr<ClientEvents> m_clientEvents;
     std::unique_ptr<CombatEvents> m_combatEvents;
     std::unique_ptr<DMActionEvents> m_dmActionEvents;

--- a/Plugins/Events/Events/BarterEvents.cpp
+++ b/Plugins/Events/Events/BarterEvents.cpp
@@ -1,0 +1,173 @@
+#include "Events/BarterEvents.hpp"
+#include "API/CAppManager.hpp"
+#include "API/CItemRepository.hpp"
+#include "API/CServerExoApp.hpp"
+#include "API/CExoLinkedListInternal.hpp"
+#include "API/CExoLinkedListNode.hpp"
+#include "API/CNWSPlayer.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/CNWSBarter.hpp"
+#include "API/Constants.hpp"
+#include "API/Functions.hpp"
+#include "API/Globals.hpp"
+#include "Events.hpp"
+#include "Utils.hpp"
+
+namespace Events {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+using namespace NWNXLib::Services;
+
+static NWNXLib::Hooking::FunctionHook* m_HandlePlayerToServerBarter_StartBarterHook;
+
+static Types::ObjectID m_initiatorOid;
+static Types::ObjectID m_targetOid;
+
+BarterEvents::BarterEvents(ViewPtr<Services::HooksProxy> hooker)
+{
+    Events::InitOnFirstSubscribe("NWNX_ON_BARTER_START_.*", [hooker]() {
+        hooker->RequestExclusiveHook<Functions::CNWSMessage__HandlePlayerToServerBarter_StartBarter, int32_t,
+                CNWSMessage*, CNWSPlayer*>(&HandlePlayerToServerBarter_StartBarterHook);
+        m_HandlePlayerToServerBarter_StartBarterHook = hooker->FindHookByAddress(API::Functions::CNWSMessage__HandlePlayerToServerBarter_StartBarter);
+    });
+    Events::InitOnFirstSubscribe("NWNX_ON_BARTER_END_.*", [hooker]() {
+        hooker->RequestSharedHook<Functions::CNWSBarter__SetListAccepted, int32_t,
+                CNWSBarter*, int32_t>(&SetListAcceptedHook);
+        hooker->RequestSharedHook<Functions::CNWSMessage__SendServerToPlayerBarterCloseBarter, int32_t,
+                CNWSMessage*, uint32_t, uint32_t, int32_t>(&SendServerToPlayerBarterCloseBarterHook);
+    });
+}
+
+int32_t BarterEvents::HandlePlayerToServerBarter_StartBarterHook(
+        CNWSMessage* pMessage,
+        CNWSPlayer* pPlayer)
+{
+    int32_t retVal;
+
+    Types::ObjectID oidPlayer = pPlayer->m_oidNWSObject;
+    Types::ObjectID targetId = Utils::PeekMessage<Types::ObjectID>(pMessage, 0) & 0x7FFFFFFF;
+
+    auto PushAndSignal = [&](std::string ev) -> bool {
+        Events::PushEventData("BARTER_TARGET", Utils::ObjectIDToString(targetId));
+        return Events::SignalEvent(ev, oidPlayer);
+    };
+
+    if (PushAndSignal("NWNX_ON_BARTER_START_BEFORE"))
+    {
+        retVal = m_HandlePlayerToServerBarter_StartBarterHook->CallOriginal<int32_t>(pMessage, pPlayer);
+    }
+    else
+        retVal = false;
+
+    PushAndSignal("NWNX_ON_BARTER_START_AFTER");
+
+    return retVal;
+}
+
+void BarterEvents::SetListAcceptedHook(
+        NWNXLib::Services::Hooks::CallType type,
+        NWNXLib::API::CNWSBarter *pBarter,
+        int32_t bAccepted)
+{
+    if (pBarter && bAccepted)
+        EndedBarter(type, pBarter, bAccepted);
+}
+
+void BarterEvents::SendServerToPlayerBarterCloseBarterHook(
+        Services::Hooks::CallType type,
+        CNWSMessage*,
+        Types::ObjectID nInitiatorId,
+        Types::ObjectID,
+        int32_t bAccepted)
+{
+    CServerExoApp* exoApp = Globals::AppManager()->m_pServerExoApp;
+    uint32_t oidPlayer = static_cast<CNWSPlayer*>(exoApp->GetClientObjectByPlayerId(nInitiatorId, 0))->m_oidPCObject;
+    CNWSCreature* pCreature = exoApp->GetCreatureByGameObjectID(oidPlayer);
+    auto *pBarter = pCreature->GetBarterInfo(0);
+
+    // We only need to run the END on a CANCEL BARTER for the initiator
+    if (pBarter->m_bInitiator && !bAccepted)
+        EndedBarter(type, pBarter, bAccepted);
+}
+
+void BarterEvents::EndedBarter(
+        NWNXLib::Services::Hooks::CallType type,
+        NWNXLib::API::CNWSBarter *pBarter,
+        int32_t bAccepted)
+{
+    CNWSBarter* otherBarter;
+    CNWSBarter* initiatorBarter;
+    CNWSBarter* targetBarter;
+    CServerExoApp* exoApp = Globals::AppManager()->m_pServerExoApp;
+
+    const bool before = type == Services::Hooks::CallType::BEFORE_ORIGINAL;
+
+    if (bAccepted && before)
+    {
+        otherBarter = Utils::AsNWSCreature(exoApp->GetGameObject(pBarter->m_oidBarrator))->GetBarterInfo(0);
+
+        // We only handle a completed barter when the other player has already accepted
+        if (!otherBarter->m_bListAccepted)
+            return;
+
+        initiatorBarter = pBarter->m_bInitiator ? pBarter : otherBarter;
+        targetBarter = pBarter->m_bInitiator ? otherBarter : pBarter;
+
+        // We need to use these in the AFTER where they're no longer available
+        m_initiatorOid = initiatorBarter->m_pOwner->m_idSelf;
+        m_targetOid = targetBarter->m_pOwner->m_idSelf;
+        if (initiatorBarter->m_pBarterList)
+        {
+            auto *itemList = initiatorBarter->m_pBarterList->m_oidItems.m_pcExoLinkedListInternal;
+            Events::PushEventData("BARTER_INITIATOR_ITEM_COUNT", std::to_string(itemList->m_nCount));
+            int i = 0;
+            for (auto *node = itemList->pHead; node; node = node->pNext)
+            {
+                auto item = *(static_cast<Types::ObjectID *>(node->pObject));
+                Events::PushEventData("BARTER_INITIATOR_ITEM_" + std::to_string(i), Utils::ObjectIDToString(item));
+                i++;
+            }
+        }
+
+        if (targetBarter->m_pBarterList)
+        {
+            auto *itemList = targetBarter->m_pBarterList->m_oidItems.m_pcExoLinkedListInternal;
+            Events::PushEventData("BARTER_TARGET_ITEM_COUNT", std::to_string(itemList->m_nCount));
+            int i = 0;
+            for (auto *node = itemList->pHead; node; node = node->pNext)
+            {
+                auto item = *(static_cast<Types::ObjectID *>(node->pObject));
+                Events::PushEventData("BARTER_TARGET_ITEM_" + std::to_string(i), Utils::ObjectIDToString(item));
+                i++;
+            }
+        }
+        Events::PushEventData("BARTER_COMPLETE", "1");
+        Events::PushEventData("BARTER_TARGET", Utils::ObjectIDToString(m_targetOid));
+        Events::SignalEvent("NWNX_ON_BARTER_END_BEFORE", m_initiatorOid);
+    }
+    else if (bAccepted)
+    {
+        // When the AcceptTrade has been selected by both players and ran both in the BEFORE and AFTER
+        // the oidBarrator becomes invalid.
+        if (pBarter->m_oidBarrator != Constants::OBJECT_INVALID)
+            return;
+
+        Events::PushEventData("BARTER_COMPLETE", "1");
+        Events::PushEventData("BARTER_TARGET", Utils::ObjectIDToString(m_targetOid));
+        Events::SignalEvent("NWNX_ON_BARTER_END_AFTER", m_initiatorOid);
+    }
+    else // Cancelled Barter
+    {
+        otherBarter = Utils::AsNWSCreature(exoApp->GetGameObject(pBarter->m_oidBarrator))->GetBarterInfo(0);
+
+        initiatorBarter = pBarter->m_bInitiator ? pBarter : otherBarter;
+        targetBarter = pBarter->m_bInitiator ? otherBarter : pBarter;
+
+        Events::PushEventData("BARTER_COMPLETE", "0");
+        Events::PushEventData("BARTER_TARGET", Utils::ObjectIDToString(targetBarter->m_pOwner->m_idSelf));
+        Events::SignalEvent(before ? "NWNX_ON_BARTER_END_BEFORE" : "NWNX_ON_BARTER_END_AFTER", initiatorBarter->m_pOwner->m_idSelf);
+    }
+}
+
+}

--- a/Plugins/Events/Events/BarterEvents.hpp
+++ b/Plugins/Events/Events/BarterEvents.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "Common.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include "ViewPtr.hpp"
+
+namespace Events {
+
+class BarterEvents
+{
+public:
+    BarterEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
+
+private:
+    static int32_t HandlePlayerToServerBarter_StartBarterHook(NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*);
+    static void EndedBarter(
+            NWNXLib::Services::Hooks::CallType,
+            NWNXLib::API::CNWSBarter*,
+            int32_t);
+    static void SetListAcceptedHook(
+            NWNXLib::Services::Hooks::CallType,
+            NWNXLib::API::CNWSBarter*,
+            int32_t);
+    static void SendServerToPlayerBarterCloseBarterHook(
+            NWNXLib::Services::Hooks::CallType,
+            NWNXLib::API::CNWSMessage*,
+            NWNXLib::API::Types::ObjectID,
+            NWNXLib::API::Types::ObjectID,
+            int32_t);
+};
+
+}

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -595,6 +595,31 @@
         Variable Name           Type        Notes
         CURRENT_PANEL           int         The current panel, index starts at 0
         SELECTED_PANEL          int         The selected panel, index starts at 0
+////////////////////////////////////////////////////////////////////////////////
+    NWNX_ON_BARTER_START_BEFORE
+    NWNX_ON_BARTER_START_AFTER
+
+    Usage:
+        OBJECT_SELF = The player who initiated the barter
+
+    Event data:
+        Variable Name           Type        Notes
+        BARTER_TARGET           object      The other player involved in the barter
+
+    NWNX_ON_BARTER_END_BEFORE
+    NWNX_ON_BARTER_END_AFTER
+
+    Usage:
+        OBJECT_SELF = The player who initiated the barter
+
+    Event data:
+        Variable Name                 Type        Notes
+        BARTER_TARGET                 object      The other player involved in the barter
+        BARTER_COMPLETE               int         TRUE/FALSE - whether the barter completed successfully
+        BARTER_INITIATOR_ITEM_COUNT   int         How many items the initiator traded away
+        BARTER_TARGET_ITEM_COUNT      int         How many items the target traded away
+        BARTER_INITIATOR_ITEM_*       object      Convert to object with NWNX_Object_StringToObject()
+        BARTER_TARGET_ITEM_*          object      Convert to object with NWNX_Object_StringToObject()
 *///////////////////////////////////////////////////////////////////////////////
 
 /*
@@ -647,6 +672,7 @@ string NWNX_Events_GetEventData(string tag);
 // - Client connect event
 // - Spell events
 // - QuickChat events
+// - Barter event (START only)
 void NWNX_Events_SkipEvent();
 
 // Set the return value of the event.

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -616,10 +616,10 @@
         Variable Name                 Type        Notes
         BARTER_TARGET                 object      The other player involved in the barter
         BARTER_COMPLETE               int         TRUE/FALSE - whether the barter completed successfully
-        BARTER_INITIATOR_ITEM_COUNT   int         How many items the initiator traded away
-        BARTER_TARGET_ITEM_COUNT      int         How many items the target traded away
-        BARTER_INITIATOR_ITEM_*       object      Convert to object with NWNX_Object_StringToObject()
-        BARTER_TARGET_ITEM_*          object      Convert to object with NWNX_Object_StringToObject()
+        BARTER_INITIATOR_ITEM_COUNT   int         How many items the initiator traded away, only in _BEFORE events
+        BARTER_TARGET_ITEM_COUNT      int         How many items the target traded away, only in _BEFORE events
+        BARTER_INITIATOR_ITEM_*       object      Convert to object with NWNX_Object_StringToObject(), only in _BEFORE events
+        BARTER_TARGET_ITEM_*          object      Convert to object with NWNX_Object_StringToObject(), only in _BEFORE events
 *///////////////////////////////////////////////////////////////////////////////
 
 /*


### PR DESCRIPTION
This resolves #156 - though it's only done through events and not a fancy complete plugin. Users can set a local int on start and then delete on end and then bypass an autosave when that flag is set. Additionally it makes sense to run `ExportSingleCharacter` on the barter end event anyway.

Barter is rather hairy, there's a lot of weird things going on. I wanted to know the items traded on completion and the only way I could figure out I could get those was by hooking into `CNWSBarter::AcceptTrade` when the other player has already accepted.

I also made the BARTER_START able to be bypassed. 

Below is a sample `event_barter.nss` 

```c
#include "nwnx_events"
#include "nwnx_object"

void main()
{
    object oPC = OBJECT_SELF;
    if (!GetIsPC(oPC))
        return;

    string sCurrentEvent = NWNX_Events_GetCurrentEvent();
    object oTarget = NWNX_Object_StringToObject(NWNX_Events_GetEventData("BARTER_TARGET"));
    if (sCurrentEvent == "NWNX_ON_BARTER_START_BEFORE")
    {
        if (!GetIsObjectValid(oTarget))
            return;
        SetLocalInt(oPC, "bartering", 1);
        SetLocalInt(oTarget, "bartering", 1);
        SendMessageToPC(oPC, "Starting Barter with "+GetName(oTarget));
        SendMessageToPC(oTarget, "Starting Barter with "+GetName(oPC));
    }
    else if (sCurrentEvent == "NWNX_ON_BARTER_END_BEFORE")
    {
        int nCount = StringToInt(NWNX_Events_GetEventData("BARTER_INITIATOR_ITEM_COUNT"));
        int i = 0;
        while (i < nCount)
        {
            SendMessageToPC(oPC,"Lost Item: "+GetName(NWNX_Object_StringToObject(NWNX_Events_GetEventData("BARTER_INITIATOR_ITEM_"+IntToString(i)))));
            i++;
        }
        i = 0;
        nCount = StringToInt(NWNX_Events_GetEventData("BARTER_TARGET_ITEM_COUNT"));
        while (i < nCount)
        {
            SendMessageToPC(oTarget,"Lost Item: "+GetName(NWNX_Object_StringToObject(NWNX_Events_GetEventData("BARTER_TARGET_ITEM_"+IntToString(i)))));
            i++;
        }
    }
    else if (sCurrentEvent == "NWNX_ON_BARTER_END_AFTER")
    {
        int nSuccess = StringToInt(NWNX_Events_GetEventData("BARTER_COMPLETE"));
        if (nSuccess)
        {
            SendMessageToPC(oPC, "Completed Barter with "+GetName(oTarget));
            SendMessageToPC(oTarget, "Completed Barter with "+GetName(oPC));
        }
        DeleteLocalInt(oPC, "bartering");
        DeleteLocalInt(oTarget, "bartering");
        ExportSingleCharacter(oPC);
        ExportSingleCharacter(oTarget);
    }
}
```