### PR TITLE
Damage: DealDamage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The following plugins were added:
 - Damage: SetAttackEventScript()
 - Damage: GetAttackEventData()
 - Damage: SetAttackEventData()
+- Damage: DealDamage()
 - Effect: PackEffect()
 - Effect: UnpackEffect()
 - Effect: SetEffectExpiredScript()

--- a/Plugins/Damage/Damage.cpp
+++ b/Plugins/Damage/Damage.cpp
@@ -230,7 +230,7 @@ ArgumentStack Damage::DealDamage(ArgumentStack&& args)
     int damagePower = Services::Events::ExtractArgument<int32_t>(args);
 
     CNWSCreature *pSource = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(oidSource);
-    CNWSCreature *pTarget = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(oidTarget);
+    CNWSObject *pTarget = Utils::AsNWSObject(Globals::AppManager()->m_pServerExoApp->GetGameObject(oidTarget));
     ASSERT_OR_THROW(pTarget != nullptr);
 
     // apply damage immunity and resistance

--- a/Plugins/Damage/Damage.cpp
+++ b/Plugins/Damage/Damage.cpp
@@ -12,6 +12,7 @@
 #include "Utils.hpp"
 
 #include <cstring>
+#include <bitset>
 
 using namespace NWNXLib;
 using namespace NWNXLib::API;
@@ -51,6 +52,7 @@ Damage::Damage(const Plugin::CreateParams& params)
     REGISTER(SetDamageEventData);
     REGISTER(GetAttackEventData);
     REGISTER(SetAttackEventData);
+    REGISTER(DealDamage);
 
 #undef REGISTER
 
@@ -205,6 +207,53 @@ void Damage::OnCombatAttack(NWNXLib::API::CNWSCombatRound *pThis, uint8_t attack
     }
 
     g_plugin->m_OnCombatAttackHook->CallOriginal<void>(pThis, attackNumber);
+}
+
+//--------------------------- Dealing Damage ----------------------------------
+
+ArgumentStack Damage::DealDamage(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    int vDamage[13];
+    std::bitset<13> positive;
+
+    // read input
+    uint32_t oidSource = Services::Events::ExtractArgument<Types::ObjectID>(args);
+    uint32_t oidTarget = Services::Events::ExtractArgument<Types::ObjectID>(args);
+
+    for (int k = 0; k < 12; k++)
+    {
+        vDamage[k] = Services::Events::ExtractArgument<int32_t>(args);
+        // need to distinguish between no damage dealt, and damage reduced to 0
+        positive[k] = vDamage[k] > 0;
+    }
+    int damagePower = Services::Events::ExtractArgument<int32_t>(args);
+
+    // apply damage immunity, resistance and reduction
+    CNWSCreature *pSource = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(oidSource);
+    CNWSCreature *pTarget = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(oidTarget);
+    for (int k = 0; k < 12; k++)
+    {
+        vDamage[k] = pTarget->DoDamageImmunity(pSource, vDamage[k], 1 << k, 0, 1);
+        vDamage[k] = pTarget->DoDamageResistance(pSource, vDamage[k], 1 << k, 0, 1, 0);
+    }
+    // base damage (combine physical for DR)
+    vDamage[13] = pTarget->DoDamageReduction(pSource, vDamage[0] + vDamage[1] + vDamage[2], damagePower, 0, 1);
+    vDamage[0] = vDamage[1] = vDamage[2] = 0;
+    positive[13] = positive[0] || positive[1] || positive[2];
+
+    // create damage effect ...
+    CGameEffect *pEffect = new CGameEffect(true);
+    pEffect->m_nType = 38;
+    pEffect->SetCreator(oidSource);
+    pEffect->SetNumIntegers(19);
+    for (int k = 0; k < 13; k++)
+        pEffect->SetInteger(k, positive[k] ? vDamage[k] : -1);
+    pEffect->SetInteger(17, true); // combat damage
+    // ... and apply it
+    pTarget->ApplyEffect(pEffect, false, true);
+
+    return stack;
 }
 
 }

--- a/Plugins/Damage/Damage.cpp
+++ b/Plugins/Damage/Damage.cpp
@@ -242,10 +242,10 @@ ArgumentStack Damage::DealDamage(ArgumentStack&& args)
             vDamage[k] = pTarget->DoDamageResistance(pSource, vDamage[k], 1 << k, false, false, false);
     }
     // apply DR (combine physical damage for this)
-    vDamage[13] = vDamage[0] + vDamage[1] + vDamage[2];
-    positive[13] = positive[0] || positive[1] || positive[2];
-    if (vDamage[13] > 0)
-        vDamage[13] = pTarget->DoDamageReduction(pSource, vDamage[13], damagePower, false, false);
+    vDamage[12] = vDamage[0] + vDamage[1] + vDamage[2];
+    positive[12] = positive[0] || positive[1] || positive[2];
+    if (vDamage[12] > 0)
+        vDamage[12] = pTarget->DoDamageReduction(pSource, vDamage[12], damagePower, false, false);
 
     // create damage effect ...
     CGameEffect *pEffect = new CGameEffect(true);

--- a/Plugins/Damage/Damage.hpp
+++ b/Plugins/Damage/Damage.hpp
@@ -36,6 +36,7 @@ private:
     ArgumentStack SetDamageEventData(ArgumentStack&& args);
     ArgumentStack GetAttackEventData(ArgumentStack&& args);
     ArgumentStack SetAttackEventData(ArgumentStack&& args);
+    ArgumentStack DealDamage(ArgumentStack&& args);
 
     NWNXLib::Hooking::FunctionHook* m_OnApplyDamageHook;
     NWNXLib::Hooking::FunctionHook* m_OnCombatAttackHook;

--- a/Plugins/Damage/NWScript/nwnx_damage.nss
+++ b/Plugins/Damage/NWScript/nwnx_damage.nss
@@ -42,6 +42,24 @@ struct NWNX_Damage_AttackEventData
     int iSneakAttack;  // 0=neither, 1=sneak attack, 2=death attack, 3=both
 };
 
+// for DealDamage
+struct NWNX_Damage_DamageData
+{
+    int iBludgeoning;
+    int iPierce;
+    int iSlash;
+    int iMagical;
+    int iAcid;
+    int iCold;
+    int iDivine;
+    int iElectrical;
+    int iFire;
+    int iNegative;
+    int iPositive;
+    int iSonic;
+    int iPower; // for overcoming DR
+};
+
 // Set Damage Event Script
 // If oOwner is OBJECT_INVALID, this sets the script globally for all creatures
 // If oOwner is valid, it will set it only for that creature.
@@ -64,6 +82,10 @@ struct NWNX_Damage_AttackEventData NWNX_Damage_GetAttackEventData();
 // Set Attack Event Data (to use only on Attack Event Script)
 void NWNX_Damage_SetAttackEventData(struct NWNX_Damage_AttackEventData data);
 
+// Deal damage to target - permits multiple damage types and checks enhancement bonus for overcoming DR
+void NWNX_Damage_DealDamage(struct NWNX_Damage_DamageData data, object oTarget, object oSource=OBJECT_SELF);
+
+//--------------------------- Implementation ----------------------------------
 
 void NWNX_Damage_SetDamageEventScript(string sScript, object oOwner=OBJECT_INVALID)
 {
@@ -179,6 +201,29 @@ void NWNX_Damage_SetAttackEventData(struct NWNX_Damage_AttackEventData data)
     NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iSlash);
     NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iPierce);
     NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iBludgeoning);
+
+    NWNX_CallFunction(NWNX_Damage, sFunc);
+}
+
+void NWNX_Damage_DealDamage(struct NWNX_Damage_DamageData data, object oTarget, object oSource)
+{
+    string sFunc = "DealDamage";
+
+    NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iPower);
+    NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iSonic);
+    NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iPositive);
+    NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iNegative);
+    NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iFire);
+    NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iElectrical);
+    NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iDivine);
+    NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iCold);
+    NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iAcid);
+    NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iMagical);
+    NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iSlash);
+    NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iPierce);
+    NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iBludgeoning);
+    NWNX_PushArgumentObject(NWNX_Damage, sFunc, oTarget);
+    NWNX_PushArgumentObject(NWNX_Damage, sFunc, oSource);
 
     NWNX_CallFunction(NWNX_Damage, sFunc);
 }


### PR DESCRIPTION
Allows dealing of multiple damage types in one go (single effect & message). Damage immunity, resistance and reduction are applied automatically, and enhancement bonus is considered for overcoming DR.
Example (Hellball spell):
```
#include "x2_i0_spells"
#include "nwnx_damage"

void main()
{
    int nSpellDC = GetEpicSpellSaveDC(OBJECT_SELF);
    effect eKnock = EffectKnockdown();
    effect eExplode = EffectVisualEffect(464);
    location lTarget = GetSpellTargetLocation();

    ApplyEffectAtLocation(DURATION_TYPE_INSTANT, eExplode, lTarget);
    // roll damage once
    struct NWNX_Damage_DamageData damage, half;
    damage.iAcid        = d6(10);
    damage.iElectrical  = d6(10);
    damage.iFire        = d6(10);
    damage.iSonic       = d6(10);
    half.iAcid          = damage.iAcid / 2;
    half.iElectrical    = damage.iElectrical / 2;
    half.iFire          = damage.iFire / 2;
    half.iSonic         = damage.iSonic / 2;
    // apply damage
    object oTarget = GetFirstObjectInShape(SHAPE_SPHERE, 20.0f, lTarget, TRUE, OBJECT_TYPE_CREATURE);
    while (GetIsObjectValid(oTarget))
    {
        if (spellsIsTarget(oTarget, SPELL_TARGET_STANDARDHOSTILE, OBJECT_SELF))
        {
            SignalEvent(oTarget, EventSpellCastAt(OBJECT_SELF, GetSpellId()));
            float fDelay = GetDistanceBetweenLocations(lTarget, GetLocation(oTarget))/20 + 0.5f;
            // no we don't care about evasion. there is no evasion to hellball
            if (MySavingThrow(SAVING_THROW_REFLEX,oTarget,nSpellDC,SAVING_THROW_TYPE_SPELL,OBJECT_SELF,fDelay) > 0)
                DelayCommand(fDelay, NWNX_Damage_DealDamage(half, oTarget));
            else
            {
                DelayCommand(fDelay, NWNX_Damage_DealDamage(damage, oTarget));
                DelayCommand(fDelay + 0.3f, ApplyEffectToObject(DURATION_TYPE_INSTANT, eKnock, oTarget));
            }
        }
        oTarget = GetNextObjectInShape(SHAPE_SPHERE, 20.0f, lTarget, TRUE, OBJECT_TYPE_CREATURE);
    }
}

```