### PR TITLE
Redis plugin documentation addition

### DIFF
--- a/Plugins/Redis/Documentation/README.md
+++ b/Plugins/Redis/Documentation/README.md
@@ -18,12 +18,38 @@ TODO:
 ## Hints
 
 * There are two includes, `nwnx_redis` and `nwnx_redis_short`. They do the same, but `_short` is not prefixed with `NWNX_Redis`.
+* `nwnx_redis_ps.nss` and `on_pubsub.nss` are not needed if PubSub functionality is not being used.
 
-## Getting started with PubSub
+## Setup
 
 * Set up redis-server. Start it. This should be as simple as apt-get install redis. There's also a docker image.
 * Configure `NWNX_REDIS_HOST` and `NWNX_REDIS_PORT` for nwnx. `NWNX_REDIS_PORT` is not necessary if the default redis port is used.
 * Include the .nss files in NWScript/ into your module.
+
+## Accessing Redis from nwscript
+
+To use Redis commands in nwscript include `nwnx_redis` and `nwnx_redis_lib`. The nwnx_redis include contains the redis commands like, for example, `int NWNX_Redis_GET(string key)`. All of the nwnx redis comands return an int which is the resultId. The nwnx_redis_lib include contains functions to get the data (and type) you can work with for this resultId. Three of these functions are:
+* int NWNX_Redis_GetResultAsInt(int resultId)
+* string NWNX_Redis_GetResultAsString(int resultId)
+* float NWNX_Redis_GetResultAsFloat(int resultId)
+
+There are also functions to work with result arrays and one to get the type of a result. You can look those up in [nwnx_redis_lib.nss](../NWScript/nwnx_redis_lib.nss).
+
+`NWNX_Redis_GetResultAs<Type>` has to be called on all the commands that return a resultId even if the actual value is an int as well. The following is an example to set, check for existance of and get a key.
+```c
+#include "nwnx_redis"
+#include "nwnx_redis_lib"
+
+NWNX_Redis_SET("examples:examplekey", "testvalue");
+if (NWNX_Redis_GetResultAsInt(NWNX_Redis_EXISTS("examples:examplekey")))
+{
+  string sValue = NWNX_Redis_GetResultAsString(NWNX_Redis_GET("examples:examplekey"));
+  WriteTimestampedLogEntry("Value of redis key 'examples:examplekey': " + sValue);
+}
+```
+
+## Getting started with PubSub
+
 * Create a script called "on_pubsub" (or rename it through `NWNX_REDIS_PUBSUB_SCRIPT`). An example is included in NWScript/.
 * Configure `NWNX_REDIS_PUBSUB_CHANNELS` to be "test".
 * Hint: Subscriptions support wildcards.


### PR DESCRIPTION
Added a section about using Redis commands and moved the first three steps from PubSub to a new section called Setup, which comes before the other two and is relevant for both of them.