### PR TITLE
Rename: Overhaul to support per target names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ The following plugins were added:
 - Regex: Search()
 - Regex: Replace()
 - Rename: SetPCNameOverride()
+- Rename: GetPCNameOverride()
 - Reveal: RevealTo()
 - Reveal: SetRevealToParty()
 - Util: GenerateUUID()

--- a/Plugins/Redis/Documentation/README.md
+++ b/Plugins/Redis/Documentation/README.md
@@ -18,38 +18,12 @@ TODO:
 ## Hints
 
 * There are two includes, `nwnx_redis` and `nwnx_redis_short`. They do the same, but `_short` is not prefixed with `NWNX_Redis`.
-* `nwnx_redis_ps.nss` and `on_pubsub.nss` are not needed if PubSub functionality is not being used.
 
-## Setup
+## Getting started with PubSub
 
 * Set up redis-server. Start it. This should be as simple as apt-get install redis. There's also a docker image.
 * Configure `NWNX_REDIS_HOST` and `NWNX_REDIS_PORT` for nwnx. `NWNX_REDIS_PORT` is not necessary if the default redis port is used.
 * Include the .nss files in NWScript/ into your module.
-
-## Accessing Redis from nwscript
-
-To use Redis commands in nwscript include `nwnx_redis` and `nwnx_redis_lib`. The nwnx_redis include contains the redis commands like, for example, `int NWNX_Redis_GET(string key)`. All of the nwnx redis comands return an int which is the resultId. The nwnx_redis_lib include contains functions to get the data (and type) you can work with for this resultId. Three of these functions are:
-* int NWNX_Redis_GetResultAsInt(int resultId)
-* string NWNX_Redis_GetResultAsString(int resultId)
-* float NWNX_Redis_GetResultAsFloat(int resultId)
-
-There are also functions to work with result arrays and one to get the type of a result. You can look those up in [nwnx_redis_lib.nss](../NWScript/nwnx_redis_lib.nss).
-
-`NWNX_Redis_GetResultAs<Type>` has to be called on all the commands that return a resultId even if the actual value is an int as well. The following is an example to set, check for existance of and get a key.
-```c
-#include "nwnx_redis"
-#include "nwnx_redis_lib"
-
-NWNX_Redis_SET("examples:examplekey", "testvalue");
-if (NWNX_Redis_GetResultAsInt(NWNX_Redis_EXISTS("examples:examplekey")))
-{
-  string sValue = NWNX_Redis_GetResultAsString(NWNX_Redis_GET("examples:examplekey"));
-  WriteTimestampedLogEntry("Value of redis key 'examples:examplekey': " + sValue);
-}
-```
-
-## Getting started with PubSub
-
 * Create a script called "on_pubsub" (or rename it through `NWNX_REDIS_PUBSUB_SCRIPT`). An example is included in NWScript/.
 * Configure `NWNX_REDIS_PUBSUB_CHANNELS` to be "test".
 * Hint: Subscriptions support wildcards.

--- a/Plugins/Redis/Documentation/README.md
+++ b/Plugins/Redis/Documentation/README.md
@@ -18,12 +18,38 @@ TODO:
 ## Hints
 
 * There are two includes, `nwnx_redis` and `nwnx_redis_short`. They do the same, but `_short` is not prefixed with `NWNX_Redis`.
+* `nwnx_redis_ps.nss` and `on_pubsub.nss` are not needed if PubSub functionality is not being used.
 
-## Getting started with PubSub
+## Setup
 
 * Set up redis-server. Start it. This should be as simple as apt-get install redis. There's also a docker image.
 * Configure `NWNX_REDIS_HOST` and `NWNX_REDIS_PORT` for nwnx. `NWNX_REDIS_PORT` is not necessary if the default redis port is used.
 * Include the .nss files in NWScript/ into your module.
+
+## Accessing Redis from nwscript
+
+To use Redis commands in nwscript include `nwnx_redis` and `nwnx_redis_lib`. The nwnx_redis include contains the redis commands like, for example, `int NWNX_Redis_GET(string key)`. All of the nwnx redis comands return an int which is the resultId. The nwnx_redis_lib include contains functions to get the data (and type) you can work with for this resultId. Three of these functions are:
+* int NWNX_Redis_GetResultAsInt(int resultId)
+* string NWNX_Redis_GetResultAsString(int resultId)
+* float NWNX_Redis_GetResultAsFloat(int resultId)
+
+There are also functions to work with result arrays and one to get the type of a result. You can look those up in [nwnx_redis_lib.nss](../NWScript/nwnx_redis_lib.nss).
+
+`NWNX_Redis_GetResultAs<Type>` has to be called on all the commands that return a resultId even if the actual value is an int as well. The following is an example to set, check for existance of and get a key.
+```c
+#include "nwnx_redis"
+#include "nwnx_redis_lib"
+
+NWNX_Redis_SET("examples:examplekey", "testvalue");
+if (NWNX_Redis_GetResultAsInt(NWNX_Redis_EXISTS("examples:examplekey")))
+{
+  string sValue = NWNX_Redis_GetResultAsString(NWNX_Redis_GET("examples:examplekey"));
+  WriteTimestampedLogEntry("Value of redis key 'examples:examplekey': " + sValue);
+}
+```
+
+## Getting started with PubSub
+
 * Create a script called "on_pubsub" (or rename it through `NWNX_REDIS_PUBSUB_SCRIPT`). An example is included in NWScript/.
 * Configure `NWNX_REDIS_PUBSUB_CHANNELS` to be "test".
 * Hint: Subscriptions support wildcards.

--- a/Plugins/Rename/Documentation/README.md
+++ b/Plugins/Rename/Documentation/README.md
@@ -1,9 +1,5 @@
 # Rename Plugin Reference
 
-## Environment Variables
-
-None
-
 ## Description
 
 
@@ -11,5 +7,185 @@ This plugin facilitates renaming, overriding and customization of player names.
 
 Script function | Description  
 ----------------|-------------
-NWNX_Rename_SetPCNameOverride | Set a PC's floaty/chat name(sPrefix+sNewName+sSuffix) and name (sNewName) on the player list. If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OVERRIDE the player name will change to (sNewName) on tells. If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OBFUSCATE the player name will be set to a random string.
-If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_DEFAULT the player name will be untouched. DMs and the player themselves will still see their original player name regardless of option set Will not persist through saving, resets or logout.
+NWNX_Rename_SetPCNameOverride | Set a PCs floaty/chat name(sPrefix+sNewName+sSuffix) and name (sNewName) on the player list. If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OVERRIDE the player name will change to (sNewName) on tells. If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OBFUSCATE the player name will be set to a random string.
+NWNX_Rename_GetPCNameOverride | Gets the PCs name as seen by a specified target or all clients.
+If `iPlayerNameState` is set to `NWNX_RENAME_PLAYERNAME_DEFAULT` the player name will be untouched. DMs and the player themselves will still see their original player name regardless of option set. Will not persist through saving, resets or logout.
+
+If a target object is specified, only that target will see the PCs name as defined. This overrides a global rename.
+
+Due to the conflict with this plugin and the Tweaks plugin to hide classes on the module character listing, this module also provides that functionality.
+
+## Environment Variables
+
+| Variable Name | Value | Default | Notes |
+| -------------   | :----: | :----: |----------------------------- |
+| `NWNX_RENAME_ON_MODULE_CHAR_LIST` | 0-3 | 0 | This is the listing of players from the character selection screen before entering the server. Setting the value to 1 overrides their names if a global rename has been set, 2 also hides class information, 3 hides class information but keeps names as their original.
+| `NWNX_RENAME_ON_PLAYER_LIST` | true or false | true | Renames the player name on the player list as well.
+
+## Sample Include
+
+```c
+#include "nwnx_rename"
+// For GetPlayerID function, set to your own lib that returns the unique player ID for your PW
+// Then replace GetPlayerID in this include to whatever your call is.
+#include "inc_pc_db"
+
+const string UNKNOWN_PLAYER = "Unknown";
+const string UNKNOWN_PLAYER_PREFIX = "<c~~~>";
+const string UNKNOWN_PLAYER_SUFFIX = "</c>";
+
+const string RENAMED_PLAYER_PREFIX = "";
+const string RENAMED_PLAYER_SUFFIX = "";
+
+// This should be fired on client enter as soon as possible, it loads all
+// the dynamic names for the PC for the other PCs connected and the dynamic
+// name for the other PCs for the connecting PC.
+void LoadNamesForPC(object oPC);
+
+// Stores the info on the database
+void SetDynamicNameDB(object oPC, object oOtherPC, string sName, int iDub = 0);
+
+// Returns whether the PC has dubbed the target PC already
+int GetDynamicNameIsDubbed(object oPC, object oTarget);
+
+// We use three custom commands =c intro, =c introparty and =c introarea (20m radius)
+// So the player could do =c intro Joe and the nearest player would then see the PCs
+// name as Joe
+void IntroducePlayers(object oPC, object oTarget, string sName, int iType = 0);
+
+// Dub works the other way, a PC can dub someone what they wish to see as their
+// name. =c dub Joseph (nearest PC) would then change the target's name for the
+// caller to Joseph.
+void DubPlayer(object oPC, object oTarget, string sName);
+
+void LoadNamesForPC(object oPC)
+{
+    NWNX_Rename_SetPCNameOverride(oPC, UNKNOWN_PLAYER, UNKNOWN_PLAYER_PREFIX,
+                UNKNOWN_PLAYER_SUFFIX, NWNX_RENAME_PLAYERNAME_OBFUSCATE);
+
+    int nPCID = GetPlayerID(oPC);
+    object oOtherPC = GetFirstPC();
+    while (GetIsObjectValid(oOtherPC))
+    {
+        if (oOtherPC != oPC)
+        {
+            int nOtherPCID = GetPlayerID(oOtherPC);
+            string sSQL = "SELECT name FROM dynamic_names WHERE pc1 = ? AND pc2 = ?";
+            NWNX_SQL_PrepareQuery(sSQL);
+            NWNX_SQL_PreparedInt(0, nPCID);
+            NWNX_SQL_PreparedInt(1, nOtherPCID);
+            NWNX_SQL_ExecutePreparedQuery();
+            if (NWNX_SQL_ReadyToReadNextRow())
+            {
+                NWNX_SQL_ReadNextRow();
+                NWNX_Rename_SetPCNameOverride(oOtherPC, NWNX_SQL_ReadDataInActiveRow(0),
+                            RENAMED_PLAYER_PREFIX, RENAMED_PLAYER_SUFFIX, NWNX_RENAME_PLAYERNAME_OVERRIDE, oPC);
+            }
+            NWNX_SQL_PrepareQuery(sSQL);
+            NWNX_SQL_PreparedInt(0, nOtherPCID);
+            NWNX_SQL_PreparedInt(1, nPCID);
+            NWNX_SQL_ExecutePreparedQuery();
+            if (NWNX_SQL_ReadyToReadNextRow())
+            {
+                NWNX_SQL_ReadNextRow();
+                NWNX_Rename_SetPCNameOverride(oPC, NWNX_SQL_ReadDataInActiveRow(0),
+                            RENAMED_PLAYER_PREFIX, RENAMED_PLAYER_SUFFIX, NWNX_RENAME_PLAYERNAME_OVERRIDE, oOtherPC);
+            }
+        }
+        oOtherPC = GetNextPC();
+    }
+}
+
+void SetDynamicNameDB(object oPC, object oOtherPC, string sName, int iDub = 0)
+{
+    int nPC1ID = GetPlayerID(oPC);
+    int nPC2ID = GetPlayerID(oOtherPC);
+    if (nPC1ID && nPC2ID)
+    {
+        string sSQL = "INSERT INTO dynamic_names (pc1, pc2, name, dub) "+
+                      "VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE name = ?, dub = ?";
+        NWNX_SQL_PrepareQuery(sSQL);
+        NWNX_SQL_PreparedInt(0, nPC2ID);
+        NWNX_SQL_PreparedInt(1, nPC1ID);
+        NWNX_SQL_PreparedString(2, sName);
+        NWNX_SQL_PreparedInt(3, iDub);
+        NWNX_SQL_PreparedString(4, sName);
+        NWNX_SQL_PreparedInt(5, iDub);
+        NWNX_SQL_ExecutePreparedQuery();
+    }
+}
+
+int GetDynamicNameIsDubbed(object oPC, object oTarget)
+{
+    int nPCID = GetPlayerID(oPC);
+    int nPCID2 = GetPlayerID(oTarget);
+    int iDub = 0;
+    string sSQL = "SELECT dub FROM dynamic_names WHERE pc1 = ? AND pc2 = ?";
+    NWNX_SQL_PrepareQuery(sSQL);
+    NWNX_SQL_PreparedInt(0, nPCID);
+    NWNX_SQL_PreparedInt(1, nPCID2);
+    NWNX_SQL_ExecutePreparedQuery();
+    if (NWNX_SQL_ReadyToReadNextRow())
+    {
+        NWNX_SQL_ReadNextRow();
+        iDub = StringToInt(NWNX_SQL_ReadDataInActiveRow(0));
+    }
+    return iDub;
+}
+
+void IntroducePlayers(object oPC, object oTarget, string sName, int iType = 0)
+{
+    int nPC1ID = GetPlayerID(oPC);
+    int nPC2ID = GetPlayerID(oTarget);
+    if (nPC1ID == nPC2ID)
+        return;
+    int iDub = GetDynamicNameIsDubbed(oTarget, oPC);
+    string sMyName = NWNX_Rename_GetPCNameOverride(oPC, oTarget);
+    if (sMyName == "")
+        sMyName = "Someone";
+    string sTargetName = NWNX_Rename_GetPCNameOverride(oTarget, oPC);
+    if (sTargetName == "")
+        sTargetName = "Someone";
+    if (!iType)
+        SendMessageToPC(oPC, "Introducing yourself to " + sTargetName + " as " + sName + ".");
+    if (iDub)
+        SendMessageToPC(oTarget, "Someone wants you to know them as " + sName + " but you've "+
+                                 "already dubbed them " + sMyName + " so it's ignored.");
+    else
+    {
+        SendMessageToPC(oTarget, sMyName + " wants you to know them as " + sName + ".");
+        NWNX_Rename_SetPCNameOverride(oPC, sName, RENAMED_PLAYER_PREFIX,
+                        RENAMED_PLAYER_SUFFIX, NWNX_RENAME_PLAYERNAME_OVERRIDE, oOtherPC);
+        SetDynamicNameDB(oPC, oTarget, sName);
+    }
+}
+
+void DubPlayer(object oPC, object oTarget, string sName)
+{
+    string sTargetName = NWNX_Rename_GetPCNameOverride(oTarget, oPC);
+    if (sTargetName == "")
+        sTargetName = "Someone";
+    SendMessageToPC(oPC, sTargetName + " will now be known as " + sName + " to you.");
+    NWNX_Rename_SetPCNameOverride(oTarget, sName, RENAMED_PLAYER_PREFIX,
+                    RENAMED_PLAYER_SUFFIX, NWNX_RENAME_PLAYERNAME_OVERRIDE, oPC);
+    SetDynamicNameDB(oTarget, oPC, sName, 1);
+}
+
+```
+
+And a corresponding MySQL example DB structure:
+
+```sql
+CREATE TABLE `dynamic_names` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `pc1` mediumint(8) unsigned NOT NULL,
+  `pc2` mediumint(8) unsigned NOT NULL,
+  `name` varchar(40) NOT NULL,
+  `dub` tinyint(1) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `pair` (`pc1`,`pc2`),
+  KEY `pc1` (`pc1`),
+  KEY `pc2` (`pc2`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8
+
+```

--- a/Plugins/Rename/Documentation/README.md
+++ b/Plugins/Rename/Documentation/README.md
@@ -156,7 +156,7 @@ void IntroducePlayers(object oPC, object oTarget, string sName, int iType = 0)
     {
         SendMessageToPC(oTarget, sMyName + " wants you to know them as " + sName + ".");
         NWNX_Rename_SetPCNameOverride(oPC, sName, RENAMED_PLAYER_PREFIX,
-                        RENAMED_PLAYER_SUFFIX, NWNX_RENAME_PLAYERNAME_OVERRIDE, oOtherPC);
+                        RENAMED_PLAYER_SUFFIX, NWNX_RENAME_PLAYERNAME_OVERRIDE, oTarget);
         SetDynamicNameDB(oPC, oTarget, sName);
     }
 }

--- a/Plugins/Rename/Documentation/README.md
+++ b/Plugins/Rename/Documentation/README.md
@@ -9,6 +9,7 @@ Script function | Description
 ----------------|-------------
 NWNX_Rename_SetPCNameOverride | Set a PCs floaty/chat name(sPrefix+sNewName+sSuffix) and name (sNewName) on the player list. If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OVERRIDE the player name will change to (sNewName) on tells. If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OBFUSCATE the player name will be set to a random string.
 NWNX_Rename_GetPCNameOverride | Gets the PCs name as seen by a specified target or all clients.
+
 If `iPlayerNameState` is set to `NWNX_RENAME_PLAYERNAME_DEFAULT` the player name will be untouched. DMs and the player themselves will still see their original player name regardless of option set. Will not persist through saving, resets or logout.
 
 If a target object is specified, only that target will see the PCs name as defined. This overrides a global rename.

--- a/Plugins/Rename/NWScript/nwnx_rename.nss
+++ b/Plugins/Rename/NWScript/nwnx_rename.nss
@@ -8,18 +8,25 @@ const int NWNX_RENAME_PLAYERNAME_OBFUSCATE = 1;
 const int NWNX_RENAME_PLAYERNAME_OVERRIDE = 2;
 
 //Set a PC's floaty/chat name(sPrefix+sNewName+sSuffix) and name (sNewName) on the player list.
+//If a target is specified, the PCs name will appear to that target as set, this overrides a global setting.
 //If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OVERRIDE the player name will change to (sNewName) on tells.
 //If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_OBFUSCATE the player name will be set to a random string.
 //If (iPlayerNameState) is set to NWNX_RENAME_PLAYERNAME_DEFAULT the player name will be untouched.
 //DMs and the player themselves will still see their original player name regardless of option set
 //Will not persist through saving, resets or logout.
-void NWNX_Rename_SetPCNameOverride(object oPC, string sNewName, string sPrefix = "" , string sSuffix = "" , int iPlayerNameState = NWNX_RENAME_PLAYERNAME_DEFAULT);
+void NWNX_Rename_SetPCNameOverride(object oPC, string sNewName, string sPrefix = "" , string sSuffix = "" ,
+                                   int iPlayerNameState = NWNX_RENAME_PLAYERNAME_DEFAULT, object oTarget=OBJECT_INVALID);
+
+//Gets a PCs name as overridden
+string NWNX_Rename_GetPCNameOverride(object oPC, object oTarget=OBJECT_INVALID);
 
 
-void NWNX_Rename_SetPCNameOverride(object oPC, string sNewName, string sPrefix = "" , string sSuffix = "" , int iPlayerNameState = NWNX_RENAME_PLAYERNAME_DEFAULT)
+void NWNX_Rename_SetPCNameOverride(object oPC, string sNewName, string sPrefix = "" , string sSuffix = "" ,
+                                   int iPlayerNameState = NWNX_RENAME_PLAYERNAME_DEFAULT, object oTarget=OBJECT_INVALID)
 {
     string sFunc = "SetPCNameOverride";
-    
+
+    NWNX_PushArgumentObject(NWNX_Rename, sFunc, oTarget);
     NWNX_PushArgumentInt(NWNX_Rename, sFunc, iPlayerNameState);
     NWNX_PushArgumentString(NWNX_Rename, sFunc, sSuffix);
     NWNX_PushArgumentString(NWNX_Rename, sFunc, sPrefix);
@@ -27,4 +34,14 @@ void NWNX_Rename_SetPCNameOverride(object oPC, string sNewName, string sPrefix =
     NWNX_PushArgumentObject(NWNX_Rename, sFunc, oPC);
 
     NWNX_CallFunction(NWNX_Rename, sFunc);
+}
+string NWNX_Rename_GetPCNameOverride(object oPC, object oTarget=OBJECT_INVALID)
+{
+    string sFunc = "GetPCNameOverride";
+
+    NWNX_PushArgumentObject(NWNX_Rename, sFunc, oTarget);
+    NWNX_PushArgumentObject(NWNX_Rename, sFunc, oPC);
+
+    NWNX_CallFunction(NWNX_Rename, sFunc);
+    return NWNX_GetReturnValueString(NWNX_Rename, sFunc);
 }

--- a/Plugins/Rename/Rename.cpp
+++ b/Plugins/Rename/Rename.cpp
@@ -135,7 +135,6 @@ Rename::~Rename()
 
 CNWSPlayer *Rename::player(Types::ObjectID playerId)
 {
-
     if (playerId == Constants::OBJECT_INVALID)
     {
         LOG_NOTICE("NWNX_Rename function called on OBJECT_INVALID");
@@ -258,7 +257,6 @@ int32_t Rename::SendServerToPlayerPlayModuleCharacterListResponseHook(
         Types::ObjectID targetOid,
         int32_t add)
 {
-
     Rename& plugin = *g_plugin;
     auto *targetPlayer = Globals::AppManager()->m_pServerExoApp->GetClientObjectByObjectId(targetOid);
     auto *client = Globals::AppManager()->m_pServerExoApp->GetClientObjectByPlayerId(observerPlayerId, 0);

--- a/Plugins/Rename/Rename.cpp
+++ b/Plugins/Rename/Rename.cpp
@@ -15,11 +15,13 @@
 #include "API/CNWSCreature.hpp"
 #include "API/CServerExoAppInternal.hpp"
 #include "API/CExoLinkedListInternal.hpp"
+#include "API/CExoString.hpp"
 #include "API/CLastUpdateObject.hpp"
 #include "API/CExoLinkedListTemplatedCNWSClient.hpp"
 #include "API/CExoLinkedListNode.hpp"
 #include "API/CNWSCreatureStats.hpp"
 #include "API/Functions.hpp"
+#include "Services/Config/Config.hpp"
 #include "Services/PerObjectStorage/PerObjectStorage.hpp"
 #include "Services/Messaging/Messaging.hpp"
 
@@ -27,14 +29,19 @@
 using namespace NWNXLib;
 using namespace NWNXLib::API;
 
+static Hooking::FunctionHook* m_SendServerToPlayerPopUpGUIPanelHook;
+static Hooking::FunctionHook* m_SendServerToPlayerPlayModuleCharacterListResponseHook;
+
 static ViewPtr<Rename::Rename> g_plugin;
 
 //key names for Per Object Storage
-const std::string firstNameKey = "REAL FIRST NAME";
-const std::string lastNameKey = "REAL LAST NAME";
-const std::string playerNameKey = "REAL PLAYER NAME";
-const std::string playerNameOverrideStateKey = "PLAYER NAME OVERRIDE STATE";
-const std::string overrideNameKey = "OVERRIDE NAME";
+const std::string firstNameKey = "REAL_FIRST_NAME";
+const std::string lastNameKey = "REAL_LAST_NAME";
+const std::string playerNameKey = "REAL_PLAYER_NAME";
+const std::string playerNameOverrideStateKey = "PLAYER_NAME_OVERRIDE_STATE";
+const std::string overrideNameKey = "OVERRIDE_NAME";
+const std::string displayNameKey = "DISPLAY_NAME";
+const std::string addedToPlayerListKey = "ADDED_TO_PLAYER_LIST";
 
 //Constants for Player Name states.
 const int NWNX_RENAME_PLAYERNAME_DEFAULT = 0;
@@ -47,9 +54,9 @@ NWNX_PLUGIN_ENTRY Plugin::Info* PluginInfo()
     {
         "Rename",
         "Functions to facilitate renaming, overriding and customization of player names.",
-        "Silvard",
+        "Silvard / orth",
         "jusenkyo at gmail.com",
-        2,
+        3,
         true
     };
 }
@@ -69,25 +76,57 @@ Rename::Rename(const Plugin::CreateParams& params)
     GetServices()->m_events->RegisterEvent(#func, std::bind(&Rename::func, this, std::placeholders::_1))
 
     REGISTER(SetPCNameOverride);
+    REGISTER(GetPCNameOverride);
 
 #undef REGISTER
 
-    GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__SendServerToPlayerPlayerList_All,int32_t,CNWSMessage*,CNWSPlayer*>(&HookPlayerList);
+    m_RenameOnModuleCharList = GetServices()->m_config->Get<int32_t>("ON_MODULE_CHAR_LIST", 0);
+    m_RenameOnPlayerList = GetServices()->m_config->Get<bool>("ON_PLAYER_LIST", true);
 
-    try //try to request a hook. If it fails that means that NWNX_EVENTS_PARTY_EVENTS is enabled, which should broadcast a message to trigger the name change anyway.
+    GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__WriteGameObjUpdate_UpdateObject,
+            int32_t, CNWSMessage *, CNWSPlayer *, CNWSObject *, CLastUpdateObject *, uint32_t, uint32_t>(
+            &WriteGameObjUpdate_UpdateObjectHook);
+    GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__SendServerToPlayerExamineGui_CreatureData,
+            int32_t, CNWSMessage *, CNWSPlayer *, Types::ObjectID>(&SendServerToPlayerExamineGui_CreatureDataHook);
+    GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__SendServerToPlayerChat_Party,
+            int32_t, CNWSMessage*, Types::PlayerID, Types::ObjectID, CExoString*>(&SendServerToPlayerChatHook);
+    GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__SendServerToPlayerChat_Shout,
+            int32_t, CNWSMessage*, Types::PlayerID, Types::ObjectID, CExoString*>(&SendServerToPlayerChatHook);
+    GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__SendServerToPlayerChat_Tell,
+            int32_t, CNWSMessage*, Types::PlayerID, Types::ObjectID, CExoString*>(&SendServerToPlayerChatHook);
+
+    // TODO: When shared hooks are executed by exclusive hooks we can use a shared hook for this instead and simplify
+    // For now we perform the functionality of the HideClassesOnCharList Tweak for convenience
+    if (m_RenameOnModuleCharList > 0)
     {
-        GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__HandlePlayerToServerParty,int32_t,CNWSMessage*,CNWSPlayer*,unsigned char>(&HookPartyInvite);
+        if (m_RenameOnModuleCharList == 1)
+            LOG_INFO("Renaming PCs in the module character listing.");
+        else if (m_RenameOnModuleCharList == 2)
+            LOG_INFO("Renaming PCs and hiding classes in the module character listing.");
+        else if (m_RenameOnModuleCharList == 3)
+            LOG_INFO("Hiding classes in the module character listing via the Rename plugin.");
+        GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWSMessage__SendServerToPlayerPlayModuleCharacterListResponse,
+                int32_t, CNWSMessage *, Types::PlayerID, Types::ObjectID, int32_t>(&SendServerToPlayerPlayModuleCharacterListResponseHook);
+        m_SendServerToPlayerPlayModuleCharacterListResponseHook = GetServices()->m_hooks->FindHookByAddress(API::Functions::CNWSMessage__SendServerToPlayerPlayModuleCharacterListResponse);
     }
-    catch (...){}
-    GetServices()->m_messaging->SubscribeMessage("NWNX_EVENT_SIGNAL_EVENT_SKIPPED",
-        [this](const std::vector<std::string> message)
-        {
-            if (message[1] == "0") //if the event was skipped it doesn't matter what the event was.
-            {
-                if (message[0] == "NWNX_ON_PARTY_INVITE_BEFORE") this->GlobalNameChange(false, nullptr);
-                if (message[0] == "NWNX_ON_PARTY_INVITE_AFTER") this->GlobalNameChange(true, nullptr);
-            }
-        });
+
+    if (m_RenameOnPlayerList)
+    {
+        GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__SendServerToPlayerPlayerList_All,
+                int32_t, CNWSMessage*, CNWSPlayer*>(&SendServerToPlayerPlayerList_AllHook);
+        GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__SendServerToPlayerPlayerList_Add,
+                int32_t, CNWSMessage*, Types::PlayerID, CNWSPlayer*>(&SendServerToPlayerPlayerList_AddHook);
+        GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__SendServerToPlayerPlayerList_Delete,
+                int32_t, CNWSMessage*, Types::PlayerID, CNWSPlayer*>(&SendServerToPlayerPlayerList_DeleteHook);
+    }
+    else
+        LOG_INFO("Not renaming PCs in the player list.");
+
+    // TODO: When shared hooks are executed by exclusive hooks change this to HandlePlayerToServerParty
+    GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWSMessage__SendServerToPlayerPopUpGUIPanel,
+            int32_t, CNWSMessage*, Types::ObjectID, int32_t, int32_t, int32_t, int32_t, CExoString*>(&SendServerToPlayerPopUpGUIPanelHook);
+    m_SendServerToPlayerPopUpGUIPanelHook = GetServices()->m_hooks->FindHookByAddress(API::Functions::CNWSMessage__SendServerToPlayerPopUpGUIPanel);
+
 }
 
 Rename::~Rename()
@@ -111,82 +150,351 @@ CNWSPlayer *Rename::player(Types::ObjectID playerId)
     return pPlayer;
 }
 
-void Rename::HookPlayerList(Services::Hooks::CallType cType, CNWSMessage*, CNWSPlayer* pPlayer)
+void Rename::SetOrRestorePlayerName(NWNXLib::Services::Hooks::CallType cType,
+                                    CNWSPlayer *targetPlayer, CNWSPlayer *observerPlayer)
 {
-    Rename& plugin = *g_plugin;
-    if (cType == Services::Hooks::CallType::BEFORE_ORIGINAL)
+    if (targetPlayer == nullptr ||
+        observerPlayer == nullptr ||
+        targetPlayer == observerPlayer)
+        return;
+
+    auto *targetCreature = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(targetPlayer->m_oidNWSObject);
+    auto *observerCreature = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(observerPlayer->m_oidNWSObject);
+
+    Types::ObjectID observerOid;
+    if (observerCreature == nullptr)
+        observerOid = Constants::PLAYERID_ALL_PLAYERS;
+    else
+        observerOid = observerPlayer->m_oidNWSObject;
+
+    // There's a moment when a player is just logging in that pStats doesn't exist yet.
+    if (targetCreature == nullptr || targetCreature->m_pStats == nullptr || targetCreature->m_pStats->m_bIsDM ||
+            (observerCreature != nullptr && (observerCreature->m_pStats == nullptr || observerCreature->m_pStats->m_bIsDM)))
     {
-        //traverse the player list and replace the names of all players on the override list
-        plugin.GlobalNameChange(false, pPlayer);
+        return;
+    }
+
+    if (cType == Services::Hooks::CallType::BEFORE_ORIGINAL)
+        SetPlayerNameAsObservedBy(targetCreature, observerOid);
+    else
+        RestorePlayerName(targetCreature);
+
+}
+
+void Rename::SetPlayerNameAsObservedBy(CNWSCreature *targetCreature, Types::ObjectID observerOid)
+{
+    Rename &plugin = *g_plugin;
+    auto targetOid = targetCreature->m_idSelf;
+    auto *pPOS = plugin.GetServices()->m_perObjectStorage.get();
+    std::string displayNameKeyObserver = displayNameKey + ":" + Utils::ObjectIDToString(observerOid);
+    std::string overrideNameKeyObserver = overrideNameKey + ":" + Utils::ObjectIDToString(observerOid);
+    std::string displayName = *pPOS->Get<std::string>(targetOid, displayNameKeyObserver);
+    std::string overrideName = *pPOS->Get<std::string>(targetOid, overrideNameKeyObserver);
+    if (!displayName.empty())
+    {
+        targetCreature->m_pStats->m_lsFirstName = plugin.ContainString(overrideName);
+        targetCreature->m_pStats->m_lsLastName = plugin.ContainString("");
+        targetCreature->m_sDisplayName = displayName.c_str();
+        LOG_DEBUG("Observer %x will see %x as %s due to personal override", observerOid, targetOid, overrideName.c_str());
     }
     else
     {
-        //And now we do it again to restore the names after the player list has been sent over
-        plugin.GlobalNameChange(true, pPlayer);
+        std::string allClients = Utils::ObjectIDToString(Constants::PLAYERID_ALL_CLIENTS);
+        displayName = *pPOS->Get<std::string>(targetOid, displayNameKey + ":" + allClients);
+        overrideName = *pPOS->Get<std::string>(targetOid, overrideNameKey + ":" + allClients);
+        if (!displayName.empty())
+        {
+            targetCreature->m_pStats->m_lsFirstName = plugin.ContainString(overrideName);
+            targetCreature->m_pStats->m_lsLastName = plugin.ContainString("");
+            targetCreature->m_sDisplayName = displayName.c_str();
+            LOG_DEBUG("Observer %x will see %x as %s due to global override", observerOid, targetOid, overrideName.c_str());
+        }
     }
 }
 
-void Rename::HookPartyInvite(Services::Hooks::CallType cType, CNWSMessage*, CNWSPlayer*, unsigned char)
+void Rename::RestorePlayerName(CNWSCreature *targetCreature)
 {
-    Rename& plugin = *g_plugin;
-    if (cType == Services::Hooks::CallType::BEFORE_ORIGINAL)
+    Rename &plugin = *g_plugin;
+    auto *pPOS = plugin.GetServices()->m_perObjectStorage.get();
+    std::string lsFirstName = *pPOS->Get<std::string>(targetCreature->m_idSelf, firstNameKey);
+    std::string lsLastName = *pPOS->Get<std::string>(targetCreature->m_idSelf, lastNameKey);
+    if (!lsFirstName.empty())
     {
-        //traverse the player list and replace the names of all players on the override list
-        plugin.GlobalNameChange(false, nullptr);
+        targetCreature->m_pStats->m_lsFirstName = plugin.ContainString(lsFirstName);
+        targetCreature->m_pStats->m_lsLastName = plugin.ContainString(lsLastName);
+        targetCreature->m_sDisplayName = "";
+    }
+}
+
+void Rename::WriteGameObjUpdate_UpdateObjectHook(
+        NWNXLib::Services::Hooks::CallType cType,
+        CNWSMessage*,
+        CNWSPlayer *observerPlayer,
+        CNWSObject *targetObject,
+        CLastUpdateObject*,
+        uint32_t,
+        uint32_t)
+{
+    auto *targetPlayer = Globals::AppManager()->m_pServerExoApp->GetClientObjectByObjectId(targetObject->m_idSelf);
+    SetOrRestorePlayerName(cType, targetPlayer, observerPlayer);
+}
+
+void Rename::SendServerToPlayerExamineGui_CreatureDataHook(
+        NWNXLib::Services::Hooks::CallType cType,
+        CNWSMessage*,
+        CNWSPlayer *observerPlayer,
+        Types::ObjectID targetOid)
+{
+    auto *targetPlayer = Globals::AppManager()->m_pServerExoApp->GetClientObjectByObjectId(targetOid);
+    SetOrRestorePlayerName(cType, targetPlayer, observerPlayer);
+}
+
+// This can't work on per target basis as the player logging in hasn't selected their PC yet but it
+// will still work for a global override. We also handle the hide classes tweak until exclusive
+// hooks call shared hooks
+int32_t Rename::SendServerToPlayerPlayModuleCharacterListResponseHook(
+        CNWSMessage *thisPtr,
+        Types::PlayerID observerPlayerId,
+        Types::ObjectID targetOid,
+        int32_t add)
+{
+
+    Rename& plugin = *g_plugin;
+    auto *targetPlayer = Globals::AppManager()->m_pServerExoApp->GetClientObjectByObjectId(targetOid);
+    auto *client = Globals::AppManager()->m_pServerExoApp->GetClientObjectByPlayerId(observerPlayerId, 0);
+    auto *observerPlayer = static_cast<API::CNWSPlayer *>(client);
+    if (plugin.m_RenameOnModuleCharList == 1 || plugin.m_RenameOnModuleCharList == 2)
+    {
+        SetOrRestorePlayerName(Services::Hooks::CallType::BEFORE_ORIGINAL, targetPlayer, observerPlayer);
+    }
+
+    int32_t retVal = -1;
+
+    if (plugin.m_RenameOnModuleCharList >= 2)
+    {
+        thisPtr->CreateWriteMessage(sizeof(observerPlayerId), observerPlayerId, true);
+
+        thisPtr->WriteBOOL(add);
+        thisPtr->WriteDWORD(targetOid, 32);
+
+        if (add)
+        {
+            auto *creature = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(targetOid);
+            if (creature)
+            {
+                thisPtr->WriteCExoLocStringServer(creature->GetFirstName(), creature->GetGender());
+                thisPtr->WriteCExoLocStringServer(creature->GetLastName(), creature->GetGender());
+
+                uint16_t portraitId = creature->GetPortraitId();
+                thisPtr->WriteWORD(portraitId, 16);
+                if (portraitId >= 0xFFFE)
+                {
+                    thisPtr->WriteCResRef(creature->GetPortrait(), 16);
+                }
+
+                thisPtr->WriteBYTE(0, 8);
+            }
+            else
+            {
+                retVal = 0;
+            }
+        }
+
+        uint8_t *message;
+        uint32_t size;
+        if (!thisPtr->GetWriteMessage(&message, &size))
+        {
+            retVal = 0;
+        }
+        if (retVal != 0)
+            retVal = thisPtr->SendServerToPlayerMessage(observerPlayerId, 0x31, 0x03, message, size);
     }
     else
     {
-        //And now we do it again to restore the names after the party invite
-        plugin.GlobalNameChange(true, nullptr);
+        retVal = m_SendServerToPlayerPlayModuleCharacterListResponseHook->CallOriginal<int32_t>(thisPtr, observerPlayerId, targetOid, add);
+    }
+
+    if (plugin.m_RenameOnModuleCharList == 1 || plugin.m_RenameOnModuleCharList == 2)
+    {
+        SetOrRestorePlayerName(Services::Hooks::CallType::AFTER_ORIGINAL, targetPlayer, observerPlayer);
+    }
+    return retVal;
+}
+
+void Rename::SendServerToPlayerChatHook(
+        NWNXLib::Services::Hooks::CallType cType,
+        CNWSMessage*,
+        Types::PlayerID observerPlayerId,
+        Types::ObjectID targetOid,
+        CExoString*)
+{
+    auto *targetPlayer = Globals::AppManager()->m_pServerExoApp->GetClientObjectByObjectId(targetOid);
+    auto *client = Globals::AppManager()->m_pServerExoApp->GetClientObjectByPlayerId(observerPlayerId, 0);
+    auto *observerPlayer = static_cast<API::CNWSPlayer*>(client);
+    SetOrRestorePlayerName(cType, targetPlayer, observerPlayer);
+}
+
+void Rename::SendServerToPlayerPlayerList_AllHook(
+        Services::Hooks::CallType cType,
+        CNWSMessage*,
+        CNWSPlayer *observerPlayer)
+{
+    Rename& plugin = *g_plugin;
+    plugin.GlobalNameChange(cType, observerPlayer->m_nPlayerID, Constants::PLAYERID_ALL_PLAYERS);
+}
+
+void Rename::SendServerToPlayerPlayerList_AddHook(
+        Services::Hooks::CallType cType,
+        CNWSMessage*,
+        Types::PlayerID observerPlayerId,
+        CNWSPlayer *targetPlayer)
+{
+    if (observerPlayerId == Constants::PLAYERID_ALL_GAMEMASTERS)
+        return;
+
+    Rename& plugin = *g_plugin;
+    if (cType == Services::Hooks::CallType::AFTER_ORIGINAL)
+    {
+        auto *pPOS = g_plugin->GetServices()->m_perObjectStorage.get();
+        pPOS->Set(targetPlayer->m_nPlayerID, addedToPlayerListKey, true);
+    }
+    plugin.GlobalNameChange(cType, observerPlayerId, targetPlayer->m_nPlayerID);
+}
+
+void Rename::SendServerToPlayerPlayerList_DeleteHook(
+        Services::Hooks::CallType cType,
+        CNWSMessage*,
+        Types::PlayerID observerPlayerId,
+        CNWSPlayer *targetPlayer)
+{
+    if (observerPlayerId == Constants::PLAYERID_ALL_GAMEMASTERS)
+        return;
+
+    if (cType == Services::Hooks::CallType::BEFORE_ORIGINAL)
+    {
+        auto *pPOS = g_plugin->GetServices()->m_perObjectStorage.get();
+        pPOS->Remove(targetPlayer->m_nPlayerID, addedToPlayerListKey);
     }
 }
 
-void Rename::GlobalNameChange(bool bOriginal, CNWSPlayer* pPlayer)
+int32_t Rename::SendServerToPlayerPopUpGUIPanelHook(
+            CNWSMessage *pMessage,
+            Types::ObjectID observerOid,
+            int32_t nGuiPanel,
+            int32_t bGUIOption1,
+            int32_t bGUIOption2,
+            int32_t nStringReference,
+            CExoString *p_sStringReference)
 {
-    API::CServerExoAppInternal* server = Globals::AppManager()->m_pServerExoApp->m_pcExoAppInternal;
-    API::CExoLinkedListInternal* playerList = server->m_pNWSPlayerList->m_pcExoLinkedListInternal;
-    Services::PerObjectStorageProxy* pPOS = g_plugin->GetServices()->m_perObjectStorage.get();
-    API::CNetLayer* pNetLayer = Globals::AppManager()->m_pServerExoApp->GetNetLayer();
+    if (nGuiPanel == 1) // Party invite popup
+    {
+        auto *server = Globals::AppManager()->m_pServerExoApp;
+        auto *observerCreature = server->GetCreatureByGameObjectID(observerOid);
+        auto targetOid = observerCreature->m_oidInvitedToPartyBy;
+        Rename& plugin = *g_plugin;
+        auto *pPOS = plugin.GetServices()->m_perObjectStorage.get();
+        std::string overrideNameKeyObserver = overrideNameKey + ":" + Utils::ObjectIDToString(observerOid);
+        std::string overrideName = *pPOS->Get<std::string>(targetOid, overrideNameKeyObserver);
+        if (!overrideName.empty())
+        {
+            *p_sStringReference = CExoString(overrideName.c_str());
+        }
+        else
+        {
+            overrideName = *pPOS->Get<std::string>(targetOid, overrideNameKey + ":" + Utils::ObjectIDToString(
+                    Constants::PLAYERID_ALL_CLIENTS));
+            if (!overrideName.empty())
+            {
+                *p_sStringReference = CExoString(overrideName.c_str());
+            }
+        }
+    }
+    return m_SendServerToPlayerPopUpGUIPanelHook->CallOriginal<int32_t>(pMessage, observerOid, nGuiPanel, bGUIOption1,
+                                                                 bGUIOption2, nStringReference, p_sStringReference);
+}
+void Rename::GlobalNameChange(
+        NWNXLib::Services::Hooks::CallType cType,
+        Types::PlayerID observerPlayerId,
+        Types::PlayerID targetPlayerId)
+{
+    auto *server = Globals::AppManager()->m_pServerExoApp;
+    auto *pPOS = g_plugin->GetServices()->m_perObjectStorage.get();
+    auto *playerList = server->m_pcExoAppInternal->m_pNWSPlayerList->m_pcExoLinkedListInternal;
+    std::vector<Types::PlayerID> observersToNotify;
+    std::vector<Types::PlayerID> targetsToNotify;
+
+    if (observerPlayerId == Constants::PLAYERID_ALL_PLAYERS)
+    {
+        for (auto *head = playerList->pHead; head; head = head->pNext)
+        {
+            auto *observerClient = static_cast<API::CNWSClient*>(head->pObject);
+            observersToNotify.emplace_back(observerClient->m_nPlayerID);
+        }
+    }
+    else if (observerPlayerId != Constants::OBJECT_INVALID)
+        observersToNotify.emplace_back(observerPlayerId);
+
+    if (targetPlayerId == Constants::PLAYERID_ALL_PLAYERS)
+    {
+        for (auto *head = playerList->pHead; head; head = head->pNext)
+        {
+            auto *targetClient = static_cast<API::CNWSClient*>(head->pObject);
+            targetsToNotify.emplace_back(targetClient->m_nPlayerID);
+        }
+    }
+    else if (targetPlayerId != Constants::OBJECT_INVALID)
+        targetsToNotify.emplace_back(targetPlayerId);
 
     std::string lsFirstName;
     std::string lsLastName;
+    auto *pNetLayer = server->GetNetLayer();
 
-    //go through all the players and change their names or restore them based on bOriginal.
-    for (API::CExoLinkedListNode* head = playerList->pHead; head; head = head->pNext)
+    for (auto &observerPid : observersToNotify)
     {
-        CNWSClient* client = static_cast<API::CNWSClient*>(head->pObject);
-        Types::ObjectID pcObjectID = static_cast<CNWSPlayer*>(client)->m_oidNWSObject;
-        lsFirstName = (bOriginal) ?  *pPOS->Get<std::string>(pcObjectID,firstNameKey) :  *pPOS->Get<std::string>(pcObjectID,overrideNameKey);
-        lsLastName = (bOriginal) ?  *pPOS->Get<std::string>(pcObjectID,lastNameKey) : std::string("");
-        CNWSCreature* pCreature = server->GetCreatureByGameObjectID(pcObjectID);
+        auto *observerClient =  server->GetClientObjectByPlayerId(observerPid, 0);
+        auto *observerPlayer = static_cast<API::CNWSPlayer*>(observerClient);
 
-        if (pCreature && !lsFirstName.empty() && ( bOriginal || !pCreature->m_sDisplayName.IsEmpty()))
+        for (auto &targetPid : targetsToNotify)
         {
-            if (pPlayer != nullptr
-            //if the pPlayer pointer is null (from a party invite) or the player name override is default...
-            && static_cast<bool>(*pPOS->Get<int>(pcObjectID, playerNameOverrideStateKey))
-                //or if pPlayer is a DM...
-            && !static_cast<bool>((server->GetCreatureByGameObjectID(pPlayer->m_oidNWSObject))->m_pStats->m_bIsDM)
-                //or pCreature is pPlayer's creature object then skip changing the player name, since it's not needed or desired.
-            && pPlayer->m_oidNWSObject != pcObjectID)
+            auto *client =  server->GetClientObjectByPlayerId(targetPid, 0);
+            auto *targetPlayer = static_cast<API::CNWSPlayer*>(client);
+            auto targetOid = targetPlayer->m_oidNWSObject;
+            auto *targetCreature = server->GetCreatureByGameObjectID(targetOid);
+            if (cType == Services::Hooks::CallType::AFTER_ORIGINAL)
             {
-                if (bOriginal)
+                lsFirstName = *pPOS->Get<std::string>(targetOid, firstNameKey);
+                lsLastName = *pPOS->Get<std::string>(targetOid, lastNameKey);
+            }
+            else
+            {
+                lsFirstName = *pPOS->Get<std::string>(targetOid, overrideNameKey + ":" + Utils::ObjectIDToString(Constants::PLAYERID_ALL_CLIENTS));
+                lsLastName = std::string("");
+            }
+            if (targetCreature && !lsFirstName.empty())
+            {
+                if (static_cast<bool>(*pPOS->Get<int>(targetOid, playerNameOverrideStateKey + ":" + Utils::ObjectIDToString(Constants::PLAYERID_ALL_CLIENTS))))
                 {
-                    pNetLayer->GetPlayerInfo(client->m_nPlayerID)->m_sPlayerName = CExoString((*pPOS->Get<std::string>(pcObjectID, playerNameKey)).c_str());
-                }
-                else
-                {
-                    switch((*g_plugin->GetServices()->m_perObjectStorage->Get<int>(pcObjectID, playerNameOverrideStateKey)))
+                    auto playerInfo = pNetLayer->GetPlayerInfo(targetPid);
+                    if (cType == Services::Hooks::CallType::AFTER_ORIGINAL)
                     {
-                        case NWNX_RENAME_PLAYERNAME_OBFUSCATE  : pNetLayer->GetPlayerInfo(client->m_nPlayerID)->m_sPlayerName = CExoString(GenerateRandomPlayerName(7).c_str());
-                                  break;
-                        case NWNX_RENAME_PLAYERNAME_OVERRIDE  : pNetLayer->GetPlayerInfo(client->m_nPlayerID)->m_sPlayerName = CExoString(lsFirstName.c_str());
-                                  break;
+                        playerInfo->m_sPlayerName = CExoString((*pPOS->Get<std::string>(targetOid, playerNameKey)).c_str());
+                    }
+                    else
+                    {
+                        switch ((*pPOS->Get<int>(targetOid, playerNameOverrideStateKey + ":" + Utils::ObjectIDToString(Constants::PLAYERID_ALL_CLIENTS))))
+                        {
+                            case NWNX_RENAME_PLAYERNAME_OBFUSCATE:
+                                playerInfo->m_sPlayerName = CExoString(GenerateRandomPlayerName(7).c_str());
+                                break;
+                            case NWNX_RENAME_PLAYERNAME_OVERRIDE:
+                                playerInfo->m_sPlayerName = CExoString(lsFirstName.c_str());
+                                break;
+                        }
                     }
                 }
             }
-            pCreature->m_pStats->m_lsFirstName = ContainString(lsFirstName);
-            pCreature->m_pStats->m_lsLastName = ContainString(lsLastName);
+            if (m_RenameOnPlayerList)
+                SetOrRestorePlayerName(cType, targetPlayer, observerPlayer);
         }
     }
 }
@@ -212,97 +520,152 @@ std::string Rename::GenerateRandomPlayerName(size_t length)
     return randomPlayername;
 }
 
-void Rename::UpdateName(CNWSCreature* targetObject)
-{
-    API::CServerExoApp* server = Globals::AppManager()->m_pServerExoApp;
-    std::vector<Types::PlayerID> playersToNotify;
-
-    API::CExoLinkedListInternal* playerList = server->m_pcExoAppInternal->m_pNWSPlayerList->m_pcExoLinkedListInternal;
-
-    for (API::CExoLinkedListNode* head = playerList->pHead; head; head = head->pNext)
-    {
-        API::CNWSClient* client = static_cast<API::CNWSClient*>(head->pObject);
-        if (client)
-        {
-            playersToNotify.emplace_back(client->m_nPlayerID); //gather a list of players to iterate through and notify of the name change
-        }
-    }
-
-    API::CNWSMessage* message = server->m_pcExoAppInternal->m_pMessage;
-
-    for (auto& pid : playersToNotify)
-    {
-        API::CNWSPlayer* observerPlayerObject = static_cast<API::CNWSPlayer*>(server->GetClientObjectByPlayerId(pid, 0));
-
-        if (observerPlayerObject)
-        {
-            // Write a message notifying an object update.
-            message->CreateWriteMessage(0x400, pid, 1);
-
-            // We don't need one for our update.
-            // However, the appearance update is contingent on receiving a pointer which isn't nullptr.
-            API::CLastUpdateObject* lastUpdateObj = reinterpret_cast<API::CLastUpdateObject*>(0xDEADBEEF);
-
-            message->WriteGameObjUpdate_UpdateObject(observerPlayerObject, targetObject, lastUpdateObj, 0, 0x400);
-
-            uint8_t* data = nullptr;
-            uint32_t size = 0;
-
-            if (message->GetWriteMessage(&data, &size) && size)
-            {
-                message->SendServerToPlayerMessage(pid,
-                    API::Constants::MessageMajor::GameObjectUpdate,
-                    API::Constants::MessageGameObjectUpdateMinor::ObjectList,
-                    data, size);
-            }
-
-            // Update the player list. This handles updating the hover-over GUI elements too.
-            message->SendServerToPlayerPlayerList_All(observerPlayerObject);
-        }
-    }
-}
-
-
 ArgumentStack Rename::SetPCNameOverride(ArgumentStack&& args)
 {
-     ArgumentStack stack;
-    auto playerObjectID = Services::Events::ExtractArgument<Types::ObjectID>(args);
-    if (auto *pPlayer = player(playerObjectID))
+    ArgumentStack stack;
+    auto targetOid = Services::Events::ExtractArgument<Types::ObjectID>(args);
+    if (auto *targetPlayer = player(targetOid))
     {
-        CNWSCreature *pCreature = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(playerObjectID);
-        if (!pCreature)
+        auto *server = Globals::AppManager()->m_pServerExoApp;
+        auto *targetObject = server->GetCreatureByGameObjectID(targetOid);
+        if (targetObject == nullptr)
         {
-            LOG_ERROR("No creature object found for Player ID %x, oidNWSObject %x",
-                pPlayer->m_oidPCObject, playerObjectID);
+            LOG_ERROR("No creature object found for Player ID '0x%08x', oidNWSObject '%x'",
+                      targetPlayer->m_nPlayerID, targetOid);
             return stack;
         }
-        std::string newName = Services::Events::ExtractArgument<std::string>(args);
+        const auto newName = Services::Events::ExtractArgument<std::string>(args);
         const auto sPrefix = Services::Events::ExtractArgument<std::string>(args);
         const auto sSuffix = Services::Events::ExtractArgument<std::string>(args);
-        const auto bPlayerNameState = Services::Events::ExtractArgument<int>(args);
+        auto bPlayerNameState = Services::Events::ExtractArgument<int>(args);
+        const auto observerOid = Services::Events::ExtractArgument<Types::ObjectID>(args);
+
+        if (bPlayerNameState != NWNX_RENAME_PLAYERNAME_DEFAULT && observerOid != Constants::OBJECT_INVALID)
+        {
+            LOG_WARNING("You can not override or obfuscate a player name per target. Falling back to DEFAULT.");
+            bPlayerNameState = NWNX_RENAME_PLAYERNAME_DEFAULT;
+        }
+
+        auto *observerObject = server->GetCreatureByGameObjectID(observerOid);
+        if (observerOid != Constants::OBJECT_INVALID && observerObject == nullptr)
+        {
+            LOG_ERROR("No creature object found for target '%x'", observerOid);
+            return stack;
+        }
+
+        const auto targetPlayerId = targetPlayer->m_nPlayerID;
+        const auto observerPlayerId =
+                observerOid == Constants::OBJECT_INVALID ? Constants::PLAYERID_ALL_CLIENTS
+                                                         : server->GetPlayerIDByGameObjectID(observerOid);
+
+        if (observerPlayerId == Constants::PLAYERID_INVALIDID)
+        {
+            LOG_ERROR("The target observer '0x%08x' is not a valid player.", observerPlayerId);
+            return stack;
+        }
 
         std::string fullDisplayName = sPrefix + newName + sSuffix; //put together the floaty/chat/hover name
         fullDisplayName = std::regex_replace(fullDisplayName, std::regex("^ +| +$|( ) +"), "$1"); //remove trailing and leading spaces
 
-        pCreature->m_sDisplayName = fullDisplayName.c_str(); //sets the override floaty name, this goes away on logout/reset
-        pCreature->m_bUpdateDisplayName = true; //unsure if this is necessary, will be removed for next patch.
+        auto *pPOS = g_plugin->GetServices()->m_perObjectStorage.get();
 
-        Services::PerObjectStorageProxy* pPOS = g_plugin->GetServices()->m_perObjectStorage.get();
-        API::CNetLayerPlayerInfo* pPlayerInfo = Globals::AppManager()->m_pServerExoApp->GetNetLayer()->GetPlayerInfo(pPlayer->m_nPlayerID);
+        std::string keyLookup =
+                observerOid == Constants::OBJECT_INVALID ? Utils::ObjectIDToString(Constants::PLAYERID_ALL_CLIENTS)
+                                                         : Utils::ObjectIDToString(observerOid);
 
-        pPOS->Set(playerObjectID,overrideNameKey, newName); //store affix-less override
-        //store whether the player name should be obfuscated or overridden
-        pPOS->Set(playerObjectID,playerNameOverrideStateKey, bPlayerNameState);
-        // Store the original player name
-        pPOS->Set(playerObjectID,playerNameKey, std::string(pPlayerInfo->m_sPlayerName.CStr()));
-        //store original first name
-        pPOS->Set(playerObjectID,firstNameKey, Utils::ExtractLocString(pCreature->m_pStats->m_lsFirstName));
-        //store original last name
-        pPOS->Set(playerObjectID,lastNameKey, Utils::ExtractLocString(pCreature->m_pStats->m_lsLastName));
+        // Set our override values
+        pPOS->Set(targetOid, displayNameKey + ":" + keyLookup, fullDisplayName);
+        pPOS->Set(targetOid, overrideNameKey + ":" + keyLookup, newName);
+        pPOS->Set(targetOid, playerNameOverrideStateKey + ":" + keyLookup, bPlayerNameState);
 
-        UpdateName(pCreature); //this sends an update message to all clients.
+        // Store the original values
+        auto *pPlayerInfo = server->GetNetLayer()->GetPlayerInfo(targetPlayerId);
+        pPOS->Set(targetOid, playerNameKey, std::string(pPlayerInfo->m_sPlayerName.CStr()));
+        pPOS->Set(targetOid, firstNameKey, Utils::ExtractLocString(targetObject->m_pStats->m_lsFirstName));
+        pPOS->Set(targetOid, lastNameKey, Utils::ExtractLocString(targetObject->m_pStats->m_lsLastName));
 
+        // If we've ran this before the PC has even been added to the other clients' player list then there's
+        // nothing else we need to do, the hooks will take care of doing the renames. If we don't skip this
+        // then the SendServerToPlayerPlayerList_All below runs before the server has even ran a
+        // SendServerToPlayerPlayerList_Add and weird things happen(tm)
+        if (!*pPOS->Get<int>(targetPlayerId, addedToPlayerListKey))
+            return stack;
+
+        std::vector<Types::PlayerID> playersToNotify;
+
+        if (observerPlayerId == Constants::PLAYERID_ALL_CLIENTS)
+        {
+            // Get all the connected players except the targetPlayerId, we don't update their own name with ALL_CLIENTS
+            auto *playerList = server->m_pcExoAppInternal->m_pNWSPlayerList->m_pcExoLinkedListInternal;
+
+            for (auto *head = playerList->pHead; head; head = head->pNext)
+            {
+                auto *client = static_cast<API::CNWSClient*>(head->pObject);
+                if (client && client->m_nPlayerID != targetPlayerId)
+                    playersToNotify.emplace_back(client->m_nPlayerID);
+            }
+        }
+        else
+        {
+            playersToNotify.emplace_back(observerPlayerId);
+        }
+
+        auto *message = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
+        for (auto &pid : playersToNotify)
+        {
+            bool success = false;
+            auto *observerPlayerObject = static_cast<API::CNWSPlayer*>(server->GetClientObjectByPlayerId(pid, 0));
+
+            if (observerPlayerObject != nullptr)
+            {
+                // Write a message notifying an object update.
+                message->CreateWriteMessage(0x400, pid, 1);
+
+                // We don't need one for our update.
+                // However, the appearance update is contingent on receiving a pointer which isn't nullptr.
+                auto *lastUpdateObj = reinterpret_cast<API::CLastUpdateObject*>(0xDEADBEEF);
+                message->WriteGameObjUpdate_UpdateObject(observerPlayerObject, targetObject, lastUpdateObj, 0, 0x400);
+
+                uint8_t *data = nullptr;
+                uint32_t size = 0;
+
+                if (message->GetWriteMessage(&data, &size) && size)
+                {
+                    message->SendServerToPlayerMessage(pid, 5, 1, data, size);
+                    success = true;
+                }
+
+                if (m_RenameOnPlayerList)
+                    message->SendServerToPlayerPlayerList_All(observerPlayerObject);
+            }
+            LOG_DEBUG("%s sending name update message for observer (PlayerID): '0x%08x', target (ObjectID): '0x%08x'.",
+                                                  success ? "Succeeded" : "Failed", pid, targetOid);
+        }
     }
+    return stack;
+}
+
+ArgumentStack Rename::GetPCNameOverride(ArgumentStack &&args)
+{
+    ArgumentStack stack;
+    auto playerObjectID = Services::Events::ExtractArgument<Types::ObjectID>(args);
+    std::string retVal;
+    if (auto *pPlayer = player(playerObjectID))
+    {
+        auto *pCreature = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(playerObjectID);
+        if (!pCreature)
+        {
+            LOG_ERROR("No creature object found for Player ID %x, oidNWSObject %x",
+                      pPlayer->m_oidPCObject, playerObjectID);
+            return stack;
+        }
+        auto targetId = Services::Events::ExtractArgument<Types::ObjectID>(args);
+        if (targetId == Constants::OBJECT_INVALID)
+            targetId = Constants::PLAYERID_ALL_CLIENTS;
+        auto *pPOS = g_plugin->GetServices()->m_perObjectStorage.get();
+        retVal = *pPOS->Get<std::string>(playerObjectID, displayNameKey + ":" + Utils::ObjectIDToString(targetId));
+    }
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 

--- a/Plugins/Rename/Rename.hpp
+++ b/Plugins/Rename/Rename.hpp
@@ -4,13 +4,11 @@
 #include "Services/Hooks/Hooks.hpp"
 #include "Services/Events/Events.hpp"
 #include "API/Types.hpp"
-#include "API/CNWSPlayer.hpp"
-#include "API/CNWSMessage.hpp"
 #include "Common.hpp"
-#include "API/CExoLocString.hpp"
 #include "ViewPtr.hpp"
 
-#include <unordered_map>
+using namespace NWNXLib;
+using namespace NWNXLib::API;
 
 using ArgumentStack = NWNXLib::Services::Events::ArgumentStack;
 
@@ -23,20 +21,64 @@ public:
     virtual ~Rename();
 
 private:
+    int32_t m_RenameOnModuleCharList;
+    bool m_RenameOnPlayerList;
 
-    static void HookPlayerList(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer* pPlayer);
-    static void HookPartyInvite(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*, unsigned char);
+    static void WriteGameObjUpdate_UpdateObjectHook(
+            Services::Hooks::CallType,
+            CNWSMessage*,
+            CNWSPlayer*,
+            CNWSObject*,
+            CLastUpdateObject*,
+            uint32_t,
+            uint32_t);
+    static void SendServerToPlayerPlayerList_AllHook(
+            NWNXLib::Services::Hooks::CallType,
+            CNWSMessage*,
+            CNWSPlayer*);
+    static void SendServerToPlayerPlayerList_AddHook(
+            NWNXLib::Services::Hooks::CallType,
+            CNWSMessage*,
+            Types::PlayerID,
+            CNWSPlayer*);
+    static void SendServerToPlayerPlayerList_DeleteHook(
+            NWNXLib::Services::Hooks::CallType,
+            CNWSMessage*,
+            Types::PlayerID,
+            CNWSPlayer*);
+    static void SendServerToPlayerExamineGui_CreatureDataHook(
+            Services::Hooks::CallType,
+            CNWSMessage*,
+            CNWSPlayer*,
+            Types::ObjectID);
+    static int32_t SendServerToPlayerPlayModuleCharacterListResponseHook(
+            CNWSMessage*,
+            Types::PlayerID,
+            Types::ObjectID,
+            int32_t);
+    static void SendServerToPlayerChatHook(
+            NWNXLib::Services::Hooks::CallType,
+            CNWSMessage*,
+            Types::PlayerID,
+            Types::ObjectID,
+            CExoString*);
+    static int32_t SendServerToPlayerPopUpGUIPanelHook(
+            CNWSMessage*,
+            Types::ObjectID,
+            int32_t, int32_t, int32_t, int32_t, CExoString*);
 
-    NWNXLib::API::CExoLocString ContainString(const std::string& str);
-    std::string ExtractString(NWNXLib::API::CExoLocString& locStr);
+    static void SetOrRestorePlayerName(NWNXLib::Services::Hooks::CallType, CNWSPlayer*, CNWSPlayer*);
+    static void SetPlayerNameAsObservedBy(CNWSCreature *targetCreature, Types::ObjectID);
+    static void RestorePlayerName(CNWSCreature *targetCreature);
+    void GlobalNameChange(NWNXLib::Services::Hooks::CallType, Types::PlayerID, Types::PlayerID);
+
+    CExoLocString ContainString(const std::string& str);
     std::string GenerateRandomPlayerName(size_t length);
 
-    void GlobalNameChange(bool bOriginal, NWNXLib::API::CNWSPlayer* pPlayer);
-    void UpdateName(NWNXLib::API::CNWSCreature* targetObject);
-
     ArgumentStack SetPCNameOverride(ArgumentStack&& args);
+    ArgumentStack GetPCNameOverride(ArgumentStack&& args);
 
-    NWNXLib::API::CNWSPlayer *player(NWNXLib::API::Types::ObjectID playerId);
+    CNWSPlayer *player(Types::ObjectID playerId);
 };
 
 }


### PR DESCRIPTION
Builders can now add an optional target to the `NWNX_Rename_SetPCNameOverride` and only the target will see the PC's name as defined. This setting will override any global rename.

This resolves #370 as well as fixing the example issue reported in #397 (only because we don't use that hook any more). When Exclusive hooks call Shared hooks some code will be able to be simplified.

Added a couple configuration variables:
`NWNX_RENAME_ON_PLAYER_LIST` - For our module we prefer the player list show the true names, it's only the chat/feedback/name above their head that's important. Default is `true`.
`NWNX_RENAME_ON_MODULE_CHAR_LIST` - This is the listing of players from the character selection screen before entering the server. Setting the value to `1` overrides their names if a global rename has been set, `2` also hides class information, `3` hides class information but keeps names as their original. Since we use the same hook as in Tweaks [HideClassesOnCharList](https://github.com/nwnxee/unified/blob/master/Plugins/Tweaks/Tweaks/HideClassesOnCharList.cpp) . I've copied its code for people who need both these features. Default is `0` which does nothing at that screen.

Added a sample include and db structure to the [README.md](https://github.com/plenarius/unified/blob/1fac401078aac8c4c9f8dea2c1fea117dc066b1d/Plugins/Rename/Documentation/README.md), that may belong in a better place like a wiki or such.

I thought it might be better to separate the PC Name and the Player Name functionality into two separate commands but I didn't want to break backwards compatibility.
