### PR TITLE
Item: GetMinEquipLevel()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ The following plugins were added:
 - Feedback: Set{Feedback|CombatLog|JournalUpdated}MessageHidden()
 - Feedback: Set{Feedback|CombatLog}MessageMode()
 - Item: GetBaseArmorClass()
+- Item: GetMinEquipLevel()
 - ItemProperty: PackIP()
 - ItemProperty: UnpackIP()
 - Object: GetHasVisualEffect()

--- a/Plugins/Item/Documentation/README.md
+++ b/Plugins/Item/Documentation/README.md
@@ -21,6 +21,7 @@ NWNX_Item_SetBaseItemType | Change the item's base item type (e.g. change an arm
 NWNX_Item_SetItemAppearance | Change item's appearance. A more general function with syntax similar to the NWScript function CopyItemAndModify. Changes will not be visible until the item is refreshed (e.g. drop and take the item, or logging out and back in).
 NWNX_Item_GetEntireItemAppearance | Gets the full item appearance as a string.
 NWNX_Item_RestoreItemAppearance | Restores an item's appearance with the supplied appearance string.
+NWNX_Item_GetBaseArmorClass | Get the item's base armor class.
 NWNX_Item_GetMinEquipLevel | Gets the minimum level required to equip the item.
 
 

--- a/Plugins/Item/Documentation/README.md
+++ b/Plugins/Item/Documentation/README.md
@@ -19,6 +19,9 @@ NWNX_Item_SetAddGoldPieceValue | Change the item's additional value in gold piec
 NWNX_Item_GetAddGoldPieceValue | Get the item's additional value in gold pieces.
 NWNX_Item_SetBaseItemType | Change the item's base item type (e.g. change an armor into a ring). Changes will not be visible until the item is refreshed (e.g. drop and take the item, or logging out and back in).
 NWNX_Item_SetItemAppearance | Change item's appearance. A more general function with syntax similar to the NWScript function CopyItemAndModify. Changes will not be visible until the item is refreshed (e.g. drop and take the item, or logging out and back in).
+NWNX_Item_GetEntireItemAppearance | Gets the full item appearance as a string.
+NWNX_Item_RestoreItemAppearance | Restores an item's appearance with the supplied appearance string.
+NWNX_Item_GetMinEquipLevel | Gets the minimum level required to equip the item.
 
 
 

--- a/Plugins/Item/Item.cpp
+++ b/Plugins/Item/Item.cpp
@@ -50,6 +50,7 @@ Item::Item(const Plugin::CreateParams& params)
     REGISTER(GetEntireItemAppearance);
     REGISTER(RestoreItemAppearance);
     REGISTER(GetBaseArmorClass);
+    REGISTER(GetMinEquipLevel);
 
 #undef REGISTER
 }
@@ -303,5 +304,18 @@ ArgumentStack Item::GetBaseArmorClass(ArgumentStack&& args)
     Services::Events::InsertArgument(stack, retval);
     return stack;
 }
+
+ArgumentStack Item::GetMinEquipLevel(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    int32_t retval = -1;
+    if (auto *pItem = item(args))
+    {
+        retval = pItem->GetMinEquipLevel();
+    }
+    Services::Events::InsertArgument(stack, retval);
+    return stack;
+}
+
 
 }

--- a/Plugins/Item/Item.hpp
+++ b/Plugins/Item/Item.hpp
@@ -26,6 +26,7 @@ private:
     ArgumentStack GetEntireItemAppearance (ArgumentStack&& args);
     ArgumentStack RestoreItemAppearance   (ArgumentStack&& args);
     ArgumentStack GetBaseArmorClass       (ArgumentStack&& args);
+    ArgumentStack GetMinEquipLevel        (ArgumentStack&& args);
 
     NWNXLib::API::CNWSItem *item(ArgumentStack& args);
 };

--- a/Plugins/Item/NWScript/nwnx_item.nss
+++ b/Plugins/Item/NWScript/nwnx_item.nss
@@ -58,6 +58,9 @@ void NWNX_Item_RestoreItemAppearance (object oItem, string sApp);
 // Get oItem's base armor class
 int NWNX_Item_GetBaseArmorClass(object oItem);
 
+// Get oItem's minimum level needed to equip
+int NWNX_Item_GetMinEquipLevel(object oItem);
+
 void NWNX_Item_SetWeight(object oItem, int w)
 {
     string sFunc = "SetWeight";
@@ -154,6 +157,16 @@ void NWNX_Item_RestoreItemAppearance(object oItem, string sApp)
 int NWNX_Item_GetBaseArmorClass(object oItem)
 {
     string sFunc = "GetBaseArmorClass";
+
+    NWNX_PushArgumentObject(NWNX_Item, sFunc, oItem);
+
+    NWNX_CallFunction(NWNX_Item, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Item, sFunc);
+}
+
+int NWNX_Item_GetMinEquipLevel(object oItem)
+{
+    string sFunc = "GetMinEquipLevel";
 
     NWNX_PushArgumentObject(NWNX_Item, sFunc, oItem);
 


### PR DESCRIPTION
I'd prefer to just display this information on all items so PCs who qualify already can share the minimum level required (for example advertising something for sale) with other PCs but it looks like I'd have to rewrite `SendServerToPlayerExamineGui_ItemData` entirely. Instead we have a custom item that PCs use on an item to tell its level requirement.