### PR TITLE
Util: {Get|Set}MinutesPerHour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,8 @@ The following plugins were added:
 - Util: ItemPropertyToEffect()
 - Util: StripColors()
 - Util: IsValidResRef()
+- Util: GetMinutesPerHour()
+- Util: SetMinutesPerHour()
 - Visibility: GetVisibilityOverride()
 - Visibility: SetVisibilityOverride()
 - Weapon: SetWeaponIsMonkWeapon()

--- a/Plugins/Util/NWScript/nwnx_util.nss
+++ b/Plugins/Util/NWScript/nwnx_util.nss
@@ -38,6 +38,10 @@ string NWNX_Util_StripColors(string str);
 int NWNX_Util_IsValidResRef(string resref, int type = NWNX_UTIL_RESREF_TYPE_CREATURE);
 // Retrieve an environment variable
 string NWNX_Util_GetEnvironmentVariable(string sVarname);
+// Gets the module real life minutes per in game hour
+int NWNX_Util_GetMinutesPerHour();
+// Set module real life minutes per in game hour
+void NWNX_Util_SetMinutesPerHour(int minutes);
 
 
 const string NWNX_Util = "NWNX_Util";
@@ -120,4 +124,18 @@ string NWNX_Util_GetEnvironmentVariable(string sVarname)
     NWNX_PushArgumentString(NWNX_Util, sFunc, sVarname);
     NWNX_CallFunction(NWNX_Util, sFunc);
     return NWNX_GetReturnValueString(NWNX_Util, sFunc);
+}
+
+int NWNX_Util_GetMinutesPerHour()
+{
+    string sFunc = "GetMinutesPerHour";
+    NWNX_CallFunction(NWNX_Util, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Util, sFunc);
+}
+
+void NWNX_Util_SetMinutesPerHour(int minutes)
+{
+    string sFunc = "SetMinutesPerHour";
+    NWNX_PushArgumentInt(NWNX_Util, sFunc, minutes);
+    NWNX_CallFunction(NWNX_Util, sFunc);
 }

--- a/Plugins/Util/NWScript/nwnx_util_t.nss
+++ b/Plugins/Util/NWScript/nwnx_util_t.nss
@@ -49,5 +49,10 @@ void main()
     string sEnvVar = "NWNX_CORE_LOG_LEVEL";
     report("GetEnvironmentVariable", StringToInt(NWNX_Util_GetEnvironmentVariable(sEnvVar)) > 0);
 
+    int nMinsPerHour = NWNX_Util_GetMinutesPerHour();
+    report("GetMinutesPerHour", nMinsPerHour > 0);
+    NWNX_Util_SetMinutesPerHour(30);
+    report("SetMinutesPerHour", NWNX_Util_GetMinutesPerHour() == 30);
+
     WriteTimestampedLogEntry("NWNX_Util unit test end.");
 }

--- a/Plugins/Util/Util.cpp
+++ b/Plugins/Util/Util.cpp
@@ -8,6 +8,9 @@
 #include "API/CVirtualMachine.hpp"
 #include "API/CTlkTable.hpp"
 #include "API/CTlkTableTokenCustom.hpp"
+#include "API/CAppManager.hpp"
+#include "API/CServerExoApp.hpp"
+#include "API/CWorldTimer.hpp"
 #include "Utils.hpp"
 #include "ViewPtr.hpp"
 
@@ -58,6 +61,8 @@ Util::Util(const Plugin::CreateParams& params)
     REGISTER(StripColors);
     REGISTER(IsValidResRef);
     REGISTER(GetEnvironmentVariable);
+    REGISTER(GetMinutesPerHour);
+    REGISTER(SetMinutesPerHour);
 
 #undef REGISTER
 
@@ -192,9 +197,29 @@ ArgumentStack Util::IsValidResRef(ArgumentStack&& args)
     return stack;
 }
 
-ArgumentStack Util::GetEnvironmentVariable(ArgumentStack&& args) {
+ArgumentStack Util::GetEnvironmentVariable(ArgumentStack&& args)
+{
     ArgumentStack stack;
     Services::Events::InsertArgument(stack, std::getenv(Services::Events::ExtractArgument<std::string>(args).c_str()));
+    return stack;
+}
+
+ArgumentStack Util::GetMinutesPerHour(ArgumentStack&&)
+{
+    ArgumentStack stack;
+
+    Services::Events::InsertArgument(stack,Globals::AppManager()->m_pServerExoApp->GetWorldTimer()->m_nMinutesPerHour);
+    return stack;
+}
+
+ArgumentStack Util::SetMinutesPerHour(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    const auto minPerHour = Services::Events::ExtractArgument<int32_t>(args);
+    ASSERT_OR_THROW(minPerHour > 0);
+    ASSERT_OR_THROW(minPerHour <= 255);
+
+    Globals::AppManager()->m_pServerExoApp->GetWorldTimer()->SetMinutesPerHour(minPerHour);
     return stack;
 }
 

--- a/Plugins/Util/Util.hpp
+++ b/Plugins/Util/Util.hpp
@@ -24,6 +24,8 @@ private:
     ArgumentStack StripColors(ArgumentStack&& args);
     ArgumentStack IsValidResRef(ArgumentStack&& args);
     ArgumentStack GetEnvironmentVariable(ArgumentStack&& args);
+    ArgumentStack GetMinutesPerHour(ArgumentStack&& args);
+    ArgumentStack SetMinutesPerHour(ArgumentStack&& args);
 };
 
 }


### PR DESCRIPTION
This was added mainly to correct [this bug](https://support.baldursgate.com/issues/39932) when setting the exact minute of the in game time.

You can now do something like:
```
NWNX_Util_SetMinutesPerHour(60);
SetTime(0,47,0,0);
NWNX_Util_SetMinutesPerHour(15);
```
However I could see some modules preferring to speed up/slow down the passing of in game time for some reasons.

As an aside I'm starting to wonder if a `Module` plugin should be created and move these functions, `GetCustomToken`, `IsValidResRef` and future `Module` related commands into that instead.