### PR TITLE
Player: add various per-player overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ The following plugins were added:
 - Player: UpdateCharacterSheet()
 - Player: OpenInventory()
 - Player: SetObjectVisualTransformOverride()
+- Player: ApplyLoopingVisualEffectToObject()
 - Regex: Search()
 - Regex: Replace()
 - Rename: SetPCNameOverride()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ The following plugins were added:
 - Player: OpenInventory()
 - Player: SetObjectVisualTransformOverride()
 - Player: ApplyLoopingVisualEffectToObject()
+- Player: SetPlaceableNameOverride()
 - Regex: Search()
 - Regex: Replace()
 - Rename: SetPCNameOverride()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ The following plugins were added:
 - Player: ApplyInstantVisualEffectToObject()
 - Player: UpdateCharacterSheet()
 - Player: OpenInventory()
+- Player: SetObjectVisualTransformOverride()
 - Regex: Search()
 - Regex: Replace()
 - Rename: SetPCNameOverride()

--- a/NWNXLib/API/Constants/Misc.hpp
+++ b/NWNXLib/API/Constants/Misc.hpp
@@ -217,4 +217,38 @@ namespace CharacterType
     }
 }
 
+namespace ObjectVisualTransform
+{
+    enum TYPE
+    {
+        Scale           = 10,
+        RotateX         = 21,
+        RotateY         = 22,
+        RotateZ         = 23,
+        TranslateX      = 31,
+        TranslateY      = 32,
+        TranslateZ      = 33,
+        AnimationSpeed  = 40,
+    };
+    constexpr int32_t MIN = 10;
+    constexpr int32_t MAX = 40;
+    static_assert(MAX == AnimationSpeed);
+
+    constexpr const char* ToString(const unsigned value)
+    {
+        switch (value)
+        {
+            case Scale:             return "Scale";
+            case RotateX:           return "Rotate X";
+            case RotateY:           return "Rotate X";
+            case RotateZ:           return "Rotate X";
+            case TranslateX:        return "Translate X";
+            case TranslateY:        return "Translate Y";
+            case TranslateZ:        return "Translate Z";
+            case AnimationSpeed:    return "Animation Speed";
+        }
+        return "(invalid)";
+    }
+}
+
 }

--- a/NWNXLib/API/Constants/Misc.hpp
+++ b/NWNXLib/API/Constants/Misc.hpp
@@ -240,8 +240,8 @@ namespace ObjectVisualTransform
         {
             case Scale:             return "Scale";
             case RotateX:           return "Rotate X";
-            case RotateY:           return "Rotate X";
-            case RotateZ:           return "Rotate X";
+            case RotateY:           return "Rotate Y";
+            case RotateZ:           return "Rotate Z";
             case TranslateX:        return "Translate X";
             case TranslateY:        return "Translate Y";
             case TranslateZ:        return "Translate Z";

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -123,6 +123,12 @@ void NWNX_Player_UpdateCharacterSheet(object player);
 // Note: only works if player and target are in the same area
 void NWNX_Player_OpenInventory(object player, object target, int open = TRUE);
 
+// Override a visual transform on the given object that only oPlayer will see.
+// - oObject can be any valid Creature, Placeable, Item or Door.
+// - nTransform is one of OBJECT_VISUAL_TRANSFORM_* or -1 to remove the override
+// - fValue depends on the transformation to apply.
+void NWNX_Player_SetObjectVisualTransformOverride(object oPlayer, object oObject, int nTransform, float fValue);
+
 
 const string NWNX_Player = "NWNX_Player";
 
@@ -452,4 +458,27 @@ void NWNX_Player_OpenInventory(object player, object target, int open = TRUE)
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
     NWNX_CallFunction(NWNX_Player, sFunc);
+}
+
+void NWNX_Player_INTERNAL_SetObjectVisualTransformOverrideHelper(object oObject, float fOld)
+{
+   SetObjectVisualTransform(oObject, OBJECT_VISUAL_TRANSFORM_TRANSLATE_Z, fOld);
+}
+
+void NWNX_Player_SetObjectVisualTransformOverride(object oPlayer, object oObject, int nTransform, float fValue)
+{
+    string sFunc = "SetObjectVisualTransformOverride";
+
+    NWNX_PushArgumentFloat(NWNX_Player, sFunc, fValue);
+    NWNX_PushArgumentInt(NWNX_Player, sFunc, nTransform);
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, oObject);
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, oPlayer);
+
+    NWNX_CallFunction(NWNX_Player, sFunc);
+
+    if (nTransform == -1)
+    {// Force an update when the override is removed
+        float fOld = SetObjectVisualTransform(oObject, OBJECT_VISUAL_TRANSFORM_TRANSLATE_Z, GetObjectVisualTransform(oObject, OBJECT_VISUAL_TRANSFORM_TRANSLATE_Z) + 0.001f);
+        DelayCommand(0.5f, NWNX_Player_INTERNAL_SetObjectVisualTransformOverrideHelper(oObject, fOld));
+    }
 }

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -460,11 +460,6 @@ void NWNX_Player_OpenInventory(object player, object target, int open = TRUE)
     NWNX_CallFunction(NWNX_Player, sFunc);
 }
 
-void NWNX_Player_INTERNAL_SetObjectVisualTransformOverrideHelper(object oObject, float fOld)
-{
-   SetObjectVisualTransform(oObject, OBJECT_VISUAL_TRANSFORM_TRANSLATE_Z, fOld);
-}
-
 void NWNX_Player_SetObjectVisualTransformOverride(object oPlayer, object oObject, int nTransform, float fValue)
 {
     string sFunc = "SetObjectVisualTransformOverride";
@@ -475,11 +470,4 @@ void NWNX_Player_SetObjectVisualTransformOverride(object oPlayer, object oObject
     NWNX_PushArgumentObject(NWNX_Player, sFunc, oPlayer);
 
     NWNX_CallFunction(NWNX_Player, sFunc);
-
-    if (nTransform == -1)
-    {// Force an update when the override is removed
-        float fOld = SetObjectVisualTransform(oObject, OBJECT_VISUAL_TRANSFORM_TRANSLATE_Z,
-                        GetObjectVisualTransform(oObject, OBJECT_VISUAL_TRANSFORM_TRANSLATE_Z) + 0.001f);
-        DelayCommand(0.5f, NWNX_Player_INTERNAL_SetObjectVisualTransformOverrideHelper(oObject, fOld));
-    }
 }

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -129,6 +129,11 @@ void NWNX_Player_OpenInventory(object player, object target, int open = TRUE);
 // - fValue depends on the transformation to apply.
 void NWNX_Player_SetObjectVisualTransformOverride(object oPlayer, object oObject, int nTransform, float fValue);
 
+// Apply a looping visualeffect to target that only player can see
+//
+// Note: Only works with looping effects: VFX_DUR_*, -1 to remove the effect
+void NWNX_Player_ApplyLoopingVisualEffectToObject(object player, object target, int visualeffect);
+
 
 const string NWNX_Player = "NWNX_Player";
 
@@ -468,6 +473,16 @@ void NWNX_Player_SetObjectVisualTransformOverride(object oPlayer, object oObject
     NWNX_PushArgumentInt(NWNX_Player, sFunc, nTransform);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, oObject);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, oPlayer);
+
+    NWNX_CallFunction(NWNX_Player, sFunc);
+}
+
+void NWNX_Player_ApplyLoopingVisualEffectToObject(object player, object target, int visualeffect)
+{
+    string sFunc = "ApplyLoopingVisualEffectToObject";
+    NWNX_PushArgumentInt(NWNX_Player, sFunc, visualeffect);
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, target);
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
     NWNX_CallFunction(NWNX_Player, sFunc);
 }

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -132,6 +132,7 @@ void NWNX_Player_SetObjectVisualTransformOverride(object oPlayer, object oObject
 // Apply a looping visualeffect to target that only player can see
 //
 // Note: Only works with looping effects: VFX_DUR_*, -1 to remove the effect
+// Only a single effect per player/target pair, will overwrite effects from previous calls
 void NWNX_Player_ApplyLoopingVisualEffectToObject(object player, object target, int visualeffect);
 
 

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -135,6 +135,10 @@ void NWNX_Player_SetObjectVisualTransformOverride(object oPlayer, object oObject
 // Only a single effect per player/target pair, will overwrite effects from previous calls
 void NWNX_Player_ApplyLoopingVisualEffectToObject(object player, object target, int visualeffect);
 
+// Override the name of placeable for player only
+// "" to clear the override
+void NWNX_Player_SetPlaceableNameOverride(object player, object placeable, string name);
+
 
 const string NWNX_Player = "NWNX_Player";
 
@@ -483,6 +487,17 @@ void NWNX_Player_ApplyLoopingVisualEffectToObject(object player, object target, 
     string sFunc = "ApplyLoopingVisualEffectToObject";
     NWNX_PushArgumentInt(NWNX_Player, sFunc, visualeffect);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, target);
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
+
+    NWNX_CallFunction(NWNX_Player, sFunc);
+}
+
+void NWNX_Player_SetPlaceableNameOverride(object player, object placeable, string name)
+{
+    string sFunc = "SetPlaceableNameOverride";
+
+    NWNX_PushArgumentString(NWNX_Player, sFunc, name);
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, placeable);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
     NWNX_CallFunction(NWNX_Player, sFunc);

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -478,7 +478,8 @@ void NWNX_Player_SetObjectVisualTransformOverride(object oPlayer, object oObject
 
     if (nTransform == -1)
     {// Force an update when the override is removed
-        float fOld = SetObjectVisualTransform(oObject, OBJECT_VISUAL_TRANSFORM_TRANSLATE_Z, GetObjectVisualTransform(oObject, OBJECT_VISUAL_TRANSFORM_TRANSLATE_Z) + 0.001f);
+        float fOld = SetObjectVisualTransform(oObject, OBJECT_VISUAL_TRANSFORM_TRANSLATE_Z,
+                        GetObjectVisualTransform(oObject, OBJECT_VISUAL_TRANSFORM_TRANSLATE_Z) + 0.001f);
         DelayCommand(0.5f, NWNX_Player_INTERNAL_SetObjectVisualTransformOverrideHelper(oObject, fOld));
     }
 }

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -638,6 +638,9 @@ ArgumentStack Player::OpenInventory(ArgumentStack&& args)
 
 void Player::SwapOVTData(Services::Hooks::CallType type, CNWSPlayer *pPlayer, CNWSObject *pAreaObject)
 {
+    if (pPlayer == nullptr || pAreaObject == nullptr)
+        return;
+
     static ObjectVisualTransformData objectVisualTransformData;
     static bool bSwapBack;
 
@@ -707,16 +710,19 @@ ArgumentStack Player::SetObjectVisualTransformOverride(ArgumentStack&& args)
 
         const std::string key = Utils::ObjectIDToString(pPlayer->m_oidNWSObject) + "_" + Utils::ObjectIDToString(oidObject);
 
-        if (m_OVTData.find(key) == m_OVTData.end())
+        auto CheckMap = [&]() -> void
         {
-            ObjectVisualTransformData data = {};
-            data.m_scale = Vector{1.0f, 1.0f, 1.0f};
-            data.m_rotate = Vector{0.0f, 0.0f, 0.0f};
-            data.m_translate = Vector{0.0f, 0.0f, 0.0f};
-            data.m_animationSpeed = 1.0f;
+            if (m_OVTData.find(key) == m_OVTData.end())
+            {
+                ObjectVisualTransformData data = {};
+                data.m_scale = Vector{1.0f, 1.0f, 1.0f};
+                data.m_rotate = Vector{0.0f, 0.0f, 0.0f};
+                data.m_translate = Vector{0.0f, 0.0f, 0.0f};
+                data.m_animationSpeed = 1.0f;
 
-            m_OVTData.insert(std::make_pair(key, data));
-        }
+                m_OVTData.insert(std::make_pair(key, data));
+            }
+        };
 
         switch (transform)
         {
@@ -725,36 +731,60 @@ ArgumentStack Player::SetObjectVisualTransformOverride(ArgumentStack&& args)
                 break;
 
             case Constants::ObjectVisualTransform::Scale:
+            {
+                CheckMap();
                 m_OVTData[key].m_scale.x = value;
                 break;
+            }
 
             case Constants::ObjectVisualTransform::RotateX:
+            {
+                CheckMap();
                 m_OVTData[key].m_rotate.x = value;
                 break;
+            }
 
             case Constants::ObjectVisualTransform::RotateY:
+            {
+                CheckMap();
                 m_OVTData[key].m_rotate.y = value;
                 break;
+            }
 
             case Constants::ObjectVisualTransform::RotateZ:
+            {
+                CheckMap();
                 m_OVTData[key].m_rotate.z = value;
                 break;
+            }
 
             case Constants::ObjectVisualTransform::TranslateX:
+            {
+                CheckMap();
                 m_OVTData[key].m_translate.x = value;
                 break;
+            }
 
             case Constants::ObjectVisualTransform::TranslateY:
+            {
+                CheckMap();
                 m_OVTData[key].m_translate.y = value;
                 break;
+            }
 
             case Constants::ObjectVisualTransform::TranslateZ:
+            {
+                CheckMap();
                 m_OVTData[key].m_translate.z = value;
                 break;
+            }
 
             case Constants::ObjectVisualTransform::AnimationSpeed:
+            {
+                CheckMap();
                 m_OVTData[key].m_animationSpeed = value;
                 break;
+            }
 
             default:
                 LOG_WARNING("NWNX_Player_SetObjectVisualTransformOverride called with invalid transform!");

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -649,7 +649,7 @@ ArgumentStack Player::SetObjectVisualTransformOverride(ArgumentStack&& args)
                     if (auto *pObject = Utils::AsNWSObject(Utils::GetGameObject(oidObjectToUpdate)))
                     {
                         static ObjectVisualTransformData objectVisualTransformData;
-                        static bool bSwapBack;
+                        static bool bKeyExists;
 
                         if (pObject->m_nObjectType == Constants::ObjectType::Creature ||
                             pObject->m_nObjectType == Constants::ObjectType::Placeable ||
@@ -662,20 +662,17 @@ ArgumentStack Player::SetObjectVisualTransformOverride(ArgumentStack&& args)
                                                         Utils::ObjectIDToString(pObject->m_idSelf);
 
                                 auto search = g_plugin->m_OVTData.find(key);
-                                if(search != g_plugin->m_OVTData.end())
+                                bKeyExists = search != g_plugin->m_OVTData.end();
+
+                                if (bKeyExists)
                                 {
                                     objectVisualTransformData = search->second;
                                     std::swap(objectVisualTransformData, pObject->m_pVisualTransformData);
-                                    bSwapBack = true;
-                                }
-                                else
-                                {
-                                    bSwapBack = false;
                                 }
                             }
                             else
                             {
-                                if (bSwapBack)
+                                if (bKeyExists)
                                 {
                                     std::swap(objectVisualTransformData, pObject->m_pVisualTransformData);
                                 }
@@ -712,7 +709,7 @@ ArgumentStack Player::SetObjectVisualTransformOverride(ArgumentStack&& args)
                 data.m_translate = Vector{0.0f, 0.0f, 0.0f};
                 data.m_animationSpeed = 1.0f;
 
-                m_OVTData.insert(std::make_pair(key, data));
+                m_OVTData[key] = data;
             }
 
             switch (transform)

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -698,7 +698,11 @@ ArgumentStack Player::SetObjectVisualTransformOverride(ArgumentStack&& args)
 
         const std::string key = Utils::ObjectIDToString(pPlayer->m_oidNWSObject) + "_" + Utils::ObjectIDToString(oidObject);
 
-        auto CheckMap = [&]() -> void
+        if (transform == -1)
+        {
+            m_OVTData.erase(key);
+        }
+        else
         {
             if (m_OVTData.find(key) == m_OVTData.end())
             {
@@ -710,73 +714,45 @@ ArgumentStack Player::SetObjectVisualTransformOverride(ArgumentStack&& args)
 
                 m_OVTData.insert(std::make_pair(key, data));
             }
-        };
 
-        switch (transform)
-        {
-            case -1:
-                m_OVTData.erase(key);
-                break;
-
-            case Constants::ObjectVisualTransform::Scale:
+            switch (transform)
             {
-                CheckMap();
-                m_OVTData[key].m_scale.x = value;
-                break;
-            }
+                case Constants::ObjectVisualTransform::Scale:
+                    m_OVTData[key].m_scale.x = value;
+                    break;
 
-            case Constants::ObjectVisualTransform::RotateX:
-            {
-                CheckMap();
-                m_OVTData[key].m_rotate.x = value;
-                break;
-            }
+                case Constants::ObjectVisualTransform::RotateX:
+                    m_OVTData[key].m_rotate.x = value;
+                    break;
 
-            case Constants::ObjectVisualTransform::RotateY:
-            {
-                CheckMap();
-                m_OVTData[key].m_rotate.y = value;
-                break;
-            }
+                case Constants::ObjectVisualTransform::RotateY:
+                    m_OVTData[key].m_rotate.y = value;
+                    break;
 
-            case Constants::ObjectVisualTransform::RotateZ:
-            {
-                CheckMap();
-                m_OVTData[key].m_rotate.z = value;
-                break;
-            }
+                case Constants::ObjectVisualTransform::RotateZ:
+                    m_OVTData[key].m_rotate.z = value;
+                    break;
 
-            case Constants::ObjectVisualTransform::TranslateX:
-            {
-                CheckMap();
-                m_OVTData[key].m_translate.x = value;
-                break;
-            }
+                case Constants::ObjectVisualTransform::TranslateX:
+                    m_OVTData[key].m_translate.x = value;
+                    break;
 
-            case Constants::ObjectVisualTransform::TranslateY:
-            {
-                CheckMap();
-                m_OVTData[key].m_translate.y = value;
-                break;
-            }
+                case Constants::ObjectVisualTransform::TranslateY:
+                    m_OVTData[key].m_translate.y = value;
+                    break;
 
-            case Constants::ObjectVisualTransform::TranslateZ:
-            {
-                CheckMap();
-                m_OVTData[key].m_translate.z = value;
-                break;
-            }
+                case Constants::ObjectVisualTransform::TranslateZ:
+                    m_OVTData[key].m_translate.z = value;
+                    break;
 
-            case Constants::ObjectVisualTransform::AnimationSpeed:
-            {
-                CheckMap();
-                m_OVTData[key].m_animationSpeed = value;
-                break;
-            }
+                case Constants::ObjectVisualTransform::AnimationSpeed:
+                    m_OVTData[key].m_animationSpeed = value;
+                    break;
 
-            default:
-                LOG_WARNING("NWNX_Player_SetObjectVisualTransformOverride called with invalid transform!");
-                break;
+                default:
+                    LOG_WARNING("NWNX_Player_SetObjectVisualTransformOverride called with invalid transform!");
+                    break;
+            }
         }
     }
 

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -682,18 +682,14 @@ ArgumentStack Player::SetObjectVisualTransformOverride(ArgumentStack&& args)
 
     if (!bSetObjectVisualTransformOverrideHooks)
     {
-        GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__WriteGameObjUpdate_UpdateObject, int32_t>(
-                +[](Services::Hooks::CallType type, CNWSMessage*, CNWSPlayer *pPlayer, CNWSObject *pAreaObject,
-                    CLastUpdateObject*, int32_t, int32_t) -> void
+        GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__ComputeGameObjectUpdateForObject, int32_t>(
+                +[](Services::Hooks::CallType type, CNWSMessage*, CNWSPlayer *pPlayer, CNWSObject*,
+                    CGameObjectArray*, Types::ObjectID oidObjectToUpdate) -> void
                 {
-                    g_plugin->SwapOVTData(type, pPlayer, pAreaObject);
-                });
-
-        GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__TestObjectUpdateDifferences, int32_t>(
-                +[](Services::Hooks::CallType type, CNWSMessage*, CNWSPlayer *pPlayer, CNWSObject *pAreaObject,
-                    CLastUpdateObject**, int32_t*, int32_t*) -> void
-                {
-                    g_plugin->SwapOVTData(type, pPlayer, pAreaObject);
+                    if (auto *pObject = Utils::AsNWSObject(Utils::GetGameObject(oidObjectToUpdate)))
+                    {
+                        g_plugin->SwapOVTData(type, pPlayer, pObject);
+                    }
                 });
 
         bSetObjectVisualTransformOverrideHooks = true;

--- a/Plugins/Player/Player.hpp
+++ b/Plugins/Player/Player.hpp
@@ -4,6 +4,9 @@
 #include "Services/Events/Events.hpp"
 #include "API/Types.hpp"
 #include "API/CNWSPlayer.hpp"
+#include "API/ObjectVisualTransformData.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include <map>
 
 using ArgumentStack = NWNXLib::Services::Events::ArgumentStack;
 
@@ -35,9 +38,12 @@ private:
     ArgumentStack ApplyInstantVisualEffectToObject  (ArgumentStack&& args);
     ArgumentStack UpdateCharacterSheet              (ArgumentStack&& args);
     ArgumentStack OpenInventory                     (ArgumentStack&& args);
+    ArgumentStack SetObjectVisualTransformOverride  (ArgumentStack&& args);
 
     NWNXLib::API::CNWSPlayer *player(ArgumentStack& args);
 
+    std::map<std::string, NWNXLib::API::ObjectVisualTransformData> m_OVTData;
+    static void SwapOVTData(NWNXLib::Services::Hooks::CallType, NWNXLib::API::CNWSPlayer*, NWNXLib::API::CNWSObject*);
 };
 
 }

--- a/Plugins/Player/Player.hpp
+++ b/Plugins/Player/Player.hpp
@@ -2,8 +2,6 @@
 
 #include "Plugin.hpp"
 #include "Services/Events/Events.hpp"
-#include "API/Types.hpp"
-#include "API/CNWSPlayer.hpp"
 #include "API/ObjectVisualTransformData.hpp"
 #include <map>
 

--- a/Plugins/Player/Player.hpp
+++ b/Plugins/Player/Player.hpp
@@ -5,7 +5,6 @@
 #include "API/Types.hpp"
 #include "API/CNWSPlayer.hpp"
 #include "API/ObjectVisualTransformData.hpp"
-#include "Services/Hooks/Hooks.hpp"
 #include <map>
 
 using ArgumentStack = NWNXLib::Services::Events::ArgumentStack;
@@ -43,7 +42,6 @@ private:
     NWNXLib::API::CNWSPlayer *player(ArgumentStack& args);
 
     std::map<std::string, NWNXLib::API::ObjectVisualTransformData> m_OVTData;
-    static void SwapOVTData(NWNXLib::Services::Hooks::CallType, NWNXLib::API::CNWSPlayer*, NWNXLib::API::CNWSObject*);
 };
 
 }

--- a/Plugins/Player/Player.hpp
+++ b/Plugins/Player/Player.hpp
@@ -37,6 +37,7 @@ private:
     ArgumentStack OpenInventory                     (ArgumentStack&& args);
     ArgumentStack SetObjectVisualTransformOverride  (ArgumentStack&& args);
     ArgumentStack ApplyLoopingVisualEffectToObject  (ArgumentStack&& args);
+    ArgumentStack SetPlaceableNameOverride          (ArgumentStack&& args);
 
     NWNXLib::API::CNWSPlayer *player(ArgumentStack& args);
 

--- a/Plugins/Player/Player.hpp
+++ b/Plugins/Player/Player.hpp
@@ -36,6 +36,7 @@ private:
     ArgumentStack UpdateCharacterSheet              (ArgumentStack&& args);
     ArgumentStack OpenInventory                     (ArgumentStack&& args);
     ArgumentStack SetObjectVisualTransformOverride  (ArgumentStack&& args);
+    ArgumentStack ApplyLoopingVisualEffectToObject  (ArgumentStack&& args);
 
     NWNXLib::API::CNWSPlayer *player(ArgumentStack& args);
 


### PR DESCRIPTION
Lets you set various per player overrides!

Adds:
SetObjectVisualTransformOverride()
ApplyLoopingVisualEffectToObject()
SetPlaceableNameOverride()