### PR TITLE
Area: add {Get/Set}TileAnimationLoop()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The following plugins were added:
 - Area: SetDayNightCycle()
 - Area: {Get|Set}SunMoonColors()
 - Area: CreateTransition()
+- Area: {Get|Set}TileAnimationLoop()
 - Creature: GetAttackBonus()
 - Creature: GetHighestLevelOfFeat()
 - Creature: GetFeatRemainingUses()

--- a/Plugins/Area/Area.cpp
+++ b/Plugins/Area/Area.cpp
@@ -6,6 +6,7 @@
 #include "API/CNWSModule.hpp"
 #include "API/CNWSTransition.hpp"
 #include "API/CNWSTrigger.hpp"
+#include "API/CNWSTile.hpp"
 #include "API/Constants.hpp"
 #include "API/Globals.hpp"
 #include "Services/Events/Events.hpp"
@@ -69,6 +70,8 @@ Area::Area(const Plugin::CreateParams& params)
     REGISTER(GetSunMoonColors);
     REGISTER(SetSunMoonColors);
     REGISTER(CreateTransition);
+    REGISTER(GetTileAnimationLoop);
+    REGISTER(SetTileAnimationLoop);
 
 #undef REGISTER
 }
@@ -95,6 +98,18 @@ CNWSArea *Area::area(ArgumentStack& args)
     }
 
     return pArea;
+}
+
+CNWSTile *Area::GetTile(CNWSArea *pArea, float x, float y)
+{
+    int nTile = (int)(y / 10) * pArea->m_nWidth + (int)(x / 10);
+
+    if (nTile >= 0 && nTile < (pArea->m_nWidth * pArea->m_nHeight))
+    {
+        return  &pArea->m_pTile[nTile];
+    }
+    else
+        return nullptr;
 }
 
 ArgumentStack Area::GetNumberOfPlayersInArea(ArgumentStack&& args)
@@ -611,6 +626,88 @@ ArgumentStack Area::CreateTransition(ArgumentStack&& args)
     }
     else
         Services::Events::InsertArgument(stack, Constants::OBJECT_INVALID);
+
+    return stack;
+}
+
+ArgumentStack Area::GetTileAnimationLoop(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    int32_t retVal = -1;
+
+    if (auto *pArea = area(args))
+    {
+        const auto tileX = Services::Events::ExtractArgument<float>(args);
+        const auto tileY = Services::Events::ExtractArgument<float>(args);
+        const auto tileAnimLoop = Services::Events::ExtractArgument<int32_t>(args);
+          ASSERT_OR_THROW(tileAnimLoop >= 1);
+          ASSERT_OR_THROW(tileAnimLoop <= 3);
+
+        CNWSTile *pTile = GetTile(pArea, tileX, tileY);
+
+        if (pTile)
+        {
+            switch(tileAnimLoop)
+            {
+                case 1:
+                    retVal = pTile->m_nAnimLoop1;
+                    break;
+
+                case 2:
+                    retVal = pTile->m_nAnimLoop2;
+                    break;
+
+                case 3:
+                    retVal = pTile->m_nAnimLoop3;
+                    break;
+
+                default:
+                    break;
+            }
+        }
+    }
+
+    Services::Events::InsertArgument(stack, retVal);
+
+    return stack;
+}
+
+ArgumentStack Area::SetTileAnimationLoop(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+
+    if (auto *pArea = area(args))
+    {
+        const auto tileX = Services::Events::ExtractArgument<float>(args);
+        const auto tileY = Services::Events::ExtractArgument<float>(args);
+        const auto tileAnimLoop = Services::Events::ExtractArgument<int32_t>(args);
+          ASSERT_OR_THROW(tileAnimLoop >= 1);
+          ASSERT_OR_THROW(tileAnimLoop <= 3);
+        const auto tileEnabled = !!Services::Events::ExtractArgument<int32_t>(args);
+
+        CNWSTile *pTile = GetTile(pArea, tileX, tileY);
+
+        if (pTile)
+        {
+            switch(tileAnimLoop)
+            {
+                case 1:
+                    pTile->m_nAnimLoop1 = tileEnabled;
+                    break;
+
+                case 2:
+                    pTile->m_nAnimLoop2 = tileEnabled;
+                    break;
+
+                case 3:
+                    pTile->m_nAnimLoop3 = tileEnabled;
+                    break;
+
+                default:
+                    break;
+            }
+        }
+    }
 
     return stack;
 }

--- a/Plugins/Area/Area.cpp
+++ b/Plugins/Area/Area.cpp
@@ -105,9 +105,7 @@ CNWSTile *Area::GetTile(CNWSArea *pArea, float x, float y)
     int nTile = (int)(y / 10) * pArea->m_nWidth + (int)(x / 10);
 
     if (nTile >= 0 && nTile < (pArea->m_nWidth * pArea->m_nHeight))
-    {
-        return  &pArea->m_pTile[nTile];
-    }
+        return &pArea->m_pTile[nTile];
     else
         return nullptr;
 }
@@ -665,6 +663,10 @@ ArgumentStack Area::GetTileAnimationLoop(ArgumentStack&& args)
                     break;
             }
         }
+        else
+        {
+            LOG_ERROR("NWNX_Area_GetTileAnimationLoop: invalid tile specified");
+        }
     }
 
     Services::Events::InsertArgument(stack, retVal);
@@ -706,6 +708,10 @@ ArgumentStack Area::SetTileAnimationLoop(ArgumentStack&& args)
                 default:
                     break;
             }
+        }
+        else
+        {
+            LOG_ERROR("NWNX_Area_SetTileAnimationLoop: invalid tile specified");
         }
     }
 

--- a/Plugins/Area/Area.cpp
+++ b/Plugins/Area/Area.cpp
@@ -636,7 +636,9 @@ ArgumentStack Area::GetTileAnimationLoop(ArgumentStack&& args)
     if (auto *pArea = area(args))
     {
         const auto tileX = Services::Events::ExtractArgument<float>(args);
+          ASSERT_OR_THROW(tileX >= 0.0f);
         const auto tileY = Services::Events::ExtractArgument<float>(args);
+          ASSERT_OR_THROW(tileY >= 0.0f);
         const auto tileAnimLoop = Services::Events::ExtractArgument<int32_t>(args);
           ASSERT_OR_THROW(tileAnimLoop >= 1);
           ASSERT_OR_THROW(tileAnimLoop <= 3);
@@ -681,7 +683,9 @@ ArgumentStack Area::SetTileAnimationLoop(ArgumentStack&& args)
     if (auto *pArea = area(args))
     {
         const auto tileX = Services::Events::ExtractArgument<float>(args);
+          ASSERT_OR_THROW(tileX >= 0.0f);
         const auto tileY = Services::Events::ExtractArgument<float>(args);
+          ASSERT_OR_THROW(tileY >= 0.0f);
         const auto tileAnimLoop = Services::Events::ExtractArgument<int32_t>(args);
           ASSERT_OR_THROW(tileAnimLoop >= 1);
           ASSERT_OR_THROW(tileAnimLoop <= 3);

--- a/Plugins/Area/Area.hpp
+++ b/Plugins/Area/Area.hpp
@@ -39,9 +39,11 @@ private:
     ArgumentStack GetSunMoonColors          (ArgumentStack&& args);
     ArgumentStack SetSunMoonColors          (ArgumentStack&& args);
     ArgumentStack CreateTransition          (ArgumentStack&& args);
+    ArgumentStack GetTileAnimationLoop      (ArgumentStack&& args);
+    ArgumentStack SetTileAnimationLoop      (ArgumentStack&& args);
 
     NWNXLib::API::CNWSArea *area(ArgumentStack& args);
-
+    static NWNXLib::API::CNWSTile *GetTile(NWNXLib::API::CNWSArea *pArea, float x, float y);
 };
 
 }

--- a/Plugins/Area/NWScript/nwnx_area.nss
+++ b/Plugins/Area/NWScript/nwnx_area.nss
@@ -114,6 +114,16 @@ void NWNX_Area_SetSunMoonColors(object area, int type, int color);
 // If a tag is specified the returning object will have that tag
 object NWNX_Area_CreateTransition(object area, object target, float x, float y, float z, float size = 2.0f, string tag="");
 
+// Get the state of a tile animation loop
+// nAnimLoop = 1-3
+int NWNX_Area_GetTileAnimationLoop(object oArea, float fTileX, float fTileY, int nAnimLoop);
+
+// Set the state of a tile animation loop
+// nAnimLoop = 1-3
+//
+// NOTE: Requires clients to re-enter the area for it to take effect
+void NWNX_Area_SetTileAnimationLoop(object oArea, float fTileX, float fTileY, int nAnimLoop, int bEnabled);
+
 
 const string NWNX_Area = "NWNX_Area";
 
@@ -357,4 +367,31 @@ object NWNX_Area_CreateTransition(object area, object target, float x, float y, 
     NWNX_CallFunction(NWNX_Area, sFunc);
 
     return NWNX_GetReturnValueObject(NWNX_Area, sFunc);
+}
+
+int NWNX_Area_GetTileAnimationLoop(object oArea, float fTileX, float fTileY, int nAnimLoop)
+{
+    string sFunc = "GetTileAnimationLoop";
+
+    NWNX_PushArgumentInt(NWNX_Area, sFunc, nAnimLoop);
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, fTileY);
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, fTileX);
+    NWNX_PushArgumentObject(NWNX_Area, sFunc, oArea);
+
+    NWNX_CallFunction(NWNX_Area, sFunc);
+
+    return NWNX_GetReturnValueInt(NWNX_Area, sFunc);
+}
+
+void NWNX_Area_SetTileAnimationLoop(object oArea, float fTileX, float fTileY, int nAnimLoop, int bEnabled)
+{
+    string sFunc = "SetTileAnimationLoop";
+
+    NWNX_PushArgumentInt(NWNX_Area, sFunc, bEnabled);
+    NWNX_PushArgumentInt(NWNX_Area, sFunc, nAnimLoop);
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, fTileY);
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, fTileX);
+    NWNX_PushArgumentObject(NWNX_Area, sFunc, oArea);
+
+    NWNX_CallFunction(NWNX_Area, sFunc);
 }

--- a/Plugins/Area/NWScript/nwnx_area_t.nss
+++ b/Plugins/Area/NWScript/nwnx_area_t.nss
@@ -63,6 +63,9 @@ void main()
         object oWP = CreateObject(OBJECT_TYPE_WAYPOINT, "nw_waypoint001", GetStartingLocation());
         object oAT = NWNX_Area_CreateTransition(oArea, oWP, vLoc.x, vLoc.y, vLoc.z);
         report ("CreateTransition", oAT != OBJECT_INVALID);
+
+        NWNX_Area_SetTileAnimationLoop(oArea, vLoc.x, vLoc.y, 1, FALSE);
+        report("{Set/Get}TileAnimationLoop", NWNX_Area_GetTileAnimationLoop(oArea, vLoc.x, vLoc.y, 1) == FALSE);
     }
     else
     {


### PR DESCRIPTION
Lets you enable or disable tile animation loops, needs clients to re-enter the area for it to take effect.