### PR TITLE
Events: TimingBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Added string localization support. Only Russian/Cyrillic supported at the moment. Use environment variable `NWNX_CORE_LOCALE=ru`
 - Core: Allow changing default plugin state from 'load all' to 'skip all' with the following environment variable: `NWNX_CORE_SKIP_ALL=y`. Use `NWNX_PLUGIN_SKIP=n` to enable specific plugins in this case.
 - Core: Allow passing engine structures to nwnx (Effect/Itemproperty)
-- Events: New events: SkillEvents, MapEvents, EffectEvents, QuickChatEvents, InventoryEvents, BarterEvents, TrapEvents
+- Events: New events: SkillEvents, MapEvents, EffectEvents, QuickChatEvents, InventoryEvents, BarterEvents, TrapEvents, TimingBarEvents
 - Events: The following events are now skippable: FeatEvents, ItemEvents, HealersKitEvents, CombatModeEvents, PartyEvents, SkillEvents, MapEvents, PolymorphEvents, DMActionEvents, ClientConnectEvents, SpellEvents, QuickChatEvents, InventoryEvents, BarterEvents (START only), TrapEvents
 - Events: You can now get the current event name with a nwscript function
 - Events: Added On{Listen/Spot}Detection events to StealthEvents
@@ -26,6 +26,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Events: Added Run{Un}Equip events to ItemEvents
 - Events: Added Barter Start/End events
 - Events: Added AIAction{Disarm|Examine|Flag|Recover|Set}Trap events
+- Events: Added Timing Bar events
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite
 - Tweaks: DisableQuickSave

--- a/Plugins/Events/CMakeLists.txt
+++ b/Plugins/Events/CMakeLists.txt
@@ -18,4 +18,5 @@ add_plugin(Events
     "Events/EffectEvents.cpp"
     "Events/QuickChatEvents.cpp"
     "Events/InventoryEvents.cpp"
-    "Events/TrapEvents.cpp")
+    "Events/TrapEvents.cpp"
+    "Events/TimingBarEvents.cpp")

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -22,6 +22,7 @@
 #include "Events/QuickChatEvents.hpp"
 #include "Events/InventoryEvents.hpp"
 #include "Events/TrapEvents.hpp"
+#include "Events/TimingBarEvents.hpp"
 #include "Services/Config/Config.hpp"
 #include "Services/Messaging/Messaging.hpp"
 #include "ViewPtr.hpp"
@@ -100,6 +101,7 @@ Events::Events(const Plugin::CreateParams& params)
     m_quickChatEvents   = std::make_unique<QuickChatEvents>(GetServices()->m_hooks);
     m_inventoryEvents   = std::make_unique<InventoryEvents>(GetServices()->m_hooks);
     m_trapEvents        = std::make_unique<TrapEvents>(GetServices()->m_hooks);
+    m_timingBarEvents   = std::make_unique<TimingBarEvents>(GetServices()->m_hooks);
 }
 
 Events::~Events()

--- a/Plugins/Events/Events.hpp
+++ b/Plugins/Events/Events.hpp
@@ -29,6 +29,7 @@ class EffectEvents;
 class QuickChatEvents;
 class InventoryEvents;
 class TrapEvents;
+class TimingBarEvents;
 
 class Events : public NWNXLib::Plugin
 {
@@ -106,6 +107,7 @@ private:
     std::unique_ptr<QuickChatEvents> m_quickChatEvents;
     std::unique_ptr<InventoryEvents> m_inventoryEvents;
     std::unique_ptr<TrapEvents> m_trapEvents;
+    std::unique_ptr<TimingBarEvents> m_timingBarEvents;
 };
 
 }

--- a/Plugins/Events/Events/TimingBarEvents.cpp
+++ b/Plugins/Events/Events/TimingBarEvents.cpp
@@ -1,0 +1,57 @@
+#include "Events/TimingBarEvents.hpp"
+#include "API/CNWSPlayer.hpp"
+#include "API/Functions.hpp"
+#include "Events.hpp"
+
+namespace Events {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+using namespace NWNXLib::Services;
+
+TimingBarEvents::TimingBarEvents(ViewPtr<HooksProxy> hooker)
+{
+    Events::InitOnFirstSubscribe("NWNX_ON_TIMING_BAR_.*", [hooker]() {
+        hooker->RequestSharedHook<API::Functions::CNWSMessage__SendServerToPlayerGuiTimingEvent, int32_t,
+                CNWSMessage*, CNWSPlayer*, int32_t, uint8_t, uint32_t>(&SendServerToPlayerGuiTimingEventHook);
+        hooker->RequestSharedHook<API::Functions::CNWSMessage__HandlePlayerToServerInputCancelGuiTimingEvent, int32_t,
+                CNWSMessage*, CNWSPlayer*>(&HandlePlayerToServerInputCancelGuiTimingEventHook);
+    });
+}
+
+void TimingBarEvents::SendServerToPlayerGuiTimingEventHook(
+        Hooks::CallType type,
+        CNWSMessage*,
+        CNWSPlayer* player,
+        int32_t starting,
+        uint8_t eventId,
+        uint32_t duration)
+{
+    const bool before = type == Services::Hooks::CallType::BEFORE_ORIGINAL;
+
+    if (starting)
+    {
+        Events::PushEventData("EVENT_ID", std::to_string(eventId));
+        Events::PushEventData("DURATION", std::to_string(duration));
+        Events::SignalEvent(before ? "NWNX_ON_TIMING_BAR_START_BEFORE" : "NWNX_ON_TIMING_BAR_START_AFTER",
+                            player->m_oidNWSObject);
+    }
+    else
+    {
+        Events::SignalEvent(before ? "NWNX_ON_TIMING_BAR_STOP_BEFORE" : "NWNX_ON_TIMING_BAR_STOP_AFTER",
+                            player->m_oidNWSObject);
+    }
+}
+
+void TimingBarEvents::HandlePlayerToServerInputCancelGuiTimingEventHook(
+        Hooks::CallType type,
+        CNWSMessage*,
+        CNWSPlayer* player)
+{
+    const bool before = type == Services::Hooks::CallType::BEFORE_ORIGINAL;
+
+    Events::SignalEvent(before ? "NWNX_ON_TIMING_BAR_CANCEL_BEFORE" : "NWNX_ON_TIMING_BAR_CANCEL_AFTER",
+                        player->m_oidNWSObject);
+}
+
+}

--- a/Plugins/Events/Events/TimingBarEvents.hpp
+++ b/Plugins/Events/Events/TimingBarEvents.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "Common.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include "ViewPtr.hpp"
+
+namespace Events {
+
+class TimingBarEvents
+{
+public:
+    TimingBarEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
+
+private:
+    static void HandlePlayerToServerInputCancelGuiTimingEventHook(
+            NWNXLib::Services::Hooks::CallType,
+            NWNXLib::API::CNWSMessage*,
+            NWNXLib::API::CNWSPlayer*);
+    static void SendServerToPlayerGuiTimingEventHook(
+            NWNXLib::Services::Hooks::CallType,
+            NWNXLib::API::CNWSMessage*,
+            NWNXLib::API::CNWSPlayer*,
+            int32_t, uint8_t, uint32_t);
+};
+
+}

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -642,6 +642,21 @@
         TRAP_OBJECT_ID    object      Convert to object with NWNX_Object_StringToObject()
         TRAP_FORCE_SET    int         TRUE/FALSE, only in ENTER events
         ACTION_RESULT     int         TRUE/FALSE, only in _AFTER events (not ENTER)
+////////////////////////////////////////////////////////////////////////////////
+    NWNX_ON_TIMING_BAR_START_BEFORE
+    NWNX_ON_TIMING_BAR_START_AFTER
+    NWNX_ON_TIMING_BAR_STOP_BEFORE
+    NWNX_ON_TIMING_BAR_STOP_AFTER
+    NWNX_ON_TIMING_BAR_CANCEL_BEFORE
+    NWNX_ON_TIMING_BAR_CANCEL_AFTER
+
+    Usage:
+        OBJECT_SELF = The player the timing bar is for
+
+    Event data:
+        Variable Name     Type        Notes
+        EVENT_ID          int         The type of timing bar, see constants below, only in _START_ events
+        DURATION          int         Length of time (in milliseconds) the bar is set to last, only in _START_ events
 *///////////////////////////////////////////////////////////////////////////////
 
 /*
@@ -652,6 +667,18 @@ const int NWNX_EVENTS_OBJECT_TYPE_PLACEABLE         = 9;
 const int NWNX_EVENTS_OBJECT_TYPE_WAYPOINT          = 12;
 const int NWNX_EVENTS_OBJECT_TYPE_ENCOUNTER         = 13;
 const int NWNX_EVENTS_OBJECT_TYPE_PORTAL            = 15;
+*/
+
+/*
+const int NWNX_EVENTS_TIMING_BAR_TRAP_FLAG     = 1;
+const int NWNX_EVENTS_TIMING_BAR_TRAP_RECOVER  = 2;
+const int NWNX_EVENTS_TIMING_BAR_TRAP_DISARM   = 3;
+const int NWNX_EVENTS_TIMING_BAR_TRAP_EXAMINE  = 4;
+const int NWNX_EVENTS_TIMING_BAR_TRAP_SET      = 5;
+const int NWNX_EVENTS_TIMING_BAR_REST          = 6;
+const int NWNX_EVENTS_TIMING_BAR_UNLOCK        = 7;
+const int NWNX_EVENTS_TIMING_BAR_LOCK          = 8;
+const int NWNX_EVENTS_TIMING_BAR_CUSTOM        = 10;
 */
 
 // Scripts can subscribe to events.


### PR DESCRIPTION
Resolves #439. Builders can capture the start/stop/cancel of the Gui Timing Bars

This might be handy for example if the user cancels the disarming of a trap, they could suffer a random chance of the trap setting off.

There's no way the timing bar cancel could know what actions/effects the start initiated, so automagically cancelling those is not possible as @Chimerik requested in #439, it's up to the builder to perform the appropriate actions on a cancel.

Note: A user cancelling also runs a `_STOP_` after the `_CANCEL` event.

Sample `events_timingbar.nss`
```c
#include "nwnx_events"

void main()
{
    object oPC = OBJECT_SELF;
    if (!GetIsPC(oPC))
        return;

    string sCurrentEvent = NWNX_Events_GetCurrentEvent();
    if (sCurrentEvent == "NWNX_ON_TIMING_BAR_START_BEFORE")
    {
        int iEventID = StringToInt(NWNX_Events_GetEventData("EVENT_ID"));
        SetLocalInt(oPC, "current_timer_event", iEventID);
    }
    else if (sCurrentEvent == "NWNX_ON_TIMING_BAR_STOP_AFTER")
    {
        DeleteLocalInt(oPC, "current_timer_event");
    }
    else if (sCurrentEvent == "NWNX_ON_TIMING_BAR_CANCEL_AFTER")
    {
        int iEventID = GetLocalInt(oPC, "current_timer_event");
        if (iEventID == NWNX_EVENTS_TIMING_BAR_TRAP_DISARM)
        {
            SendMessageToPC(oPC, "Your trap disarming has been interrupted. Uh oh.");
        }
    }
}
```