### PR TITLE
Area: CreateTransition()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The following plugins were added:
 - Area: GetDayNightCycle()
 - Area: SetDayNightCycle()
 - Area: SetSunMoonColors()
+- Area: CreateTransition()
 - Creature: GetAttackBonus()
 - Creature: GetFeatRemainingUses()
 - Creature: GetFeatTotalUses()

--- a/Plugins/Area/Area.cpp
+++ b/Plugins/Area/Area.cpp
@@ -542,7 +542,7 @@ ArgumentStack Area::CreateTransition(ArgumentStack&& args)
         vTransitionPosition.z = Services::Events::ExtractArgument<float>(args);
 
         const auto size = Services::Events::ExtractArgument<float>(args);
-        ASSERT_OR_THROW(size >= 0.0f);
+        ASSERT_OR_THROW(size > 0.0f);
         ASSERT_OR_THROW(vTransitionPosition.x + size < pArea->m_nWidth * 10.0f);
         ASSERT_OR_THROW(vTransitionPosition.y + size < pArea->m_nHeight * 10.0f);
 

--- a/Plugins/Area/Area.hpp
+++ b/Plugins/Area/Area.hpp
@@ -37,6 +37,7 @@ private:
     ArgumentStack GetDayNightCycle          (ArgumentStack&& args);
     ArgumentStack SetDayNightCycle          (ArgumentStack&& args);
     ArgumentStack SetSunMoonColors          (ArgumentStack&& args);
+    ArgumentStack CreateTransition          (ArgumentStack&& args);
 
     NWNXLib::API::CNWSArea *area(ArgumentStack& args);
 

--- a/Plugins/Area/Documentation/README.md
+++ b/Plugins/Area/Documentation/README.md
@@ -2,6 +2,6 @@
 
 ## Description
 
-Functions exposing additional area properties.
+Functions exposing additional area properties as well as creating transitions.
 
 ## Environment Variables

--- a/Plugins/Area/NWScript/nwnx_area.nss
+++ b/Plugins/Area/NWScript/nwnx_area.nss
@@ -103,6 +103,11 @@ void NWNX_Area_SetDayNightCycle(object area, int type);
 // DD would represent the amount of blue in the color.
 void NWNX_Area_SetSunMoonColors(object area, int type, int color);
 
+// Create and returns a transition (square shaped of specified size) at a location
+// Valid object types for the target are DOOR or WAYPOINT.
+// If a tag is specified the returning object will have that tag
+object NWNX_Area_CreateTransition(object area, object target, float x, float y, float z, float size = 2.0f, string tag="");
+
 
 const string NWNX_Area = "NWNX_Area";
 
@@ -319,4 +324,20 @@ void NWNX_Area_SetSunMoonColors(object area, int type, int color)
     NWNX_PushArgumentInt(NWNX_Area, sFunc, type);
     NWNX_PushArgumentObject(NWNX_Area, sFunc, area);
     NWNX_CallFunction(NWNX_Area, sFunc);
+}
+
+object NWNX_Area_CreateTransition(object area, object target, float x, float y, float z, float size = 2.0f, string tag="")
+{
+    string sFunc = "CreateTransition";
+
+    NWNX_PushArgumentString(NWNX_Area, sFunc, tag);
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, size);
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, z);
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, y);
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, x);
+    NWNX_PushArgumentObject(NWNX_Area, sFunc, target);
+    NWNX_PushArgumentObject(NWNX_Area, sFunc, area);
+    NWNX_CallFunction(NWNX_Area, sFunc);
+
+    return NWNX_GetReturnValueObject(NWNX_Area, sFunc);
 }

--- a/Plugins/Area/NWScript/nwnx_area_t.nss
+++ b/Plugins/Area/NWScript/nwnx_area_t.nss
@@ -55,6 +55,11 @@ void main()
 
         NWNX_Area_SetDayNightCycle(oArea, NWNX_AREA_DAYNIGHTCYCLE_ALWAYS_DARK);
         report("{Set/Get}DayNightCycle", NWNX_Area_GetDayNightCycle(oArea) == NWNX_AREA_DAYNIGHTCYCLE_ALWAYS_DARK);
+
+        vector vLoc = GetPositionFromLocation(GetStartingLocation());
+        object oWP = CreateObject(OBJECT_TYPE_WAYPOINT, "nw_waypoint001", GetStartingLocation());
+        object oAT = NWNX_Area_CreateTransition(oArea, oWP, vLoc.x, vLoc.y, vLoc.z);
+        report ("CreateTransition", oAT != OBJECT_INVALID);
     }
     else
     {


### PR DESCRIPTION
There really is no restriction on what kind of object the transition can be directed to. I thought for a moment to allow for more valid object types like placeables, other triggers or even creatures but figured I'd leave it for its intended purpose.