### PR TITLE
added NWNX_Creature_GetHighestLevelOfFeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ The following plugins were added:
 - Area: SetSunMoonColors()
 - Area: CreateTransition()
 - Creature: GetAttackBonus()
+- Creature: GetHighestLevelOfFeat()
 - Creature: GetFeatRemainingUses()
 - Creature: GetFeatTotalUses()
 - Creature: SetFeatRemainingUses()

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -119,6 +119,7 @@ Creature::Creature(const Plugin::CreateParams& params)
     REGISTER(LevelDown);
     REGISTER(SetChallengeRating);
     REGISTER(GetAttackBonus);
+    REGISTER(GetHighestLevelOfFeat);
     REGISTER(GetFeatRemainingUses);
     REGISTER(GetFeatTotalUses);
     REGISTER(SetFeatRemainingUses);
@@ -1672,6 +1673,21 @@ ArgumentStack Creature::GetAttackBonus(ArgumentStack&& args)
     }
 
     Services::Events::InsertArgument(stack, retVal);
+    return stack;
+}
+
+ArgumentStack Creature::GetHighestLevelOfFeat(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    int32_t retval = -1;
+    if (auto *pCreature = creature(args))
+    {
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args);
+          ASSERT_OR_THROW(feat >= Constants::Feat::MIN);
+          ASSERT_OR_THROW(feat <= Constants::Feat::MAX);
+        retval = pCreature->m_pStats->GetHighestLevelOfFeat(feat);
+    }
+    Services::Events::InsertArgument(stack, retval);
     return stack;
 }
 

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -83,6 +83,7 @@ private:
     ArgumentStack LevelDown                     (ArgumentStack&& args);
     ArgumentStack SetChallengeRating            (ArgumentStack&& args);
     ArgumentStack GetAttackBonus                (ArgumentStack&& args);
+    ArgumentStack GetHighestLevelOfFeat         (ArgumentStack&& args);
     ArgumentStack GetFeatRemainingUses          (ArgumentStack&& args);
     ArgumentStack GetFeatTotalUses              (ArgumentStack&& args);
     ArgumentStack SetFeatRemainingUses          (ArgumentStack&& args);

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -297,6 +297,9 @@ void NWNX_Creature_SetChallengeRating(object creature, float fCR);
 //       Defaults to Melee Attack Bonus if weapon is invalid or no weapon
 int NWNX_Creature_GetAttackBonus(object creature, int isMelee = -1, int isTouchAttack = FALSE, int isOffhand = FALSE, int includeBaseAttackBonus = TRUE);
 
+// Get highest level version of feat posessed by creature (e.g. for barbarian rage)
+int NWNX_Creature_GetHighestLevelOfFeat(object creature, int feat);
+
 // Get feat remaining uses of a creature
 int NWNX_Creature_GetFeatRemainingUses(object creature, int feat);
 
@@ -1058,6 +1061,17 @@ int NWNX_Creature_GetAttackBonus(object creature, int isMelee = -1, int isTouchA
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, isOffhand);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, isTouchAttack);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, isMelee);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
+}
+
+int NWNX_Creature_GetHighestLevelOfFeat(object creature, int feat)
+{
+    string sFunc = "GetHighestLevelOfFeat";
+
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, feat);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 
     NWNX_CallFunction(NWNX_Creature, sFunc);

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -1,6 +1,6 @@
 #include "nwnx_creature"
 
-
+const int FEAT_BARBARIAN_RAGE_2 = 326;
 
 void report(string func, int bSuccess)
 {
@@ -50,6 +50,11 @@ void main()
     report("GetFeatByIndex", NWNX_Creature_GetFeatByIndex(oCreature, nFeatCountTotal) == FEAT_PLAYER_TOOL_01);
 
     report("GetFeatByLevel", NWNX_Creature_GetFeatByLevel(oCreature, 1, nFeatCountLvl1) == FEAT_PLAYER_TOOL_01);
+
+    NWNX_Creature_AddFeat(oCreature, FEAT_BARBARIAN_RAGE);
+    report("GetHighestLevelOfFeat", NWNX_Creature_GetHighestLevelOfFeat(oCreature, FEAT_BARBARIAN_RAGE) == FEAT_BARBARIAN_RAGE);
+    NWNX_Creature_AddFeat(oCreature, FEAT_BARBARIAN_RAGE_2);
+    report("GetHighestLevelOfFeat", NWNX_Creature_GetHighestLevelOfFeat(oCreature, FEAT_BARBARIAN_RAGE) == FEAT_BARBARIAN_RAGE_2);
 
     NWNX_Creature_AddFeat(oCreature, FEAT_STUNNING_FIST);
     report("GetFeatRemainingUses", NWNX_Creature_GetFeatRemainingUses(oCreature, FEAT_STUNNING_FIST) == 1);


### PR DESCRIPTION
Exposes another NWN function. Needed to get correct number of total/remaining uses for feats with multiple levels, like barbarian rage.