### PR TITLE
Events: Trap On Enter

### DIFF
--- a/Plugins/Events/Events/TrapEvents.cpp
+++ b/Plugins/Events/Events/TrapEvents.cpp
@@ -1,5 +1,6 @@
 #include "Events/TrapEvents.hpp"
 #include "API/CNWSCreature.hpp"
+#include "API/CNWSTrigger.hpp"
 #include "API/CNWSObjectActionNode.hpp"
 #include "API/Functions.hpp"
 #include "Plugin.hpp"
@@ -16,6 +17,7 @@ static NWNXLib::Hooking::FunctionHook* m_AIActionExamineTrapHook = nullptr;
 static NWNXLib::Hooking::FunctionHook* m_AIActionFlagTrapHook = nullptr;
 static NWNXLib::Hooking::FunctionHook* m_AIActionRecoverTrapHook = nullptr;
 static NWNXLib::Hooking::FunctionHook* m_AIActionSetTrapHook = nullptr;
+static NWNXLib::Hooking::FunctionHook* m_OnEnterTrapHook = nullptr;
 
 TrapEvents::TrapEvents(ViewPtr<Services::HooksProxy> hooker)
 {
@@ -29,7 +31,9 @@ TrapEvents::TrapEvents(ViewPtr<Services::HooksProxy> hooker)
         hooker->RequestExclusiveHook<API::Functions::CNWSCreature__AIActionRecoverTrap, uint32_t, API::CNWSCreature*, API::CNWSObjectActionNode*>(&AIActionRecoverTrapHook);
         m_AIActionRecoverTrapHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__AIActionRecoverTrap);
         hooker->RequestExclusiveHook<API::Functions::CNWSCreature__AIActionSetTrap, uint32_t, API::CNWSCreature*, API::CNWSObjectActionNode*>(&AIActionSetTrapHook);
-        m_AIActionSetTrapHook =  hooker->FindHookByAddress(API::Functions::CNWSCreature__AIActionSetTrap);
+        m_AIActionSetTrapHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__AIActionSetTrap);
+        hooker->RequestExclusiveHook<API::Functions::CNWSTrigger__OnEnterTrap, void, API::CNWSTrigger*, int32_t>(&OnEnterTrapHook);
+        m_OnEnterTrapHook = hooker->FindHookByAddress(API::Functions::CNWSTrigger__OnEnterTrap);
     });
 }
 
@@ -96,6 +100,25 @@ uint32_t TrapEvents::AIActionSetTrapHook(
         CNWSObjectActionNode *pNode)
 {
     return HandleTrapHook("SET", m_AIActionSetTrapHook, pCreature, pNode);
+}
+
+void TrapEvents::OnEnterTrapHook(CNWSTrigger *pTrigger, int32_t bForceSet)
+{
+    Events::PushEventData("TRAP_OBJECT_ID", Utils::ObjectIDToString(pTrigger->m_idSelf));
+    Events::PushEventData("TRAP_FORCE_SET", std::to_string(bForceSet));
+
+    std::string forceSet;
+    if (Events::SignalEvent("NWNX_ON_TRAP_ENTER_BEFORE", pTrigger->m_oidLastEntered, &forceSet))
+    {
+        m_OnEnterTrapHook->CallOriginal<void>(pTrigger, bForceSet);
+    }
+    else if (!forceSet.empty())
+    {
+        m_OnEnterTrapHook->CallOriginal<void>(pTrigger, forceSet == "1");
+    }
+
+    Events::PushEventData("TRAP_OBJECT_ID", Utils::ObjectIDToString(pTrigger->m_idSelf));
+    Events::SignalEvent("NWNX_ON_TRAP_ENTER_AFTER", pTrigger->m_oidLastEntered);
 }
 
 }

--- a/Plugins/Events/Events/TrapEvents.cpp
+++ b/Plugins/Events/Events/TrapEvents.cpp
@@ -21,13 +21,13 @@ TrapEvents::TrapEvents(ViewPtr<Services::HooksProxy> hooker)
 {
     Events::InitOnFirstSubscribe("NWNX_ON_TRAP_.*", [hooker]() {
         hooker->RequestExclusiveHook<API::Functions::CNWSCreature__AIActionDisarmTrap, uint32_t, API::CNWSCreature*, API::CNWSObjectActionNode*>(&AIActionDisarmTrapHook);
-        m_AIActionDisarmTrapHook =  hooker->FindHookByAddress(API::Functions::CNWSCreature__AIActionDisarmTrap);
+        m_AIActionDisarmTrapHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__AIActionDisarmTrap);
         hooker->RequestExclusiveHook<API::Functions::CNWSCreature__AIActionExamineTrap, uint32_t, API::CNWSCreature*, API::CNWSObjectActionNode*>(&AIActionExamineTrapHook);
-        m_AIActionExamineTrapHook =  hooker->FindHookByAddress(API::Functions::CNWSCreature__AIActionExamineTrap);
+        m_AIActionExamineTrapHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__AIActionExamineTrap);
         hooker->RequestExclusiveHook<API::Functions::CNWSCreature__AIActionFlagTrap, uint32_t, API::CNWSCreature*, API::CNWSObjectActionNode*>(&AIActionFlagTrapHook);
-        m_AIActionFlagTrapHook =  hooker->FindHookByAddress(API::Functions::CNWSCreature__AIActionFlagTrap);
+        m_AIActionFlagTrapHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__AIActionFlagTrap);
         hooker->RequestExclusiveHook<API::Functions::CNWSCreature__AIActionRecoverTrap, uint32_t, API::CNWSCreature*, API::CNWSObjectActionNode*>(&AIActionRecoverTrapHook);
-        m_AIActionRecoverTrapHook =  hooker->FindHookByAddress(API::Functions::CNWSCreature__AIActionRecoverTrap);
+        m_AIActionRecoverTrapHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__AIActionRecoverTrap);
         hooker->RequestExclusiveHook<API::Functions::CNWSCreature__AIActionSetTrap, uint32_t, API::CNWSCreature*, API::CNWSObjectActionNode*>(&AIActionSetTrapHook);
         m_AIActionSetTrapHook =  hooker->FindHookByAddress(API::Functions::CNWSCreature__AIActionSetTrap);
     });

--- a/Plugins/Events/Events/TrapEvents.hpp
+++ b/Plugins/Events/Events/TrapEvents.hpp
@@ -17,6 +17,7 @@ private:
     static uint32_t AIActionFlagTrapHook(NWNXLib::API::CNWSCreature *pCreature, NWNXLib::API::CNWSObjectActionNode *pNode);
     static uint32_t AIActionRecoverTrapHook(NWNXLib::API::CNWSCreature *pCreature, NWNXLib::API::CNWSObjectActionNode *pNode);
     static uint32_t AIActionSetTrapHook(NWNXLib::API::CNWSCreature *pCreature, NWNXLib::API::CNWSObjectActionNode *pNode);
+    static void OnEnterTrapHook(NWNXLib::API::CNWSTrigger *pTrigger, int32_t bForceSet);
 
 };
 

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -624,6 +624,8 @@
 ////////////////////////////////////////////////////////////////////////////////
     NWNX_ON_TRAP_DISARM_BEFORE
     NWNX_ON_TRAP_DISARM_AFTER
+    NWNX_ON_TRAP_ENTER_BEFORE
+    NWNX_ON_TRAP_ENTER_AFTER
     NWNX_ON_TRAP_EXAMINE_BEFORE
     NWNX_ON_TRAP_EXAMINE_AFTER
     NWNX_ON_TRAP_FLAG_BEFORE
@@ -638,7 +640,8 @@
     Event data:
         Variable Name     Type        Notes
         TRAP_OBJECT_ID    object      Convert to object with NWNX_Object_StringToObject()
-        ACTION_RESULT     int
+        TRAP_FORCE_SET    int         TRUE/FALSE, only in ENTER events
+        ACTION_RESULT     int         TRUE/FALSE, only in _AFTER events (not ENTER)
 *///////////////////////////////////////////////////////////////////////////////
 
 /*
@@ -703,7 +706,7 @@ void NWNX_Events_SkipEvent();
 // - Listen/Spot Detection events -> "1" or "0"
 // - OnClientConnectBefore -> Reason for disconnect if skipped
 // - Ammo Reload event -> Forced ammunition returned
-// - Trap events
+// - Trap events -> "1" or "0"
 void NWNX_Events_SetEventResult(string data);
 
 // Returns the current event name


### PR DESCRIPTION
Resolves #34. Builders can do something like below to force the trap to fire regardless of any checks

```c
    string sCurrentEvent = NWNX_Events_GetCurrentEvent();
    if (sCurrentEvent == "NWNX_ON_TRAP_ENTER_BEFORE")
    {
        NWNX_Events_SetEventResult("1");
        NWNX_Events_SkipEvent();
    }
```