### PR TITLE
refactored OnAttack hook and permit setting of AttackResult

### DIFF
--- a/Plugins/Damage/Damage.cpp
+++ b/Plugins/Damage/Damage.cpp
@@ -180,6 +180,7 @@ ArgumentStack Damage::SetAttackEventData(ArgumentStack&& args)
     {
         m_AttackData.vDamage[k] = Services::Events::ExtractArgument<int32_t>(args);
     }
+    m_AttackData.nAttackResult = Services::Events::ExtractArgument<int32_t>(args);
 
     return stack;
 }
@@ -212,10 +213,11 @@ void Damage::OnCombatAttack(CNWSCreature *pThis, CNWSObject *pTarget, std::strin
     attackData.nAttackResult = combatAttackData->m_nAttackResult;
     attackData.nAttackType = combatAttackData->m_nWeaponAttackType;
     attackData.nSneakAttack = combatAttackData->m_bSneakAttack + (combatAttackData->m_bDeathAttack << 1);
-
     std::memcpy(attackData.vDamage, combatAttackData->m_nDamage, sizeof(attackData.vDamage));
+    // run script, then copy back attack data
     Utils::ExecuteScript(script, pThis->m_idSelf);
     std::memcpy(combatAttackData->m_nDamage, attackData.vDamage, sizeof(attackData.vDamage));
+    combatAttackData->m_nAttackResult = attackData.nAttackResult;
 }
 
 //--------------------------- Dealing Damage ----------------------------------

--- a/Plugins/Damage/Damage.cpp
+++ b/Plugins/Damage/Damage.cpp
@@ -57,10 +57,10 @@ Damage::Damage(const Plugin::CreateParams& params)
 #undef REGISTER
 
     GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWSEffectListHandler__OnApplyDamage>(&Damage::OnApplyDamage);
-    GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWSCombatRound__SetCurrentAttack>(&Damage::OnCombatAttack);
+    GetServices()->m_hooks->RequestSharedHook<Functions::CNWSCreature__SignalMeleeDamage, void>(&Damage::OnSignalDamage);
+    GetServices()->m_hooks->RequestSharedHook<Functions::CNWSCreature__SignalRangedDamage, void>(&Damage::OnSignalDamage);
 
     m_OnApplyDamageHook = GetServices()->m_hooks->FindHookByAddress(Functions::CNWSEffectListHandler__OnApplyDamage);
-    m_OnCombatAttackHook = GetServices()->m_hooks->FindHookByAddress(Functions::CNWSCombatRound__SetCurrentAttack);
 
     m_EventScripts["DAMAGE"] = "";
     m_EventScripts["ATTACK"] = "";
@@ -184,29 +184,38 @@ ArgumentStack Damage::SetAttackEventData(ArgumentStack&& args)
     return stack;
 }
 
-void Damage::OnCombatAttack(NWNXLib::API::CNWSCombatRound *pThis, uint8_t attackNumber)
+void Damage::OnSignalDamage(Services::Hooks::CallType type, CNWSCreature *pThis, CNWSObject *pTarget, uint32_t nAttacks)
 {
-    std::string script = GetEventScript(pThis->m_pBaseCreature, "ATTACK");
-    AttackDataStr& attackData = g_plugin->m_AttackData;
-    // SetCurrentAttack is 1-based, GetAttack is 0-based
-    CNWSCombatAttackData *combatAttackData = pThis->GetAttack(attackNumber - 1);
-
-    if (!script.empty())
+    // only call once, either before or after original
+    if ( type == Services::Hooks::CallType::BEFORE_ORIGINAL )
     {
-        // Prepare the data for the nwscript
-        attackData.oidTarget = pThis->m_pBaseCreature->m_oidAttackTarget;
-        attackData.nAttackNumber = attackNumber;
-        attackData.nAttackResult = combatAttackData->m_nAttackResult;
-        attackData.nAttackType = combatAttackData->m_nWeaponAttackType;
-        attackData.nSneakAttack = combatAttackData->m_bSneakAttack
-            + (combatAttackData->m_bDeathAttack << 1);
-
-        std::memcpy(attackData.vDamage, combatAttackData->m_nDamage, sizeof(attackData.vDamage));
-        Utils::ExecuteScript(script, pThis->m_pBaseCreature->m_idSelf);
-        std::memcpy(combatAttackData->m_nDamage, attackData.vDamage, sizeof(attackData.vDamage));
+        std::string script = GetEventScript(pThis, "ATTACK");
+        if ( !script.empty() )
+        {
+            // m_nCurrentAttack points to the attack *after* this flurry
+            uint8_t attackNumberOffset = pThis->m_pcCombatRound->m_nCurrentAttack - nAttacks;
+            // trigger script once per attack in the flurry
+            for ( uint8_t i = 0; i < nAttacks; i++ )
+                OnCombatAttack(pThis, pTarget, script, attackNumberOffset + i);
+        }
     }
+}
 
-    g_plugin->m_OnCombatAttackHook->CallOriginal<void>(pThis, attackNumber);
+void Damage::OnCombatAttack(CNWSCreature *pThis, CNWSObject *pTarget, std::string script, uint8_t attackNumber)
+{
+    AttackDataStr& attackData = g_plugin->m_AttackData;
+    CNWSCombatRound *combatRound = pThis->m_pcCombatRound;
+    CNWSCombatAttackData *combatAttackData = combatRound->GetAttack(attackNumber);
+    // Prepare the data for the nwscript
+    attackData.oidTarget = pTarget->m_idSelf;
+    attackData.nAttackNumber = attackNumber + 1; // 1-based for backwards compatibility
+    attackData.nAttackResult = combatAttackData->m_nAttackResult;
+    attackData.nAttackType = combatAttackData->m_nWeaponAttackType;
+    attackData.nSneakAttack = combatAttackData->m_bSneakAttack + (combatAttackData->m_bDeathAttack << 1);
+
+    std::memcpy(attackData.vDamage, combatAttackData->m_nDamage, sizeof(attackData.vDamage));
+    Utils::ExecuteScript(script, pThis->m_idSelf);
+    std::memcpy(combatAttackData->m_nDamage, attackData.vDamage, sizeof(attackData.vDamage));
 }
 
 //--------------------------- Dealing Damage ----------------------------------

--- a/Plugins/Damage/Damage.hpp
+++ b/Plugins/Damage/Damage.hpp
@@ -20,6 +20,7 @@ struct AttackDataStr
     uint8_t  nAttackResult;
     uint8_t  nAttackType;
     uint8_t  nSneakAttack;
+    uint8_t  bRanged;
 };
 
 namespace Damage {
@@ -39,10 +40,10 @@ private:
     ArgumentStack DealDamage(ArgumentStack&& args);
 
     NWNXLib::Hooking::FunctionHook* m_OnApplyDamageHook;
-    NWNXLib::Hooking::FunctionHook* m_OnCombatAttackHook;
 
     static int32_t OnApplyDamage(NWNXLib::API::CNWSEffectListHandler *pThis, NWNXLib::API::CNWSObject *pObject, NWNXLib::API::CGameEffect *pEffect, bool bLoadingGame);
-    static void OnCombatAttack(NWNXLib::API::CNWSCombatRound *pThis, uint8_t attackNumber);
+    static void OnSignalDamage(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWSCreature *pThis, NWNXLib::API::CNWSObject *pTarget, uint32_t nAttacks);
+    static void OnCombatAttack(NWNXLib::API::CNWSCreature *pThis, NWNXLib::API::CNWSObject *pTarget, std::string script, uint8_t attackNumber);
 
     static std::string GetEventScript(NWNXLib::API::CNWSObject *pObject, const std::string &event);
 

--- a/Plugins/Damage/NWScript/nwnx_damage.nss
+++ b/Plugins/Damage/NWScript/nwnx_damage.nss
@@ -76,10 +76,10 @@ void NWNX_Damage_SetDamageEventData(struct NWNX_Damage_DamageEventData data);
 // If oOwner is valid, it will set it only for that creature.
 void NWNX_Damage_SetAttackEventScript(string sScript, object oOwner=OBJECT_INVALID);
 
-// Get Attack Event Data (to use only on Attack Event Script)
+// Get Attack Event data (use only in Attack Event script)
 struct NWNX_Damage_AttackEventData NWNX_Damage_GetAttackEventData();
 
-// Set Attack Event Data (to use only on Attack Event Script)
+// Set Attack Event data (use only in Attack Event script)
 void NWNX_Damage_SetAttackEventData(struct NWNX_Damage_AttackEventData data);
 
 // Deal damage to target - permits multiple damage types and checks enhancement bonus for overcoming DR
@@ -188,6 +188,7 @@ void NWNX_Damage_SetAttackEventData(struct NWNX_Damage_AttackEventData data)
 {
     string sFunc = "SetAttackEventData";
 
+    NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iAttackResult);
     NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iBase);
     NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iSonic);
     NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iPositive);


### PR DESCRIPTION
* OnAttack now hooks into `CNWSCreature::Signal{Melee|Ranged}Damage` instead of `CNWSCombatRound::SetCurrentAttack` (which is conceptually cleaner)
* Changing the iAttackResult field will now propagate to the NWN engine

The latter can e.g. be used to force an attack to miss, in which case none of the damage will be dealt. A hit can also be forced, in which case damage must be set manually.