### PR TITLE
added NWNX_Creature_GetPrePolymorphAbilityScore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ The following plugins were added:
 - Creature: SetOriginalName()
 - Creature: GetOriginalName()
 - Creature: SetSpellResistance()
+- Creature: GetPrePolymorphAbilityScore()
 - Damage: SetAttackEventScript()
 - Damage: GetAttackEventData()
 - Damage: SetAttackEventData()

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -72,6 +72,7 @@ Creature::Creature(const Plugin::CreateParams& params)
     REGISTER(SetRawAbilityScore);
     REGISTER(GetRawAbilityScore);
     REGISTER(ModifyRawAbilityScore);
+    REGISTER(GetPrePolymorphAbilityScore);
     REGISTER(GetMemorisedSpell);
     REGISTER(GetMemorisedSpellCountByLevel);
     REGISTER(SetMemorisedSpell);
@@ -597,6 +598,36 @@ ArgumentStack Creature::ModifyRawAbilityScore(ArgumentStack&& args)
                 break;
         }
     }
+    return stack;
+}
+
+ArgumentStack Creature::GetPrePolymorphAbilityScore(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    int32_t retVal = -1;
+
+    if (auto *pCreature = creature(args))
+    {
+        const auto ability = Services::Events::ExtractArgument<int32_t>(args);
+
+        switch (ability)
+        {
+            case Constants::Ability::Strength:
+                retVal = pCreature->m_nPrePolymorphSTR;
+                break;
+            case Constants::Ability::Dexterity:
+                retVal = pCreature->m_nPrePolymorphDEX;
+                break;
+            case Constants::Ability::Constitution:
+                retVal = pCreature->m_nPrePolymorphCON;
+                break;
+            default:
+                LOG_NOTICE("Calling NWNX_Creature_GetPrePolymorphAbilityScore with invalid ability ID: %d", ability);
+                ASSERT_FAIL();
+                break;
+        }
+    }
+    Services::Events::InsertArgument(stack, retVal);
     return stack;
 }
 

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -36,6 +36,7 @@ private:
     ArgumentStack SetRawAbilityScore            (ArgumentStack&& args);
     ArgumentStack GetRawAbilityScore            (ArgumentStack&& args);
     ArgumentStack ModifyRawAbilityScore         (ArgumentStack&& args);
+    ArgumentStack GetPrePolymorphAbilityScore   (ArgumentStack&& args);
     ArgumentStack GetMemorisedSpell             (ArgumentStack&& args);
     ArgumentStack GetMemorisedSpellCountByLevel (ArgumentStack&& args);
     ArgumentStack SetMemorisedSpell             (ArgumentStack&& args);

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -127,6 +127,9 @@ int NWNX_Creature_GetRawAbilityScore(object creature, int ability);
 // Adjusts the provided ability score of a provided creature. Does not apply racial bonuses/penalties.
 void NWNX_Creature_ModifyRawAbilityScore(object creature, int ability, int modifier);
 
+// Gets the raw ability score a polymorphed creature had prior to polymorphing. Str/Dex/Con only.
+int NWNX_Creature_GetPrePolymorphAbilityScore(object creature, int ability);
+
 // Gets the memorised spell of the provided creature for the provided class, level, and index.
 // Index bounds: 0 <= index < NWNX_Creature_GetMemorisedSpellCountByLevel(creature, class, level).
 struct NWNX_Creature_MemorisedSpell NWNX_Creature_GetMemorisedSpell(object creature, int class, int level, int index);
@@ -553,6 +556,17 @@ void NWNX_Creature_ModifyRawAbilityScore(object creature, int ability, int modif
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 
     NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+int NWNX_Creature_GetPrePolymorphAbilityScore(object creature, int ability)
+{
+    string sFunc = "GetPrePolymorphAbilityScore";
+
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, ability);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
 }
 
 struct NWNX_Creature_MemorisedSpell NWNX_Creature_GetMemorisedSpell(object creature, int class, int level, int index)

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -101,6 +101,10 @@ void main()
     report("SetAbilityScore", nOldStr != GetAbilityScore(oCreature, ABILITY_STRENGTH, TRUE));
     report("SetAbilityScore", 25      == GetAbilityScore(oCreature, ABILITY_STRENGTH, TRUE));
 
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectPolymorph(POLYMORPH_TYPE_BADGER), oCreature);
+    report("GetPrePolymorphAbilityScore", 25 == NWNX_Creature_GetPrePolymorphAbilityScore(oCreature, ABILITY_STRENGTH));
+    RemoveEffect(oCreature, GetFirstEffect(oCreature));
+
 
     int nLvl1HP = NWNX_Creature_GetMaxHitPointsByLevel(oCreature, 1);
     report("GetMaxHitPointsByLevel", nLvl1HP >= 0);


### PR DESCRIPTION
Allows you to retrieve the original physical ability scores of a polymorphed creature.