### PR TITLE
Item Events: Identify Related

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Events: Added Sticky Player Name Reserved event allowing builders to use another method instead of knownservernames.2da to validate player names and cd keys
 - Events: Added Level{Up|UpAutomatic|Down} events to LevelEvents
 - Events: Added WebHook Success/Failure events with rate limit feedback
+- Events: Added UseLoreOnItem and PayToIdentifyItem events
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite
 - Tweaks: DisableQuickSave

--- a/Plugins/Events/Events/ItemEvents.cpp
+++ b/Plugins/Events/Events/ItemEvents.cpp
@@ -428,10 +428,8 @@ int32_t ItemEvents::UseLoreOnItemHook(CNWSCreature *thisPtr, Types::ObjectID ite
     return retVal;
 }
 
-int32_t ItemEvents::PayToIdentifyItemHook(CNWSCreature *thisPtr, Types::ObjectID item, Types::ObjectID store)
+void ItemEvents::PayToIdentifyItemHook(CNWSCreature *thisPtr, Types::ObjectID item, Types::ObjectID store)
 {
-    int32_t retVal;
-
     auto PushAndSignal = [&](std::string ev) -> bool {
         Events::PushEventData("ITEM", Utils::ObjectIDToString(item));
         Events::PushEventData("STORE", Utils::ObjectIDToString(store));
@@ -440,14 +438,10 @@ int32_t ItemEvents::PayToIdentifyItemHook(CNWSCreature *thisPtr, Types::ObjectID
 
     if (PushAndSignal("NWNX_ON_ITEM_PAY_TO_IDENTIFY_BEFORE"))
     {
-        retVal = m_PayToIdenfifyItemHook->CallOriginal<int32_t>(thisPtr, item, store);
+        m_PayToIdenfifyItemHook->CallOriginal<int32_t>(thisPtr, item, store);
     }
-    else
-        retVal = false;
 
     PushAndSignal("NWNX_ON_ITEM_PAY_TO_IDENTIFY_AFTER");
-
-    return retVal;
 }
 
 }

--- a/Plugins/Events/Events/ItemEvents.hpp
+++ b/Plugins/Events/Events/ItemEvents.hpp
@@ -25,6 +25,8 @@ private:
     static int32_t RunEquipHook(NWNXLib::API::CNWSCreature*, NWNXLib::API::Types::ObjectID, uint32_t, uint32_t);
     static int32_t RunUnequipHook(NWNXLib::API::CNWSCreature*, NWNXLib::API::Types::ObjectID, NWNXLib::API::Types::ObjectID, uint8_t, uint8_t, int32_t, uint32_t);
     static void ItemEventHandlerHook(NWNXLib::API::CNWSItem*, uint32_t, NWNXLib::API::Types::ObjectID, void*, uint32_t, uint32_t);
+    static int32_t UseLoreOnItemHook(NWNXLib::API::CNWSCreature*, NWNXLib::API::Types::ObjectID);
+    static int32_t PayToIdentifyItemHook(NWNXLib::API::CNWSCreature*, NWNXLib::API::Types::ObjectID, NWNXLib::API::Types::ObjectID);
 };
 
 }

--- a/Plugins/Events/Events/ItemEvents.hpp
+++ b/Plugins/Events/Events/ItemEvents.hpp
@@ -26,7 +26,7 @@ private:
     static int32_t RunUnequipHook(NWNXLib::API::CNWSCreature*, NWNXLib::API::Types::ObjectID, NWNXLib::API::Types::ObjectID, uint8_t, uint8_t, int32_t, uint32_t);
     static void ItemEventHandlerHook(NWNXLib::API::CNWSItem*, uint32_t, NWNXLib::API::Types::ObjectID, void*, uint32_t, uint32_t);
     static int32_t UseLoreOnItemHook(NWNXLib::API::CNWSCreature*, NWNXLib::API::Types::ObjectID);
-    static int32_t PayToIdentifyItemHook(NWNXLib::API::CNWSCreature*, NWNXLib::API::Types::ObjectID, NWNXLib::API::Types::ObjectID);
+    static void PayToIdentifyItemHook(NWNXLib::API::CNWSCreature*, NWNXLib::API::Types::ObjectID, NWNXLib::API::Types::ObjectID);
 };
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -130,6 +130,28 @@
         OBJECT_SELF = The item triggering the event
 
     Note: Use of NWNX_ON_ITEM_(DESTROY_OBJECT|DECREMENT_STACKSIZE)_* conflicts with object event handler profiling
+
+    NWNX_ON_ITEM_USE_LORE_BEFORE
+    NWNX_ON_ITEM_USE_LORE_AFTER
+
+    Usage:
+        OBJECT_SELF = The player attempting to identify an item with their lore skill
+
+    Event data:
+        Variable Name           Type        Notes
+        ITEM                    object      Convert to object with NWNX_Object_StringToObject()
+
+    NWNX_ON_ITEM_PAY_TO_IDENTIFY_BEFORE
+    NWNX_ON_ITEM_PAY_TO_IDENTIFY_AFTER
+
+    Usage:
+        OBJECT_SELF = The player attempting to pay to identify an item
+
+    Event data:
+        Variable Name           Type        Notes
+        ITEM                    object      Convert to object with NWNX_Object_StringToObject()
+        STORE                   object      Convert to object with NWNX_Object_StringToObject()
+
 ////////////////////////////////////////////////////////////////////////////////
     NWNX_ON_USE_FEAT_BEFORE
     NWNX_ON_USE_FEAT_AFTER


### PR DESCRIPTION
Builders can bypass the internal identifying functions and script their own logic, for example:

```c
#include "nwnx_events"
#include "nwnx_object"

void main()
{
    object oPC = OBJECT_SELF;
    string sCurrentEvent = NWNX_Events_GetCurrentEvent();
    object oItem = NWNX_Object_StringToObject(NWNX_Events_GetEventData("ITEM"));
    if (sCurrentEvent == "NWNX_ON_ITEM_USE_LORE_BEFORE")
    {
        if (GetLocalInt(oItem, "special_identify"))
        {
            SendMessageToPC(oPC, "You cannot identify this.");
            NWNX_Events_SkipEvent();
        }
    }
    if (sCurrentEvent == "NWNX_ON_ITEM_PAY_TO_IDENTIFY_BEFORE")
    {
        if (GetLocalInt(oItem, "special_identify"))
        {
            object oStore = NWNX_Object_StringToObject(NWNX_Events_GetEventData("STORE"));
            if (!GetLocalInt(oStore, "special_identifier"))
            {
                SendMessageToPC(oPC, "You cannot pay to identify this.");
                NWNX_Events_SkipEvent();
            }
        }
    }
}
```