### PR TITLE
[Core] Remove SavingThrow None

### DIFF
--- a/NWNXLib/API/Constants/MiscRules.hpp
+++ b/NWNXLib/API/Constants/MiscRules.hpp
@@ -97,7 +97,6 @@ namespace SavingThrow
     enum TYPE
     {
         All          = 0,
-        None         = 0,
         Fortitude    = 1,
         Reflex       = 2,
         Will         = 3,
@@ -109,7 +108,7 @@ namespace SavingThrow
     {
         constexpr const char* TYPE_STRINGS[] =
         {
-            "All/None",
+            "All",
             "Fortitude",
             "Reflex",
             "Will",


### PR DESCRIPTION
There's a SavingThrowType None but that's not the same thing.