### PR TITLE
Plugin: Appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - WebHook: Added support for richer Slack-compatible messages
 ##### New Plugins
 The following plugins were added:
+- **Appearance**: Allows the appearance and some other things of creatures to be overridden per player
 - **Area**: Adds functions exposing additional area properties
 - **CombatModes**: Allows subscribing to Combat Mode toggle events. The Events plugin is needed to subscribe to the CombatMode events
 - **Effect**: Provides various utility functions to manipulate builtin effect types
@@ -56,6 +57,7 @@ The following plugins were added:
 - Administration: GetPlayOption()
 - Administration: SetPlayOption()
 - Administration: DeleteTURD()
+- Appearance: {Get|Set}Override()
 - Area: GetNumberOfPlayersInArea()
 - Area: GetLastEntered()
 - Area: GetLastLeft()

--- a/Plugins/Appearance/Appearance.cpp
+++ b/Plugins/Appearance/Appearance.cpp
@@ -102,6 +102,7 @@ void Appearance::ComputeGameObjectUpdateForObjectHook(Services::Hooks::CallType,
             SwapIntValue(aod->bitSet[TailType], aod->tailType, pCreature->m_cAppearance.m_nTailVariation);
             SwapIntValue(aod->bitSet[WingType], aod->wingType, pCreature->m_cAppearance.m_nWingVariation);
             SwapIntValue(aod->bitSet[FootstepSound], aod->footstepSound, pCreature->m_nFootstepType);
+            SwapIntValue(aod->bitSet[Portrait], aod->portraitId, pCreature->m_nPortraitId);
         }
     }
 }
@@ -144,70 +145,68 @@ ArgumentStack Appearance::SetOverride(ArgumentStack&& args)
 
         const std::string key = Utils::ObjectIDToString(pPlayer->m_oidNWSObject) + "_" + Utils::ObjectIDToString(oidCreature);
 
-        if (type < 0)
+        if (m_AppearanceOverrideData.find(key) == m_AppearanceOverrideData.end())
         {
-            m_AppearanceOverrideData.erase(key);
+            AppearanceOverrideData data = {};
+            m_AppearanceOverrideData[key] = data;
         }
-        else
+
+        AppearanceOverrideData *aod = &m_AppearanceOverrideData[key];
+
+        switch(type)
         {
-            if (m_AppearanceOverrideData.find(key) == m_AppearanceOverrideData.end())
-            {
-                AppearanceOverrideData data = {};
-                m_AppearanceOverrideData[key] = data;
-            }
+            case AppearanceType:
+                SetIntValue(type, value, aod->bitSet, aod->appearanceType);
+                break;
 
-            AppearanceOverrideData *aod = &m_AppearanceOverrideData[key];
+            case Gender:
+                SetIntValue(type, value, aod->bitSet, aod->gender);
+                break;
 
-            switch(type)
-            {
-                case AppearanceType:
-                    SetIntValue(type, value, aod->bitSet, aod->appearanceType);
-                    break;
+            case HitPoints:
+                SetIntValue(type, value, aod->bitSet, aod->currentHitPoints);
+                break;
 
-                case Gender:
-                    SetIntValue(type, value, aod->bitSet, aod->gender);
-                    break;
+            case HairColor:
+                SetIntValue(type, value, aod->bitSet, aod->hairColor);
+                break;
 
-                case HitPoints:
-                    SetIntValue(type, value, aod->bitSet, aod->currentHitPoints);
-                    break;
+            case SkinColor:
+                SetIntValue(type, value, aod->bitSet, aod->skinColor);
+                break;
 
-                case HairColor:
-                    SetIntValue(type, value, aod->bitSet, aod->hairColor);
-                    break;
+            case PhenoType:
+                SetIntValue(type, value, aod->bitSet, aod->phenoType);
+                break;
 
-                case SkinColor:
-                    SetIntValue(type, value, aod->bitSet, aod->skinColor);
-                    break;
+            case HeadType:
+                SetIntValue(type, value, aod->bitSet, aod->headType);
+                break;
 
-                case PhenoType:
-                    SetIntValue(type, value, aod->bitSet, aod->phenoType);
-                    break;
+            case SoundSet:
+                SetIntValue(type, value, aod->bitSet, aod->soundSet);
+                break;
 
-                case HeadType:
-                    SetIntValue(type, value, aod->bitSet, aod->headType);
-                    break;
+            case TailType:
+                SetIntValue(type, value, aod->bitSet, aod->tailType);
+                break;
 
-                case SoundSet:
-                    SetIntValue(type, value, aod->bitSet, aod->soundSet);
-                    break;
+            case WingType:
+                SetIntValue(type, value, aod->bitSet, aod->wingType);
+                break;
 
-                case TailType:
-                    SetIntValue(type, value, aod->bitSet, aod->tailType);
-                    break;
+            case FootstepSound:
+                SetIntValue(type, value, aod->bitSet, aod->footstepSound);
+                break;
 
-                case WingType:
-                    SetIntValue(type, value, aod->bitSet, aod->wingType);
-                    break;
+            case Portrait:
+                SetIntValue(type, value, aod->bitSet, aod->portraitId);
+                break;
 
-                case FootstepSound:
-                    SetIntValue(type, value, aod->bitSet, aod->footstepSound);
-                    break;
-
-                default:
-                    break;
-            }
+            default:
+                break;
         }
+
     }
 
     return stack;
@@ -278,6 +277,10 @@ ArgumentStack Appearance::GetOverride(ArgumentStack&& args)
 
                     case FootstepSound:
                         retVal = aod->footstepSound;
+                        break;
+
+                    case Portrait:
+                        retVal = aod->portraitId;
                         break;
 
                     default:

--- a/Plugins/Appearance/Appearance.cpp
+++ b/Plugins/Appearance/Appearance.cpp
@@ -1,0 +1,295 @@
+#include "Appearance.hpp"
+
+#include "API/CAppManager.hpp"
+#include "API/CServerExoApp.hpp"
+#include "API/Constants.hpp"
+#include "API/Globals.hpp"
+#include "API/Functions.hpp"
+#include "API/CNWSPlayer.hpp"
+#include "API/CNWSCreatureAppearanceInfo.hpp"
+#include "API/CNWSCreature.hpp"
+#include "Services/Events/Events.hpp"
+#include "Services/PerObjectStorage/PerObjectStorage.hpp"
+#include "ViewPtr.hpp"
+
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+static ViewPtr<Appearance::Appearance> g_plugin;
+
+NWNX_PLUGIN_ENTRY Plugin::Info* PluginInfo()
+{
+    return new Plugin::Info
+    {
+        "Appearance",
+        "Allows the appearance and some other things of creatures to be overridden per player",
+        "Daz",
+        "daztek@gmail.com",
+        1,
+        true
+    };
+}
+
+NWNX_PLUGIN_ENTRY Plugin* PluginLoad(Plugin::CreateParams params)
+{
+    g_plugin = new Appearance::Appearance(params);
+    return g_plugin;
+}
+
+
+namespace Appearance {
+
+Appearance::Appearance(const Plugin::CreateParams& params)
+    : Plugin(params)
+{
+#define REGISTER(func) \
+    GetServices()->m_events->RegisterEvent(#func, std::bind(&Appearance::func, this, std::placeholders::_1))
+
+    REGISTER(SetOverride);
+    REGISTER(GetOverride);
+
+#undef REGISTER
+
+    GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__ComputeGameObjectUpdateForObject, int32_t>
+            (&ComputeGameObjectUpdateForObjectHook);
+
+}
+
+Appearance::~Appearance()
+{
+}
+
+CNWSPlayer *Appearance::Player(ArgumentStack& args)
+{
+    const auto playerId = Services::Events::ExtractArgument<Types::ObjectID>(args);
+
+    if (playerId == Constants::OBJECT_INVALID)
+    {
+        LOG_NOTICE("NWNX_Appearance function called on OBJECT_INVALID");
+        return nullptr;
+    }
+
+    auto *pPlayer = Globals::AppManager()->m_pServerExoApp->GetClientObjectByObjectId(playerId);
+    if (!pPlayer)
+    {
+        LOG_NOTICE("NWNX_Appearance function called on non-player object %x", playerId);
+    }
+
+    return pPlayer;
+}
+
+void Appearance::ComputeGameObjectUpdateForObjectHook(Services::Hooks::CallType, CNWSMessage*,
+        CNWSPlayer *pPlayer, CNWSObject*, CGameObjectArray*, Types::ObjectID oidObjectToUpdate)
+{
+    if (auto *pCreature = Utils::AsNWSCreature(Utils::GetGameObject(oidObjectToUpdate)))
+    {
+        const std::string key = Utils::ObjectIDToString(pPlayer->m_oidNWSObject) + "_" +
+                Utils::ObjectIDToString(oidObjectToUpdate);
+
+        if (g_plugin->m_AppearanceOverrideData.find(key) != g_plugin->m_AppearanceOverrideData.end())
+        {
+            AppearanceOverrideData *aod = &g_plugin->m_AppearanceOverrideData[key];
+
+            SwapIntValue(aod->bitSet[AppearanceType], aod->appearanceType, pCreature->m_cAppearance.m_nAppearanceType);
+            SwapIntValue(aod->bitSet[Gender], aod->gender, pCreature->m_cAppearance.m_nGender);
+            SwapIntValue(aod->bitSet[HitPoints], aod->currentHitPoints, pCreature->m_nCurrentHitPoints);
+            SwapIntValue(aod->bitSet[HairColor], aod->hairColor, pCreature->m_cAppearance.m_nHairColor);
+            SwapIntValue(aod->bitSet[SkinColor], aod->skinColor, pCreature->m_cAppearance.m_nSkinColor);
+            SwapIntValue(aod->bitSet[PhenoType], aod->phenoType, pCreature->m_cAppearance.m_nPhenoType);
+            SwapIntValue(aod->bitSet[HeadType], aod->headType, pCreature->m_cAppearance.m_nHeadVariation);
+            SwapIntValue(aod->bitSet[SoundSet], aod->soundSet, pCreature->m_nSoundSet);
+            SwapIntValue(aod->bitSet[TailType], aod->tailType, pCreature->m_cAppearance.m_nTailVariation);
+            SwapIntValue(aod->bitSet[WingType], aod->wingType, pCreature->m_cAppearance.m_nWingVariation);
+            SwapIntValue(aod->bitSet[FootstepSound], aod->footstepSound, pCreature->m_nFootstepType);
+        }
+    }
+}
+
+template <typename T>
+void Appearance::SwapIntValue(bool isSet, T &overrideValueVar, T &creatureValueVar)
+{
+    if(isSet)
+    {
+        std::swap(overrideValueVar, creatureValueVar);
+    }
+}
+
+template <typename T>
+void Appearance::SetIntValue(int32_t type, int32_t value, std::bitset<OverrideType_MAX> &aodBitSet, T &aodVar)
+{
+    if (value < 0)
+    {
+        aodBitSet[type] = false;
+    }
+    else
+    {
+        aodBitSet[type] = true;
+        aodVar = static_cast<T>(value);
+    }
+}
+
+ArgumentStack Appearance::SetOverride(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+
+    if (auto *pPlayer = Player(args))
+    {
+        const auto oidCreature = Services::Events::ExtractArgument<Types::ObjectID>(args);
+          ASSERT_OR_THROW(oidCreature != Constants::OBJECT_INVALID);
+        const auto type = Services::Events::ExtractArgument<int32_t>(args);
+          ASSERT_OR_THROW(type >= 0);
+          ASSERT_OR_THROW(type < OverrideType_MAX);
+        const auto value = Services::Events::ExtractArgument<int32_t>(args);
+
+        const std::string key = Utils::ObjectIDToString(pPlayer->m_oidNWSObject) + "_" + Utils::ObjectIDToString(oidCreature);
+
+        if (type < 0)
+        {
+            m_AppearanceOverrideData.erase(key);
+        }
+        else
+        {
+            if (m_AppearanceOverrideData.find(key) == m_AppearanceOverrideData.end())
+            {
+                AppearanceOverrideData data = {};
+                m_AppearanceOverrideData[key] = data;
+            }
+
+            AppearanceOverrideData *aod = &m_AppearanceOverrideData[key];
+
+            switch(type)
+            {
+                case AppearanceType:
+                    SetIntValue(type, value, aod->bitSet, aod->appearanceType);
+                    break;
+
+                case Gender:
+                    SetIntValue(type, value, aod->bitSet, aod->gender);
+                    break;
+
+                case HitPoints:
+                    SetIntValue(type, value, aod->bitSet, aod->currentHitPoints);
+                    break;
+
+                case HairColor:
+                    SetIntValue(type, value, aod->bitSet, aod->hairColor);
+                    break;
+
+                case SkinColor:
+                    SetIntValue(type, value, aod->bitSet, aod->skinColor);
+                    break;
+
+                case PhenoType:
+                    SetIntValue(type, value, aod->bitSet, aod->phenoType);
+                    break;
+
+                case HeadType:
+                    SetIntValue(type, value, aod->bitSet, aod->headType);
+                    break;
+
+                case SoundSet:
+                    SetIntValue(type, value, aod->bitSet, aod->soundSet);
+                    break;
+
+                case TailType:
+                    SetIntValue(type, value, aod->bitSet, aod->tailType);
+                    break;
+
+                case WingType:
+                    SetIntValue(type, value, aod->bitSet, aod->wingType);
+                    break;
+
+                case FootstepSound:
+                    SetIntValue(type, value, aod->bitSet, aod->footstepSound);
+                    break;
+
+                default:
+                    break;
+            }
+        }
+    }
+
+    return stack;
+}
+
+ArgumentStack Appearance::GetOverride(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    int32_t retVal = -1;
+
+    if (auto *pPlayer = Player(args))
+    {
+        const auto oidCreature = Services::Events::ExtractArgument<Types::ObjectID>(args);
+          ASSERT_OR_THROW(oidCreature != Constants::OBJECT_INVALID);
+        const auto type = Services::Events::ExtractArgument<int32_t>(args);
+          ASSERT_OR_THROW(type >= 0);
+          ASSERT_OR_THROW(type < OverrideType_MAX);
+
+        const std::string key = Utils::ObjectIDToString(pPlayer->m_oidNWSObject) + "_" + Utils::ObjectIDToString(oidCreature);
+
+        if (m_AppearanceOverrideData.find(key) != m_AppearanceOverrideData.end())
+        {
+            AppearanceOverrideData *aod = &m_AppearanceOverrideData[key];
+
+            if(aod->bitSet[type])
+            {
+                switch(type)
+                {
+                    case AppearanceType:
+                        retVal = aod->appearanceType;
+                        break;
+
+                    case Gender:
+                        retVal = aod->gender;
+                        break;
+
+                    case HitPoints:
+                        retVal = aod->currentHitPoints;
+                        break;
+
+                    case HairColor:
+                        retVal = aod->hairColor;
+                        break;
+
+                    case SkinColor:
+                        retVal = aod->skinColor;
+                        break;
+
+                    case PhenoType:
+                        retVal = aod->phenoType;
+                        break;
+
+                    case HeadType:
+                        retVal = aod->headType;
+                        break;
+
+                    case SoundSet:
+                        retVal = aod->soundSet;
+                        break;
+
+                    case TailType:
+                        retVal = aod->tailType;
+                        break;
+
+                    case WingType:
+                        retVal = aod->wingType;
+                        break;
+
+                    case FootstepSound:
+                        retVal = aod->footstepSound;
+                        break;
+
+                    default:
+                        break;
+                }
+            }
+        }
+    }
+
+    Services::Events::InsertArgument(stack, retVal);
+
+    return stack;
+}
+
+}

--- a/Plugins/Appearance/Appearance.hpp
+++ b/Plugins/Appearance/Appearance.hpp
@@ -33,6 +33,7 @@ private:
         TailType        = 8,
         WingType        = 9,
         FootstepSound   = 10,
+        Portrait        = 11,
         OverrideType_MAX // Keep as last
     };
 
@@ -51,6 +52,7 @@ private:
         uint32_t tailType;
         uint32_t wingType;
         int32_t footstepSound;
+        uint16_t portraitId;
     };
 
     std::map<std::string, AppearanceOverrideData> m_AppearanceOverrideData;

--- a/Plugins/Appearance/Appearance.hpp
+++ b/Plugins/Appearance/Appearance.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "Plugin.hpp"
+#include "Services/Events/Events.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include <map>
+#include <bitset>
+
+using ArgumentStack = NWNXLib::Services::Events::ArgumentStack;
+
+namespace Appearance {
+
+class Appearance : public NWNXLib::Plugin
+{
+public:
+    Appearance(const Plugin::CreateParams& params);
+    virtual ~Appearance();
+
+private:
+    static NWNXLib::API::CNWSPlayer *Player(ArgumentStack& args);
+    static void ComputeGameObjectUpdateForObjectHook(NWNXLib::Services::Hooks::CallType, NWNXLib::API::CNWSMessage*,
+            NWNXLib::API::CNWSPlayer*, NWNXLib::API::CNWSObject*, NWNXLib::API::CGameObjectArray*, NWNXLib::API::Types::ObjectID);
+
+    enum OverrideType {
+        AppearanceType  = 0,
+        Gender          = 1,
+        HitPoints       = 2,
+        HairColor       = 3,
+        SkinColor       = 4,
+        PhenoType       = 5,
+        HeadType        = 6,
+        SoundSet        = 7,
+        TailType        = 8,
+        WingType        = 9,
+        FootstepSound   = 10,
+        OverrideType_MAX // Keep as last
+    };
+
+    struct AppearanceOverrideData
+    {
+        std::bitset<OverrideType_MAX> bitSet;
+
+        uint16_t appearanceType;
+        uint8_t gender;
+        int32_t currentHitPoints;
+        uint8_t hairColor;
+        uint8_t skinColor;
+        uint8_t phenoType;
+        uint8_t headType;
+        uint16_t soundSet;
+        uint32_t tailType;
+        uint32_t wingType;
+        int32_t footstepSound;
+    };
+
+    std::map<std::string, AppearanceOverrideData> m_AppearanceOverrideData;
+
+    template <typename T>
+    static void SwapIntValue(bool, T&, T&);
+    template <typename T>
+    static void SetIntValue(int32_t, int32_t, std::bitset<OverrideType_MAX>&, T&);
+
+    ArgumentStack SetOverride (ArgumentStack&& args);
+    ArgumentStack GetOverride (ArgumentStack&& args);
+};
+
+}

--- a/Plugins/Appearance/CMakeLists.txt
+++ b/Plugins/Appearance/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_plugin(Appearance
+    "Appearance.cpp")

--- a/Plugins/Appearance/Documentation/README.md
+++ b/Plugins/Appearance/Documentation/README.md
@@ -1,0 +1,7 @@
+# Appearance Plugin Reference
+
+## Description
+
+Allows the appearance and some other things of creatures to be overridden per player
+
+## Environment Variables

--- a/Plugins/Appearance/NWScript/nwnx_appearance.nss
+++ b/Plugins/Appearance/NWScript/nwnx_appearance.nss
@@ -1,0 +1,79 @@
+#include "nwnx"
+
+const int NWNX_APPEARANCE_TYPE_APPEARANCE       = 0;
+const int NWNX_APPEARANCE_TYPE_GENDER           = 1;
+const int NWNX_APPEARANCE_TYPE_HITPOINTS        = 2;
+const int NWNX_APPEARANCE_TYPE_HAIR_COLOR       = 3;
+const int NWNX_APPEARANCE_TYPE_SKIN_COLOR       = 4;
+const int NWNX_APPEARANCE_TYPE_PHENOTYPE        = 5;
+const int NWNX_APPEARANCE_TYPE_HEAD_TYPE        = 6;
+const int NWNX_APPEARANCE_TYPE_SOUNDSET         = 7;
+const int NWNX_APPEARANCE_TYPE_TAIL_TYPE        = 8;
+const int NWNX_APPEARANCE_TYPE_WING_TYPE        = 9;
+const int NWNX_APPEARANCE_TYPE_FOOTSTEP_SOUND   = 10;
+
+// Override oCreature's nType to nValue for oPlayer
+//
+// nType = NWNX_APPEARANCE_TYPE_APPEARANCE
+// nValue = APPEARANCE_TYPE_* or -1 to remove
+//
+// nType = NWNX_APPEARANCE_TYPE_GENDER
+// nValue = GENDER_* or -1 to remove
+//
+// nType = NWNX_APPEARANCE_TYPE_HITPOINTS
+// nValue = 0-GetMaxHitPoints(oCreature) or -1 to remove
+//
+// nType = NWNX_APPEARANCE_TYPE_HAIR_COLOR
+// nType = NWNX_APPEARANCE_TYPE_SKIN_COLOR
+// nValue = 0-175 or -1 to remove
+//
+// nType = NWNX_APPEARANCE_TYPE_PHENOTYPE
+// nValue = PHENOTYPE_* or -1 to remove
+//
+// nType = NWNX_APPEARANCE_TYPE_HEAD_TYPE
+// nValue = 0-? or -1 to remove
+//
+// nType = NWNX_APPEARANCE_TYPE_SOUNDSET
+// nValue = See soundset.2da or -1 to remove
+//
+// nType = NWNX_APPEARANCE_TYPE_TAIL_TYPE
+// nValue = CREATURE_WING_TYPE_* or see wingmodel.2da, -1 to remove
+//
+// nType = NWNX_APPEARANCE_TYPE_WING_TYPE
+// nValue = CREATURE_TAIL_TYPE_* or see tailmodel.2da, -1 to remove
+//
+// nType = NWNX_APPEARANCE_TYPE_FOOTSTEP_SOUND
+// nValue = 0-17 or see footstepsounds.2da, -1 to remove
+void NWNX_Appearance_SetOverride(object oPlayer, object oCreature, int nType, int nValue);
+
+// Get oCreature's nValue of nType for oPlayer
+// Returns -1 when not set
+int NWNX_Appearance_GetOverride(object oPlayer, object oCreature, int nType);
+
+const string NWNX_Appearance = "NWNX_Appearance";
+
+
+void NWNX_Appearance_SetOverride(object oPlayer, object oCreature, int nType, int nValue)
+{
+    string sFunc = "SetOverride";
+
+    NWNX_PushArgumentInt(NWNX_Appearance, sFunc, nValue);
+    NWNX_PushArgumentInt(NWNX_Appearance, sFunc, nType);
+    NWNX_PushArgumentObject(NWNX_Appearance, sFunc, oCreature);
+    NWNX_PushArgumentObject(NWNX_Appearance, sFunc, oPlayer);
+
+    NWNX_CallFunction(NWNX_Appearance, sFunc);
+}
+
+int NWNX_Appearance_GetOverride(object oPlayer, object oCreature, int nType)
+{
+    string sFunc = "GetOverride";
+
+    NWNX_PushArgumentInt(NWNX_Appearance, sFunc, nType);
+    NWNX_PushArgumentObject(NWNX_Appearance, sFunc, oCreature);
+    NWNX_PushArgumentObject(NWNX_Appearance, sFunc, oPlayer);
+
+    NWNX_CallFunction(NWNX_Appearance, sFunc);
+
+    return NWNX_GetReturnValueInt(NWNX_Appearance, sFunc);
+}

--- a/Plugins/Appearance/NWScript/nwnx_appearance.nss
+++ b/Plugins/Appearance/NWScript/nwnx_appearance.nss
@@ -11,8 +11,10 @@ const int NWNX_APPEARANCE_TYPE_SOUNDSET         = 7;
 const int NWNX_APPEARANCE_TYPE_TAIL_TYPE        = 8;
 const int NWNX_APPEARANCE_TYPE_WING_TYPE        = 9;
 const int NWNX_APPEARANCE_TYPE_FOOTSTEP_SOUND   = 10;
+const int NWNX_APPEARANCE_TYPE_PORTRAIT         = 11;
 
 // Override oCreature's nType to nValue for oPlayer
+// - oCreature can be a PC
 //
 // nType = NWNX_APPEARANCE_TYPE_APPEARANCE
 // nValue = APPEARANCE_TYPE_* or -1 to remove
@@ -44,9 +46,14 @@ const int NWNX_APPEARANCE_TYPE_FOOTSTEP_SOUND   = 10;
 //
 // nType = NWNX_APPEARANCE_TYPE_FOOTSTEP_SOUND
 // nValue = 0-17 or see footstepsounds.2da, -1 to remove
+//
+// nType = NWNX_APPEARANCE_TYPE_PORTRAIT
+// nValue = See portraits.2da, -1 to remove
+// NOTE: Does not change the Examine Window portrait
 void NWNX_Appearance_SetOverride(object oPlayer, object oCreature, int nType, int nValue);
 
 // Get oCreature's nValue of nType for oPlayer
+// - oCreature can be a PC
 // Returns -1 when not set
 int NWNX_Appearance_GetOverride(object oPlayer, object oCreature, int nType);
 

--- a/Plugins/Appearance/NWScript/nwnx_appearance.nss
+++ b/Plugins/Appearance/NWScript/nwnx_appearance.nss
@@ -24,6 +24,7 @@ const int NWNX_APPEARANCE_TYPE_PORTRAIT         = 11;
 //
 // nType = NWNX_APPEARANCE_TYPE_HITPOINTS
 // nValue = 0-GetMaxHitPoints(oCreature) or -1 to remove
+// NOTE: This is visual only. Does not change the Examine Window health status
 //
 // nType = NWNX_APPEARANCE_TYPE_HAIR_COLOR
 // nType = NWNX_APPEARANCE_TYPE_SKIN_COLOR


### PR DESCRIPTION
Lets you override the appearance and some other things of creatures per player!

Example:
`NWNX_Appearance_SetOverride(oPlayerOne, oPlayerTwo, NWNX_APPEARANCE_TYPE_GENDER, 1);`
Result: 
PlayerTwo will now look female to PlayerOne!

Currently supports the following:
- AppearanceType
- Gender
- HitPoints
- HairColor
- SkinColor
- PhenoType
- HeadType
- SoundSet
- TailType
- WingType
- FootstepSound
- Portrait 