### PR TITLE
added DESTROY_OBJECT and DECREMENT_STACKSIZE hooks to Events/ItemEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Events: Added On{Un}Polymorph events as PolymorphEvents
 - Events: Added Event Data for SpawnObject, GiveItem, GiveAlignment, Heal, Kill, ToggleInvulnerabilty, ForceRest, Limbo, ToggleAI, ToggleImmortal, Goto, Possess, PossessFullPower, ToggleLock, DisableTrap, JumpToPoint, JumpTargetToPoint, JumpAllPlayersToPoint, ChangeDifficulty, ViewInventory, SpawnTrapOnObject events in DMActionEvents
 - Events: Added OnClientConnect events that fire before the player sees the server vault.
-- Events: Added ItemInventory{Open/Close}, ItemInventory{Add/Remove}Item and ScrollLearn events to ItemEvents
+- Events: Added ItemInventory{Open/Close}, ItemInventory{Add/Remove}Item, ScrollLearn and EventHandler events to ItemEvents
 - Events: Added {Set|Clear}MemorizedSpellSlot events to SpellEvents
 - Events: Added AmmoReload events that are used when the engine is looking for ammunition to reload
 - Events: Added Run{Un}Equip events to ItemEvents
@@ -110,7 +110,6 @@ The following plugins were added:
 - Encounter: GetResetTime()
 - Encounter: SetResetTime()
 - Events: GetCurrentEvent()
-- Events: ON_ITEM_EVENT_{BEFORE|AFTER}
 - Feedback: Get{Feedback|CombatLog|JournalUpdated}MessageHidden()
 - Feedback: Set{Feedback|CombatLog|JournalUpdated}MessageHidden()
 - Feedback: Set{Feedback|CombatLog}MessageMode()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ The following plugins were added:
 - Encounter: GetResetTime()
 - Encounter: SetResetTime()
 - Events: GetCurrentEvent()
+- Events: ON_ITEM_EVENT_{BEFORE|AFTER}
 - Feedback: Get{Feedback|CombatLog|JournalUpdated}MessageHidden()
 - Feedback: Set{Feedback|CombatLog|JournalUpdated}MessageHidden()
 - Feedback: Set{Feedback|CombatLog}MessageMode()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Events: Added On{Un}Polymorph events as PolymorphEvents
 - Events: Added Event Data for SpawnObject, GiveItem, GiveAlignment, Heal, Kill, ToggleInvulnerabilty, ForceRest, Limbo, ToggleAI, ToggleImmortal, Goto, Possess, PossessFullPower, ToggleLock, DisableTrap, JumpToPoint, JumpTargetToPoint, JumpAllPlayersToPoint, ChangeDifficulty, ViewInventory, SpawnTrapOnObject events in DMActionEvents
 - Events: Added OnClientConnect events that fire before the player sees the server vault.
-- Events: Added ItemInventory{Open/Close}, ItemInventory{Add/Remove}Item, ScrollLearn and EventHandler events to ItemEvents
+- Events: Added ItemInventory{Open/Close}, ItemInventory{Add/Remove}Item, ScrollLearn, DestroyObject and DecrementStackSize events to ItemEvents
 - Events: Added {Set|Clear}MemorizedSpellSlot events to SpellEvents
 - Events: Added AmmoReload events that are used when the engine is looking for ammunition to reload
 - Events: Added Run{Un}Equip events to ItemEvents

--- a/Plugins/Events/Events/ItemEvents.hpp
+++ b/Plugins/Events/Events/ItemEvents.hpp
@@ -24,6 +24,7 @@ private:
     static int32_t LearnScrollHook(NWNXLib::API::CNWSCreature*, NWNXLib::API::Types::ObjectID);
     static int32_t RunEquipHook(NWNXLib::API::CNWSCreature*, NWNXLib::API::Types::ObjectID, uint32_t, uint32_t);
     static int32_t RunUnequipHook(NWNXLib::API::CNWSCreature*, NWNXLib::API::Types::ObjectID, NWNXLib::API::Types::ObjectID, uint8_t, uint8_t, int32_t, uint32_t);
+    static void ItemEventHandlerHook(NWNXLib::API::CNWSItem*, uint32_t, NWNXLib::API::Types::ObjectID, void*, uint32_t, uint32_t);
 };
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -130,6 +130,8 @@
     Event data:
         Variable Name           Type        Notes
         EVENT_ID                int         Type of event triggered, see ITEM_EVENT_* constants below
+
+    Note: Use of NWNX_ON_ITEM_EVENT_{BEFORE|AFTER} conflicts object event handler profiling
 ////////////////////////////////////////////////////////////////////////////////
     NWNX_ON_USE_FEAT_BEFORE
     NWNX_ON_USE_FEAT_AFTER

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -120,6 +120,16 @@
     Event data:
         Variable Name           Type        Notes
         ITEM                    object      Convert to object with NWNX_Object_StringToObject()
+
+    NWNX_ON_ITEM_EVENT_BEFORE
+    NWNX_ON_ITEM_EVENT_AFTER
+
+    Usage:
+        OBJECT_SELF = The item triggering the event
+
+    Event data:
+        Variable Name           Type        Notes
+        EVENT_ID                int         Type of event triggered, see ITEM_EVENT_* constants below
 ////////////////////////////////////////////////////////////////////////////////
     NWNX_ON_USE_FEAT_BEFORE
     NWNX_ON_USE_FEAT_AFTER
@@ -727,6 +737,11 @@ const int NWNX_EVENTS_TIMING_BAR_REST          = 6;
 const int NWNX_EVENTS_TIMING_BAR_UNLOCK        = 7;
 const int NWNX_EVENTS_TIMING_BAR_LOCK          = 8;
 const int NWNX_EVENTS_TIMING_BAR_CUSTOM        = 10;
+*/
+
+/*
+const int NWNX_EVENTS_ITEM_EVENT_DESTROY_OBJECT = 11;
+const int NWNX_EVENTS_ITEM_EVENT_DECREMENT_STACKSIZE = 16;
 */
 
 // Scripts can subscribe to events.

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -121,17 +121,15 @@
         Variable Name           Type        Notes
         ITEM                    object      Convert to object with NWNX_Object_StringToObject()
 
-    NWNX_ON_ITEM_EVENT_BEFORE
-    NWNX_ON_ITEM_EVENT_AFTER
+    NWNX_ON_ITEM_DESTROY_OBJECT_BEFORE
+    NWNX_ON_ITEM_DESTROY_OBJECT_AFTER
+    NWNX_ON_ITEM_DECREMENT_STACKSIZE_BEFORE
+    NWNX_ON_ITEM_DECREMENT_STACKSIZE_AFTER
 
     Usage:
         OBJECT_SELF = The item triggering the event
 
-    Event data:
-        Variable Name           Type        Notes
-        EVENT_ID                int         Type of event triggered, see ITEM_EVENT_* constants below
-
-    Note: Use of NWNX_ON_ITEM_EVENT_{BEFORE|AFTER} conflicts object event handler profiling
+    Note: Use of NWNX_ON_ITEM_(DESTROY_OBJECT|DECREMENT_STACKSIZE)_* conflicts with object event handler profiling
 ////////////////////////////////////////////////////////////////////////////////
     NWNX_ON_USE_FEAT_BEFORE
     NWNX_ON_USE_FEAT_AFTER
@@ -739,11 +737,6 @@ const int NWNX_EVENTS_TIMING_BAR_REST          = 6;
 const int NWNX_EVENTS_TIMING_BAR_UNLOCK        = 7;
 const int NWNX_EVENTS_TIMING_BAR_LOCK          = 8;
 const int NWNX_EVENTS_TIMING_BAR_CUSTOM        = 10;
-*/
-
-/*
-const int NWNX_EVENTS_ITEM_EVENT_DESTROY_OBJECT = 11;
-const int NWNX_EVENTS_ITEM_EVENT_DECREMENT_STACKSIZE = 16;
 */
 
 // Scripts can subscribe to events.


### PR DESCRIPTION
Can e.g. be used to create infinite ammunition:

on module load:
```
#include "nwnx_events"
void main()
{
    NWNX_Events_SubscribeEvent("NWNX_ON_ITEM_DECREMENT_STACKSIZE_BEFORE", "on_decr_stack");
}
```
on_decr_stack:
```
#include "nwnx_events"
void main()
{
   if ( IsMarkedAsInfinite(OBJECT_SELF) )
       NWNX_Events_SkipEvent();
}
```