### PR TITLE
Util: add Get{First|Next}ResRef()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,7 @@ The following plugins were added:
 - Util: SetMinutesPerHour()
 - Util: EncodeStringForURL()
 - Util: Get2DARowCount()
+- Util: Get{First|Next}ResRef()
 - Visibility: GetVisibilityOverride()
 - Visibility: SetVisibilityOverride()
 - Weapon: SetWeaponIsMonkWeapon()

--- a/Plugins/Util/NWScript/nwnx_util.nss
+++ b/Plugins/Util/NWScript/nwnx_util.nss
@@ -46,6 +46,19 @@ void NWNX_Util_SetMinutesPerHour(int minutes);
 string NWNX_Util_EncodeStringForURL(string str);
 // Gets the row count for a 2da
 int NWNX_Util_Get2DARowCount(string str);
+// Get the first resref of nType
+// - nType: NWNX_UTIL_RESREF_TYPE_*
+// - sRegexFilter: Lets you filter out resrefs using a regexfilter
+//                 For example: "nwnx_.*" gets you all scripts prefixed with nwnx_
+//                 when using the NSS resref type.
+// - bModuleResourcesOnly: If TRUE only custom resources will be returned
+//
+// Returns "" if no resref is found
+string NWNX_Util_GetFirstResRef(int nType, string sRegexFilter = "", int bModuleResourcesOnly = TRUE);
+// Get the next resref
+// Returns "" if no resref is found
+string NWNX_Util_GetNextResRef();
+
 
 const string NWNX_Util = "NWNX_Util";
 
@@ -159,4 +172,25 @@ int NWNX_Util_Get2DARowCount(string str)
     NWNX_PushArgumentString(NWNX_Util, sFunc, str);
     NWNX_CallFunction(NWNX_Util, sFunc);
     return NWNX_GetReturnValueInt(NWNX_Util, sFunc);
+}
+
+string NWNX_Util_GetFirstResRef(int nType, string sRegexFilter = "", int bModuleResourcesOnly = TRUE)
+{
+    string sFunc = "GetFirstResRef";
+
+    NWNX_PushArgumentInt(NWNX_Util, sFunc, bModuleResourcesOnly);
+    NWNX_PushArgumentString(NWNX_Util, sFunc, sRegexFilter);
+    NWNX_PushArgumentInt(NWNX_Util, sFunc, nType);
+    NWNX_CallFunction(NWNX_Util, sFunc);
+
+    return NWNX_GetReturnValueString(NWNX_Util, sFunc);
+}
+
+string NWNX_Util_GetNextResRef()
+{
+    string sFunc = "GetNextResRef";
+
+    NWNX_CallFunction(NWNX_Util, sFunc);
+
+    return NWNX_GetReturnValueString(NWNX_Util, sFunc);
 }

--- a/Plugins/Util/NWScript/nwnx_util_t.nss
+++ b/Plugins/Util/NWScript/nwnx_util_t.nss
@@ -60,5 +60,8 @@ void main()
     string sTwoDA = "bodybag";
     report("Get2DARowCount", NWNX_Util_Get2DARowCount(sTwoDA) == 7);
 
+    report("GetFirstResRef", NWNX_Util_GetFirstResRef(NWNX_UTIL_RESREF_TYPE_NSS, "nwnx_util.*") != "");
+    report("GetNextResRef", NWNX_Util_GetNextResRef() != "");
+
     WriteTimestampedLogEntry("NWNX_Util unit test end.");
 }

--- a/Plugins/Util/Util.hpp
+++ b/Plugins/Util/Util.hpp
@@ -28,6 +28,11 @@ private:
     ArgumentStack SetMinutesPerHour(ArgumentStack&& args);
     ArgumentStack EncodeStringForURL(ArgumentStack&& args);
     ArgumentStack Get2DARowCount(ArgumentStack&& args);
+    ArgumentStack GetFirstResRef(ArgumentStack&& args);
+    ArgumentStack GetNextResRef(ArgumentStack&& args);
+
+    size_t m_resRefIndex;
+    std::vector<std::string> m_listResRefs;
 };
 
 }


### PR DESCRIPTION
Resolves #497

Example: 

Getting all the nwnx scripts

```
#include "nwnx_util"

void main()
{
    string sResRef = NWNX_Util_GetFirstResRef(NWNX_UTIL_RESREF_TYPE_NSS, "nwnx.*");

    while (sResRef != "")
    {
        SendMessageToPC(GetFirstPC(), sResRef);

        sResRef = NWNX_Util_GetNextResRef();
    }
}
```