### PR TITLE
Util: EncodeStringForURL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ The following plugins were added:
 - Util: IsValidResRef()
 - Util: GetMinutesPerHour()
 - Util: SetMinutesPerHour()
+- Util: EncodeStringForURL()
 - Visibility: GetVisibilityOverride()
 - Visibility: SetVisibilityOverride()
 - Weapon: SetWeaponIsMonkWeapon()

--- a/Plugins/Util/NWScript/nwnx_util.nss
+++ b/Plugins/Util/NWScript/nwnx_util.nss
@@ -42,6 +42,8 @@ string NWNX_Util_GetEnvironmentVariable(string sVarname);
 int NWNX_Util_GetMinutesPerHour();
 // Set module real life minutes per in game hour
 void NWNX_Util_SetMinutesPerHour(int minutes);
+// Encodes a string for usage in a URL
+string NWNX_Util_EncodeStringForURL(string str);
 
 
 const string NWNX_Util = "NWNX_Util";
@@ -138,4 +140,14 @@ void NWNX_Util_SetMinutesPerHour(int minutes)
     string sFunc = "SetMinutesPerHour";
     NWNX_PushArgumentInt(NWNX_Util, sFunc, minutes);
     NWNX_CallFunction(NWNX_Util, sFunc);
+}
+
+string NWNX_Util_EncodeStringForURL(string sURL)
+{
+    string sFunc = "EncodeStringForURL";
+
+    NWNX_PushArgumentString(NWNX_Util, sFunc, sURL);
+    NWNX_CallFunction(NWNX_Util, sFunc);
+
+    return NWNX_GetReturnValueString(NWNX_Util, sFunc);
 }

--- a/Plugins/Util/NWScript/nwnx_util_t.nss
+++ b/Plugins/Util/NWScript/nwnx_util_t.nss
@@ -54,5 +54,8 @@ void main()
     NWNX_Util_SetMinutesPerHour(30);
     report("SetMinutesPerHour", NWNX_Util_GetMinutesPerHour() == 30);
 
+    string sStringForURL = "This is a test, yes.";
+    report("EncodeStringForURL", NWNX_Util_EncodeStringForURL(sStringForURL) == "This+is+a+test%2C+yes.");
+
     WriteTimestampedLogEntry("NWNX_Util unit test end.");
 }

--- a/Plugins/Util/Util.cpp
+++ b/Plugins/Util/Util.cpp
@@ -1,3 +1,30 @@
+/*
+Part of the code for method Util::EncodeStringForURL() was taken from yhirose's cpp-httplib.
+The cpp-httplib copyright notice is as follows:
+
+The MIT License (MIT)
+
+Copyright (c) 2017 yhirose
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 #include "Util.hpp"
 
 #include "API/Constants.hpp"
@@ -230,7 +257,7 @@ ArgumentStack Util::EncodeStringForURL(ArgumentStack&& args)
     const auto s = Services::Events::ExtractArgument<std::string>(args);
     std::string result;
 
-    // Taken from httplib.h endode_url
+    // For licensing information pertaining to this part of the method, see the comment at the top of this file.
     for (auto i = 0; s[i]; i++)
     {
         switch (s[i]) {
@@ -252,6 +279,7 @@ ArgumentStack Util::EncodeStringForURL(ArgumentStack&& args)
                 break;
         }
     }
+    // End of cpp-httplib code
     Services::Events::InsertArgument(stack, result);
     return stack;
 }

--- a/Plugins/Util/Util.hpp
+++ b/Plugins/Util/Util.hpp
@@ -26,6 +26,7 @@ private:
     ArgumentStack GetEnvironmentVariable(ArgumentStack&& args);
     ArgumentStack GetMinutesPerHour(ArgumentStack&& args);
     ArgumentStack SetMinutesPerHour(ArgumentStack&& args);
+    ArgumentStack EncodeStringForURL(ArgumentStack&& args);
 };
 
 }


### PR DESCRIPTION
Instead of putting `httplib.h` into External thus necessitating `openssl-dev` for the build to use Util I just took the code for `encode_url` from `httplib.h` and put it directly in our function.