### PR TITLE
Updating nss files for style consistency

### DIFF
--- a/Core/NWScript/nwnx_consts.nss
+++ b/Core/NWScript/nwnx_consts.nss
@@ -2,6 +2,7 @@
 
 // Translates ANIMATION_LOOPING_* and ANIMATION_FIREFORGET_* constants to their NWNX equivalent.
 int NWNX_Consts_TranslateNWScriptAnimation(int nAnimation);
+
 // Translates OBJECT_TYPE_* constants to their NWNX equivalent.
 int NWNX_Consts_TranslateNWScriptObjectType(int nObjectType);
 

--- a/Plugins/Administration/NWScript/nwnx_admin.nss
+++ b/Plugins/Administration/NWScript/nwnx_admin.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Administration = "NWNX_Administration";
+
 const int NWNX_ADMINISTRATION_OPTION_ALL_KILLABLE               = 0;  // TRUE/FALSE
 const int NWNX_ADMINISTRATION_OPTION_NON_PARTY_KILLABLE         = 1;  // TRUE/FALSE
 const int NWNX_ADMINISTRATION_OPTION_REQUIRE_RESURRECTION       = 2;  // TRUE/FALSE
@@ -55,13 +57,16 @@ void NWNX_Administration_DeletePlayerCharacter(object pc, int bPreserveBackup = 
 // Ban a given IP - get via GetPCIPAddress()
 void NWNX_Administration_AddBannedIP(string ip);
 void NWNX_Administration_RemoveBannedIP(string ip);
+
 // Ban a given public cdkey - get via GetPCPublicCDKey
 void NWNX_Administration_AddBannedCDKey(string key);
 void NWNX_Administration_RemoveBannedCDKey(string key);
+
 // Ban a given player name - get via GetPCPlayerName
 // NOTE: Players can easily change their names
 void NWNX_Administration_AddBannedPlayerName(string playername);
 void NWNX_Administration_RemoveBannedPlayerName(string playername);
+
 // Get a list of all banned IPs/Keys/names as a string
 string NWNX_Administration_GetBannedList();
 
@@ -81,36 +86,48 @@ void NWNX_Administration_DeleteTURD(string playerName, string characterName);
 
 string NWNX_Administration_GetPlayerPassword()
 {
-    NWNX_CallFunction("NWNX_Administration", "GET_PLAYER_PASSWORD");
-    return NWNX_GetReturnValueString("NWNX_Administration", "GET_PLAYER_PASSWORD");
+    string sFunc = "GET_PLAYER_PASSWORD";
+
+    NWNX_CallFunction(NWNX_Administration, sFunc);
+    return NWNX_GetReturnValueString(NWNX_Administration, sFunc);
 }
 
 void NWNX_Administration_SetPlayerPassword(string password)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "SET_PLAYER_PASSWORD", password);
-    NWNX_CallFunction("NWNX_Administration", "SET_PLAYER_PASSWORD");
+    string sFunc = "SET_PLAYER_PASSWORD";
+
+    NWNX_PushArgumentString(NWNX_Administration, sFunc, password);
+    NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 
 void NWNX_Administration_ClearPlayerPassword()
 {
-    NWNX_CallFunction("NWNX_Administration", "CLEAR_PLAYER_PASSWORD");
+    string sFunc = "CLEAR_PLAYER_PASSWORD";
+
+    NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 
 string NWNX_Administration_GetDMPassword()
 {
-    NWNX_CallFunction("NWNX_Administration", "GET_DM_PASSWORD");
-    return NWNX_GetReturnValueString("NWNX_Administration", "GET_DM_PASSWORD");
+    string sFunc = "GET_DM_PASSWORD";
+
+    NWNX_CallFunction(NWNX_Administration, sFunc);
+    return NWNX_GetReturnValueString(NWNX_Administration, sFunc);
 }
 
 void NWNX_Administration_SetDMPassword(string password)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "SET_DM_PASSWORD", password);
-    NWNX_CallFunction("NWNX_Administration", "SET_DM_PASSWORD");
+    string sFunc = "SET_DM_PASSWORD";
+
+    NWNX_PushArgumentString(NWNX_Administration, sFunc, password);
+    NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 
 void NWNX_Administration_ShutdownServer()
 {
-    NWNX_CallFunction("NWNX_Administration", "SHUTDOWN_SERVER");
+    string sFunc = "SHUTDOWN_SERVER";
+
+    NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 
 void NWNX_Administration_BootPCWithMessage(object pc, int strref)
@@ -121,78 +138,104 @@ void NWNX_Administration_BootPCWithMessage(object pc, int strref)
 
 void NWNX_Administration_DeletePlayerCharacter(object pc, int bPreserveBackup)
 {
-    NWNX_PushArgumentInt("NWNX_Administration", "DELETE_PLAYER_CHARACTER", bPreserveBackup);
-    NWNX_PushArgumentObject("NWNX_Administration", "DELETE_PLAYER_CHARACTER", pc);
-    NWNX_CallFunction("NWNX_Administration", "DELETE_PLAYER_CHARACTER");
+    string sFunc = "DELETE_PLAYER_CHARACTER";
+
+    NWNX_PushArgumentInt(NWNX_Administration, sFunc, bPreserveBackup);
+    NWNX_PushArgumentObject(NWNX_Administration, sFunc, pc);
+    NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 
 void NWNX_Administration_AddBannedIP(string ip)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "ADD_BANNED_IP", ip);
-    NWNX_CallFunction("NWNX_Administration", "ADD_BANNED_IP");
+    string sFunc = "ADD_BANNED_IP";
+
+    NWNX_PushArgumentString(NWNX_Administration, sFunc, ip);
+    NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 void NWNX_Administration_RemoveBannedIP(string ip)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "REMOVE_BANNED_IP", ip);
-    NWNX_CallFunction("NWNX_Administration", "REMOVE_BANNED_IP");
+    string sFunc = "REMOVE_BANNED_IP";
+
+    NWNX_PushArgumentString(NWNX_Administration, sFunc, ip);
+    NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 void NWNX_Administration_AddBannedCDKey(string key)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "ADD_BANNED_CDKEY", key);
-    NWNX_CallFunction("NWNX_Administration", "ADD_BANNED_CDKEY");
+    string sFunc = "ADD_BANNED_CDKEY";
+
+    NWNX_PushArgumentString(NWNX_Administration, sFunc, key);
+    NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 void NWNX_Administration_RemoveBannedCDKey(string key)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "REMOVE_BANNED_CDKEY", key);
-    NWNX_CallFunction("NWNX_Administration", "REMOVE_BANNED_CDKEY");
+    string sFunc = "REMOVE_BANNED_CDKEY";
+
+    NWNX_PushArgumentString(NWNX_Administration, sFunc, key);
+    NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 void NWNX_Administration_AddBannedPlayerName(string playername)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "ADD_BANNED_PLAYER_NAME", playername);
-    NWNX_CallFunction("NWNX_Administration", "ADD_BANNED_PLAYER_NAME");
+    string sFunc = "ADD_BANNED_PLAYER_NAME";
+
+    NWNX_PushArgumentString(NWNX_Administration, sFunc, playername);
+    NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 void NWNX_Administration_RemoveBannedPlayerName(string playername)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "REMOVE_BANNED_PLAYER_NAME", playername);
-    NWNX_CallFunction("NWNX_Administration", "REMOVE_BANNED_PLAYER_NAME");
+    string sFunc = "REMOVE_BANNED_PLAYER_NAME";
+
+    NWNX_PushArgumentString(NWNX_Administration, sFunc, playername);
+    NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 string NWNX_Administration_GetBannedList()
 {
-    NWNX_CallFunction("NWNX_Administration", "GET_BANNED_LIST");
-    return NWNX_GetReturnValueString("NWNX_Administration", "GET_BANNED_LIST");
+    string sFunc = "GET_BANNED_LIST";
+
+    NWNX_CallFunction(NWNX_Administration, sFunc);
+    return NWNX_GetReturnValueString(NWNX_Administration, sFunc);
 }
 
 
 void NWNX_Administration_SetModuleName(string name)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "SET_MODULE_NAME", name);
-    NWNX_CallFunction("NWNX_Administration", "SET_MODULE_NAME");
+    string sFunc = "SET_MODULE_NAME";
+
+    NWNX_PushArgumentString(NWNX_Administration, sFunc, name);
+    NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 
 void NWNX_Administration_SetServerName(string name)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "SET_SERVER_NAME", name);
-    NWNX_CallFunction("NWNX_Administration", "SET_SERVER_NAME");
+    string sFunc = "SET_SERVER_NAME";
+    
+    NWNX_PushArgumentString(NWNX_Administration, sFunc, name);
+    NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 
 int NWNX_Administration_GetPlayOption(int option)
 {
-    NWNX_PushArgumentInt("NWNX_Administration", "GET_PLAY_OPTION", option);
-    NWNX_CallFunction("NWNX_Administration", "GET_PLAY_OPTION");
+    string sFunc = "GET_PLAY_OPTION";
 
-    return NWNX_GetReturnValueInt("NWNX_Administration", "GET_PLAY_OPTION");
+    NWNX_PushArgumentInt(NWNX_Administration, sFunc, option);
+    NWNX_CallFunction(NWNX_Administration, sFunc);
+
+    return NWNX_GetReturnValueInt(NWNX_Administration, sFunc);
 }
 
 void NWNX_Administration_SetPlayOption(int option, int value)
 {
-    NWNX_PushArgumentInt("NWNX_Administration", "SET_PLAY_OPTION", value);
-    NWNX_PushArgumentInt("NWNX_Administration", "SET_PLAY_OPTION", option);
-    NWNX_CallFunction("NWNX_Administration", "SET_PLAY_OPTION");
+    string sFunc = "SET_PLAY_OPTION";
+
+    NWNX_PushArgumentInt(NWNX_Administration, sFunc, value);
+    NWNX_PushArgumentInt(NWNX_Administration, sFunc, option);
+    NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 
 void NWNX_Administration_DeleteTURD(string playerName, string characterName)
 {
-    NWNX_PushArgumentString("NWNX_Administration", "DELETE_TURD", characterName);
-    NWNX_PushArgumentString("NWNX_Administration", "DELETE_TURD", playerName);
-    NWNX_CallFunction("NWNX_Administration", "DELETE_TURD");
+    string sFunc = "DELETE_TURD";
+
+    NWNX_PushArgumentString(NWNX_Administration, sFunc, characterName);
+    NWNX_PushArgumentString(NWNX_Administration, sFunc, playerName);
+    NWNX_CallFunction(NWNX_Administration, sFunc);
 }

--- a/Plugins/Appearance/NWScript/nwnx_appearance.nss
+++ b/Plugins/Appearance/NWScript/nwnx_appearance.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Appearance = "NWNX_Appearance";
+
 const int NWNX_APPEARANCE_TYPE_APPEARANCE       = 0;
 const int NWNX_APPEARANCE_TYPE_GENDER           = 1;
 const int NWNX_APPEARANCE_TYPE_HITPOINTS        = 2;
@@ -57,8 +59,6 @@ void NWNX_Appearance_SetOverride(object oPlayer, object oCreature, int nType, in
 // - oCreature can be a PC
 // Returns -1 when not set
 int NWNX_Appearance_GetOverride(object oPlayer, object oCreature, int nType);
-
-const string NWNX_Appearance = "NWNX_Appearance";
 
 
 void NWNX_Appearance_SetOverride(object oPlayer, object oCreature, int nType, int nValue)

--- a/Plugins/Area/NWScript/nwnx_area.nss
+++ b/Plugins/Area/NWScript/nwnx_area.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Area = "NWNX_Area";
+
 const int NWNX_AREA_PVP_SETTING_NO_PVP              = 0;
 const int NWNX_AREA_PVP_SETTING_PARTY_PVP           = 1;
 const int NWNX_AREA_PVP_SETTING_FULL_PVP            = 2;
@@ -123,9 +125,6 @@ int NWNX_Area_GetTileAnimationLoop(object oArea, float fTileX, float fTileY, int
 //
 // NOTE: Requires clients to re-enter the area for it to take effect
 void NWNX_Area_SetTileAnimationLoop(object oArea, float fTileX, float fTileY, int nAnimLoop, int bEnabled);
-
-
-const string NWNX_Area = "NWNX_Area";
 
 
 int NWNX_Area_GetNumberOfPlayersInArea(object area)

--- a/Plugins/Chat/NWScript/nwnx_chat.nss
+++ b/Plugins/Chat/NWScript/nwnx_chat.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Chat = "NWNX_Chat";
+
 const int NWNX_CHAT_CHANNEL_PLAYER_TALK     = 1;
 const int NWNX_CHAT_CHANNEL_PLAYER_SHOUT    = 2;
 const int NWNX_CHAT_CHANNEL_PLAYER_WHISPER  = 3;
@@ -52,63 +54,82 @@ void NWNX_Chat_SetChatHearingDistance(float distance, object listener = OBJECT_I
 // OBJECT_INVALID listener returns server setting
 float NWNX_Chat_GetChatHearingDistance(object listener = OBJECT_INVALID, int channel = NWNX_CHAT_CHANNEL_PLAYER_TALK);
 
+
 int NWNX_Chat_SendMessage(int channel, string message, object sender = OBJECT_SELF, object target = OBJECT_INVALID)
 {
-    NWNX_PushArgumentObject("NWNX_Chat", "SEND_MESSAGE", target);
-    NWNX_PushArgumentObject("NWNX_Chat", "SEND_MESSAGE", sender);
-    NWNX_PushArgumentString("NWNX_Chat", "SEND_MESSAGE", message);
-    NWNX_PushArgumentInt("NWNX_Chat", "SEND_MESSAGE", channel);
-    NWNX_CallFunction("NWNX_Chat", "SEND_MESSAGE");
-    return NWNX_GetReturnValueInt("NWNX_Chat", "SEND_MESSAGE");
+    string sFunc = "SEND_MESSAGE";
+
+    NWNX_PushArgumentObject(NWNX_Chat, sFunc, target);
+    NWNX_PushArgumentObject(NWNX_Chat, sFunc, sender);
+    NWNX_PushArgumentString(NWNX_Chat, sFunc, message);
+    NWNX_PushArgumentInt(NWNX_Chat, sFunc, channel);
+    NWNX_CallFunction(NWNX_Chat, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Chat, sFunc);
 }
 
 void NWNX_Chat_RegisterChatScript(string script)
 {
-    NWNX_PushArgumentString("NWNX_Chat", "REGISTER_CHAT_SCRIPT", script);
-    NWNX_CallFunction("NWNX_Chat", "REGISTER_CHAT_SCRIPT");
+    string sFunc = "REGISTER_CHAT_SCRIPT";
+
+    NWNX_PushArgumentString(NWNX_Chat, sFunc, script);
+    NWNX_CallFunction(NWNX_Chat, sFunc);
 }
 
 void NWNX_Chat_SkipMessage()
 {
-    NWNX_CallFunction("NWNX_Chat", "SKIP_MESSAGE");
+    string sFunc = "SKIP_MESSAGE";
+
+    NWNX_CallFunction(NWNX_Chat, sFunc);
 }
 
 int NWNX_Chat_GetChannel()
 {
-    NWNX_CallFunction("NWNX_Chat", "GET_CHANNEL");
-    return NWNX_GetReturnValueInt("NWNX_Chat", "GET_CHANNEL");
+    string sFunc = "GET_CHANNEL";
+
+    NWNX_CallFunction(NWNX_Chat, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Chat, sFunc);
 }
 
 string NWNX_Chat_GetMessage()
 {
-    NWNX_CallFunction("NWNX_Chat", "GET_MESSAGE");
-    return NWNX_GetReturnValueString("NWNX_Chat", "GET_MESSAGE");
+    string sFunc = "GET_MESSAGE";
+
+    NWNX_CallFunction(NWNX_Chat, sFunc);
+    return NWNX_GetReturnValueString(NWNX_Chat, sFunc);
 }
 
 object NWNX_Chat_GetSender()
 {
-    NWNX_CallFunction("NWNX_Chat", "GET_SENDER");
-    return NWNX_GetReturnValueObject("NWNX_Chat", "GET_SENDER");
+    string sFunc = "GET_SENDER";
+
+    NWNX_CallFunction(NWNX_Chat, sFunc);
+    return NWNX_GetReturnValueObject(NWNX_Chat, sFunc);
 }
 
 object NWNX_Chat_GetTarget()
 {
-    NWNX_CallFunction("NWNX_Chat", "GET_TARGET");
-    return NWNX_GetReturnValueObject("NWNX_Chat", "GET_TARGET");
+    string sFunc = "GET_TARGET";
+
+    NWNX_CallFunction(NWNX_Chat, sFunc);
+    return NWNX_GetReturnValueObject(NWNX_Chat, sFunc);
 }
 
 void NWNX_Chat_SetChatHearingDistance(float distance, object listener = OBJECT_INVALID, int channel = NWNX_CHAT_CHANNEL_PLAYER_TALK)
 {
-    NWNX_PushArgumentInt("NWNX_Chat", "SET_CHAT_HEARING_DISTANCE", channel);
-    NWNX_PushArgumentObject("NWNX_Chat", "SET_CHAT_HEARING_DISTANCE", listener);
-    NWNX_PushArgumentFloat("NWNX_Chat", "SET_CHAT_HEARING_DISTANCE", distance);
-    NWNX_CallFunction("NWNX_Chat", "SET_CHAT_HEARING_DISTANCE");
+    string sFunc = "SET_CHAT_HEARING_DISTANCE";
+
+    NWNX_PushArgumentInt(NWNX_Chat, sFunc, channel);
+    NWNX_PushArgumentObject(NWNX_Chat, sFunc, listener);
+    NWNX_PushArgumentFloat(NWNX_Chat, sFunc, distance);
+    NWNX_CallFunction(NWNX_Chat, sFunc);
 }
 
 float NWNX_Chat_GetChatHearingDistance(object listener = OBJECT_INVALID, int channel = NWNX_CHAT_CHANNEL_PLAYER_TALK)
 {
-    NWNX_PushArgumentInt("NWNX_Chat", "GET_CHAT_HEARING_DISTANCE", channel);
-    NWNX_PushArgumentObject("NWNX_Chat", "GET_CHAT_HEARING_DISTANCE", listener);
-    NWNX_CallFunction("NWNX_Chat", "GET_CHAT_HEARING_DISTANCE");
-    return NWNX_GetReturnValueFloat("NWNX_Chat", "GET_CHAT_HEARING_DISTANCE");
+    string sFunc = "GET_CHAT_HEARING_DISTANCE";
+
+    NWNX_PushArgumentInt(NWNX_Chat, sFunc, channel);
+    NWNX_PushArgumentObject(NWNX_Chat, sFunc, listener);
+    NWNX_CallFunction(NWNX_Chat, sFunc);
+    return NWNX_GetReturnValueFloat(NWNX_Chat, sFunc);
 }

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Creature = "NWNX_Creature";
+
 const int NWNX_CREATURE_MOVEMENT_RATE_PC        = 0;
 const int NWNX_CREATURE_MOVEMENT_RATE_IMMOBILE  = 1;
 const int NWNX_CREATURE_MOVEMENT_RATE_VERY_SLOW = 2;
@@ -346,9 +348,6 @@ void NWNX_Creature_SetAnimalCompanionName(object creature, string name);
 
 // Set creature's familiar's name
 void NWNX_Creature_SetFamiliarName(object creature, string name);
-
-
-const string NWNX_Creature = "NWNX_Creature";
 
 
 void NWNX_Creature_AddFeat(object creature, int feat)

--- a/Plugins/Data/NWScript/nwnx_data.nss
+++ b/Plugins/Data/NWScript/nwnx_data.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Data = "NWNX_Data";
+
 const int NWNX_DATA_INVALID_INDEX = -1;
 const int NWNX_DATA_TYPE_FLOAT = 0;
 const int NWNX_DATA_TYPE_INTEGER = 1;
@@ -69,264 +71,291 @@ void NWNX_Data_Array_SortDescending(int type, object obj, string tag);
 
 float NWNX_Data_Array_At_Flt(object obj, string tag, int index)
 {
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_AT", index);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_AT", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_AT", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_AT", NWNX_DATA_TYPE_FLOAT);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_AT");
-    return NWNX_GetReturnValueFloat("NWNX_Data", "ARRAY_AT");
+    string sFunc = "ARRAY_AT";
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, index);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_FLOAT);
+    NWNX_CallFunction(NWNX_Data, sFunc);
+    return NWNX_GetReturnValueFloat(NWNX_Data, sFunc);
 }
 
 int NWNX_Data_Array_At_Int(object obj, string tag, int index)
 {
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_AT", index);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_AT", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_AT", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_AT", NWNX_DATA_TYPE_INTEGER);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_AT");
-    return NWNX_GetReturnValueInt("NWNX_Data", "ARRAY_AT");
+    string sFunc = "ARRAY_AT";
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, index);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_INTEGER);
+    NWNX_CallFunction(NWNX_Data, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Data, sFunc);
 }
 
 object NWNX_Data_Array_At_Obj(object obj, string tag, int index)
 {
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_AT", index);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_AT", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_AT", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_AT", NWNX_DATA_TYPE_OBJECT);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_AT");
-    return NWNX_GetReturnValueObject("NWNX_Data", "ARRAY_AT");
+    string sFunc = "ARRAY_AT";
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, index);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_OBJECT);
+    NWNX_CallFunction(NWNX_Data, sFunc);
+    return NWNX_GetReturnValueObject(NWNX_Data, sFunc);
 }
 
 string NWNX_Data_Array_At_Str(object obj, string tag, int index)
 {
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_AT", index);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_AT", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_AT", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_AT", NWNX_DATA_TYPE_STRING);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_AT");
-    return NWNX_GetReturnValueString("NWNX_Data", "ARRAY_AT");
+    string sFunc = "ARRAY_AT";
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, index);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_STRING);
+    NWNX_CallFunction(NWNX_Data, sFunc);
+    return NWNX_GetReturnValueString(NWNX_Data, sFunc);
 }
 
 void NWNX_Data_Array_Clear(int type, object obj, string tag)
 {
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_CLEAR", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_CLEAR", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_CLEAR", type);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_CLEAR");
+    string sFunc = "ARRAY_CLEAR";
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, type);
+    NWNX_CallFunction(NWNX_Data, sFunc);
 }
 
 int NWNX_Data_Array_Contains_Flt(object obj, string tag, float element)
 {
-    NWNX_PushArgumentFloat("NWNX_Data", "ARRAY_CONTAINS", element);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_CONTAINS", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_CONTAINS", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_CONTAINS", NWNX_DATA_TYPE_FLOAT);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_CONTAINS");
-    return NWNX_GetReturnValueInt("NWNX_Data", "ARRAY_CONTAINS");
+    string sFunc = "ARRAY_CONTAINS";
+    NWNX_PushArgumentFloat(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_FLOAT);
+    NWNX_CallFunction(NWNX_Data, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Data, sFunc);
 }
 
 int NWNX_Data_Array_Contains_Int(object obj, string tag, int element)
 {
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_CONTAINS", element);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_CONTAINS", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_CONTAINS", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_CONTAINS", NWNX_DATA_TYPE_INTEGER);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_CONTAINS");
-    return NWNX_GetReturnValueInt("NWNX_Data", "ARRAY_CONTAINS");
+    string sFunc = "ARRAY_CONTAINS";
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_INTEGER);
+    NWNX_CallFunction(NWNX_Data, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Data, sFunc);
 }
 
 int NWNX_Data_Array_Contains_Obj(object obj, string tag, object element)
 {
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_CONTAINS", element);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_CONTAINS", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_CONTAINS", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_CONTAINS", NWNX_DATA_TYPE_OBJECT);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_CONTAINS");
-    return NWNX_GetReturnValueInt("NWNX_Data", "ARRAY_CONTAINS");
+    string sFunc = "ARRAY_CONTAINS";
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_OBJECT);
+    NWNX_CallFunction(NWNX_Data, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Data, sFunc);
 }
 
 int NWNX_Data_Array_Contains_Str(object obj, string tag, string element)
 {
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_CONTAINS", element);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_CONTAINS", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_CONTAINS", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_CONTAINS", NWNX_DATA_TYPE_STRING);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_CONTAINS");
-    return NWNX_GetReturnValueInt("NWNX_Data", "ARRAY_CONTAINS");
+    string sFunc = "ARRAY_CONTAINS";
+    NWNX_PushArgumentString(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_STRING);
+    NWNX_CallFunction(NWNX_Data, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Data, sFunc);
 }
 
 void NWNX_Data_Array_Copy(int type, object obj, string tag, string otherTag)
 {
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_COPY", otherTag);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_COPY", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_COPY", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_COPY", type);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_COPY");
+    string sFunc = "ARRAY_COPY";
+    NWNX_PushArgumentString(NWNX_Data, sFunc, otherTag);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, type);
+    NWNX_CallFunction(NWNX_Data, sFunc);
 }
 
 void NWNX_Data_Array_Erase(int type, object obj, string tag, int index)
 {
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_ERASE", index);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_ERASE", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_ERASE", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_ERASE", type);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_ERASE");
+    string sFunc = "ARRAY_ERASE";
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, index);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, type);
+    NWNX_CallFunction(NWNX_Data, sFunc);
 }
 
 int NWNX_Data_Array_Find_Flt(object obj, string tag, float element)
 {
-    NWNX_PushArgumentFloat("NWNX_Data", "ARRAY_FIND", element);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_FIND", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_FIND", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_FIND", NWNX_DATA_TYPE_FLOAT);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_FIND");
-    return NWNX_GetReturnValueInt("NWNX_Data", "ARRAY_FIND");
+    string sFunc = "ARRAY_FIND";
+    NWNX_PushArgumentFloat(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_FLOAT);
+    NWNX_CallFunction(NWNX_Data, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Data, sFunc);
 }
 
 int NWNX_Data_Array_Find_Int(object obj, string tag, int element)
 {
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_FIND", element);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_FIND", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_FIND", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_FIND", NWNX_DATA_TYPE_INTEGER);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_FIND");
-    return NWNX_GetReturnValueInt("NWNX_Data", "ARRAY_FIND");
+    string sFunc = "ARRAY_FIND";
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_INTEGER);
+    NWNX_CallFunction(NWNX_Data, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Data, sFunc);
 }
 
 int NWNX_Data_Array_Find_Obj(object obj, string tag, object element)
 {
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_FIND", element);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_FIND", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_FIND", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_FIND", NWNX_DATA_TYPE_OBJECT);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_FIND");
-    return NWNX_GetReturnValueInt("NWNX_Data", "ARRAY_FIND");
+    string sFunc = "ARRAY_FIND";
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_OBJECT);
+    NWNX_CallFunction(NWNX_Data, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Data, sFunc);
 }
 
 int NWNX_Data_Array_Find_Str(object obj, string tag, string element)
 {
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_FIND", element);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_FIND", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_FIND", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_FIND", NWNX_DATA_TYPE_STRING);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_FIND");
-    return NWNX_GetReturnValueInt("NWNX_Data", "ARRAY_FIND");
+    string sFunc = "ARRAY_FIND";
+    NWNX_PushArgumentString(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_STRING);
+    NWNX_CallFunction(NWNX_Data, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Data, sFunc);
 }
 
 void NWNX_Data_Array_Insert_Flt(object obj, string tag, int index, float element)
 {
-    NWNX_PushArgumentFloat("NWNX_Data", "ARRAY_INSERT", element);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_INSERT", index);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_INSERT", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_INSERT", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_INSERT", NWNX_DATA_TYPE_FLOAT);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_INSERT");
+    string sFunc = "ARRAY_INSERT";
+    NWNX_PushArgumentFloat(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, index);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_FLOAT);
+    NWNX_CallFunction(NWNX_Data, sFunc);
 }
 
 void NWNX_Data_Array_Insert_Int(object obj, string tag, int index, int element)
 {
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_INSERT", element);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_INSERT", index);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_INSERT", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_INSERT", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_INSERT", NWNX_DATA_TYPE_INTEGER);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_INSERT");
+    string sFunc = "ARRAY_INSERT";
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, index);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_INTEGER);
+    NWNX_CallFunction(NWNX_Data, sFunc);
 }
 
 void NWNX_Data_Array_Insert_Obj(object obj, string tag, int index, object element)
 {
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_INSERT", element);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_INSERT", index);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_INSERT", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_INSERT", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_INSERT", NWNX_DATA_TYPE_OBJECT);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_INSERT");
+    string sFunc = "ARRAY_INSERT";
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, index);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_OBJECT);
+    NWNX_CallFunction(NWNX_Data, sFunc);
 }
 
 void NWNX_Data_Array_Insert_Str(object obj, string tag, int index, string element)
 {
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_INSERT", element);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_INSERT", index);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_INSERT", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_INSERT", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_INSERT", NWNX_DATA_TYPE_STRING);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_INSERT");
+    string sFunc = "ARRAY_INSERT";
+    NWNX_PushArgumentString(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, index);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_STRING);
+    NWNX_CallFunction(NWNX_Data, sFunc);
 }
 
 void NWNX_Data_Array_PushBack_Flt(object obj, string tag, float element)
 {
-    NWNX_PushArgumentFloat("NWNX_Data", "ARRAY_PUSH_BACK", element);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_PUSH_BACK", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_PUSH_BACK", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_PUSH_BACK", NWNX_DATA_TYPE_FLOAT);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_PUSH_BACK");
+    string sFunc = "ARRAY_PUSH_BACK";
+    NWNX_PushArgumentFloat(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_FLOAT);
+    NWNX_CallFunction(NWNX_Data, sFunc);
 }
 
 void NWNX_Data_Array_PushBack_Int(object obj, string tag, int element)
 {
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_PUSH_BACK", element);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_PUSH_BACK", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_PUSH_BACK", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_PUSH_BACK", NWNX_DATA_TYPE_INTEGER);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_PUSH_BACK");
+    string sFunc = "ARRAY_PUSH_BACK";
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_INTEGER);
+    NWNX_CallFunction(NWNX_Data, sFunc);
 }
 
 void NWNX_Data_Array_PushBack_Obj(object obj, string tag, object element)
 {
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_PUSH_BACK", element);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_PUSH_BACK", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_PUSH_BACK", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_PUSH_BACK", NWNX_DATA_TYPE_OBJECT);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_PUSH_BACK");
+    string sFunc = "ARRAY_PUSH_BACK";
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_OBJECT);
+    NWNX_CallFunction(NWNX_Data, sFunc);
 }
 
 void NWNX_Data_Array_PushBack_Str(object obj, string tag, string element)
 {
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_PUSH_BACK", element);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_PUSH_BACK", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_PUSH_BACK", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_PUSH_BACK", NWNX_DATA_TYPE_STRING);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_PUSH_BACK");
+    string sFunc = "ARRAY_PUSH_BACK";
+    NWNX_PushArgumentString(NWNX_Data, sFunc, element);
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, NWNX_DATA_TYPE_STRING);
+    NWNX_CallFunction(NWNX_Data, sFunc);
 }
 
 void NWNX_Data_Array_Resize(int type, object obj, string tag, int size)
 {
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_RESIZE", size);
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_RESIZE", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_RESIZE", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_RESIZE", type);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_RESIZE");
+    NWNX_PushArgumentInt(NWNX_Data, "ARRAY_RESIZE", size);
+    NWNX_PushArgumentString(NWNX_Data, "ARRAY_RESIZE", tag);
+    NWNX_PushArgumentObject(NWNX_Data, "ARRAY_RESIZE", obj);
+    NWNX_PushArgumentInt(NWNX_Data, "ARRAY_RESIZE", type);
+    NWNX_CallFunction(NWNX_Data, "ARRAY_RESIZE");
 }
 
 void NWNX_Data_Array_Shuffle(int type, object obj, string tag)
 {
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_SHUFFLE", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_SHUFFLE", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_SHUFFLE", type);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_SHUFFLE");
+    string sFunc = "ARRAY_SHUFFLE";
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, type);
+    NWNX_CallFunction(NWNX_Data, sFunc);
 }
 
 int NWNX_Data_Array_Size(int type, object obj, string tag)
 {
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_SIZE", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_SIZE", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_SIZE", type);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_SIZE");
-    return NWNX_GetReturnValueInt("NWNX_Data", "ARRAY_SIZE");
+    string sFunc = "ARRAY_SIZE";
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, type);
+    NWNX_CallFunction(NWNX_Data, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Data, sFunc);
 }
 
 void NWNX_Data_Array_SortAscending(int type, object obj, string tag)
 {
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_SORT_ASCENDING", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_SORT_ASCENDING", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_SORT_ASCENDING", type);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_SORT_ASCENDING");
+    string sFunc = "ARRAY_SORT_ASCENDING";
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, type);
+    NWNX_CallFunction(NWNX_Data, sFunc);
 }
 
 void NWNX_Data_Array_SortDescending(int type, object obj, string tag)
 {
-    NWNX_PushArgumentString("NWNX_Data", "ARRAY_SORT_DESCENDING", tag);
-    NWNX_PushArgumentObject("NWNX_Data", "ARRAY_SORT_DESCENDING", obj);
-    NWNX_PushArgumentInt("NWNX_Data", "ARRAY_SORT_DESCENDING", type);
-    NWNX_CallFunction("NWNX_Data", "ARRAY_SORT_DESCENDING");
+    string sFunc = "ARRAY_SORT_DESCENDING";
+    NWNX_PushArgumentString(NWNX_Data, sFunc, tag);
+    NWNX_PushArgumentObject(NWNX_Data, sFunc, obj);
+    NWNX_PushArgumentInt(NWNX_Data, sFunc, type);
+    NWNX_CallFunction(NWNX_Data, sFunc);
 }

--- a/Plugins/Dialog/NWScript/nwnx_dialog.nss
+++ b/Plugins/Dialog/NWScript/nwnx_dialog.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Dialog = "NWNX_Dialog";
+
 const int NWNX_DIALOG_NODE_TYPE_INVALID                = -1;
 const int NWNX_DIALOG_NODE_TYPE_STARTING_NODE          = 0;
 const int NWNX_DIALOG_NODE_TYPE_ENTRY_NODE             = 1;
@@ -45,11 +47,10 @@ string NWNX_Dialog_GetCurrentNodeText(int language=NWNX_DIALOG_LANGUAGE_ENGLISH,
 void NWNX_Dialog_SetCurrentNodeText(string text, int language=NWNX_DIALOG_LANGUAGE_ENGLISH, int gender=GENDER_MALE);
 
 
-const string NWNX_Dialog = "NWNX_Dialog";
-
 int NWNX_Dialog_GetCurrentNodeType()
 {
     string sFunc = "GetCurrentNodeType";
+
     NWNX_CallFunction(NWNX_Dialog, sFunc);
     return NWNX_GetReturnValueInt(NWNX_Dialog, sFunc);
 }
@@ -57,6 +58,7 @@ int NWNX_Dialog_GetCurrentNodeType()
 int NWNX_Dialog_GetCurrentScriptType()
 {
     string sFunc = "GetCurrentScriptType";
+
     NWNX_CallFunction(NWNX_Dialog, sFunc);
     return NWNX_GetReturnValueInt(NWNX_Dialog, sFunc);
 }
@@ -64,6 +66,7 @@ int NWNX_Dialog_GetCurrentScriptType()
 int NWNX_Dialog_GetCurrentNodeID()
 {
     string sFunc = "GetCurrentNodeID";
+
     NWNX_CallFunction(NWNX_Dialog, sFunc);
     return NWNX_GetReturnValueInt(NWNX_Dialog, sFunc);
 }
@@ -71,6 +74,7 @@ int NWNX_Dialog_GetCurrentNodeID()
 int NWNX_Dialog_GetCurrentNodeIndex()
 {
     string sFunc = "GetCurrentNodeIndex";
+
     NWNX_CallFunction(NWNX_Dialog, sFunc);
     return NWNX_GetReturnValueInt(NWNX_Dialog, sFunc);
 }
@@ -78,6 +82,7 @@ int NWNX_Dialog_GetCurrentNodeIndex()
 string NWNX_Dialog_GetCurrentNodeText(int language=NWNX_DIALOG_LANGUAGE_ENGLISH, int gender=GENDER_MALE)
 {
     string sFunc = "GetCurrentNodeText";
+
     NWNX_PushArgumentInt(NWNX_Dialog, sFunc, gender);
     NWNX_PushArgumentInt(NWNX_Dialog, sFunc, language);
     NWNX_CallFunction(NWNX_Dialog, sFunc);
@@ -87,6 +92,7 @@ string NWNX_Dialog_GetCurrentNodeText(int language=NWNX_DIALOG_LANGUAGE_ENGLISH,
 void NWNX_Dialog_SetCurrentNodeText(string text, int language=NWNX_DIALOG_LANGUAGE_ENGLISH, int gender=GENDER_MALE)
 {
     string sFunc = "SetCurrentNodeText";
+    
     NWNX_PushArgumentInt(NWNX_Dialog, sFunc, gender);
     NWNX_PushArgumentInt(NWNX_Dialog, sFunc, language);
     NWNX_PushArgumentString(NWNX_Dialog, sFunc, text);

--- a/Plugins/Effect/NWScript/nwnx_effect.nss
+++ b/Plugins/Effect/NWScript/nwnx_effect.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Effect = "NWNX_Effect";
+
 struct NWNX_EffectUnpacked
 {
     int nEffectId;
@@ -50,24 +52,26 @@ struct NWNX_EffectUnpacked
 
 // Convert native effect type to unpacked structure
 struct NWNX_EffectUnpacked NWNX_Effect_UnpackEffect(effect e);
+
 // Convert unpacked effect structure to native type
 effect NWNX_Effect_PackEffect(struct NWNX_EffectUnpacked e);
+
 // Set a script with optional data that runs when an effect expires
 // Only works for TEMPORARY and PERMANENT effects applied to an object
 //
 // Note: OBJECT_SELF in the script is the object the effect is applied to
 effect NWNX_Effect_SetEffectExpiredScript(effect e, string script, string data = "");
+
 // Get the data set with NWNX_Effect_SetEffectExpiredScript()
 //
 // THIS SHOULD ONLY BE CALLED FROM WITHIN A SCRIPT THAT WAS EXECUTED BY NWNX_Effect_SetEffectExpiredScript()
 string NWNX_Effect_GetEffectExpiredData();
+
 // Get the effect creator of NWNX_Effect_SetEffectExpiredScript()
 //
 // THIS SHOULD ONLY BE CALLED FROM WITHIN A SCRIPT THAT WAS EXECUTED BY NWNX_Effect_SetEffectExpiredScript()
 object NWNX_Effect_GetEffectExpiredCreator();
 
-
-const string NWNX_Effect = "NWNX_Effect";
 
 struct NWNX_EffectUnpacked NWNX_Effect_UnpackEffect(effect e)
 {

--- a/Plugins/Encounter/NWScript/nwnx_encounter.nss
+++ b/Plugins/Encounter/NWScript/nwnx_encounter.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Encounter = "NWNX_Encounter";
+
 struct NWNX_Encounter_CreatureListEntry
 {
     string resref;
@@ -36,9 +38,6 @@ int NWNX_Encounter_GetResetTime(object encounter);
 
 // Set the reset time of encounter
 void NWNX_Encounter_SetResetTime(object encounter, int resetTime);
-
-
-const string NWNX_Encounter = "NWNX_Encounter";
 
 
 int NWNX_Encounter_GetNumberOfCreaturesInEncounterList(object encounter)

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Events = "NWNX_Events";
+
 ////////////////////////////////////////////////////////////////////////////////
 /* The following events are exposed by this plugin:
 ////////////////////////////////////////////////////////////////////////////////
@@ -855,46 +857,60 @@ string NWNX_Events_GetCurrentEvent();
 
 void NWNX_Events_SubscribeEvent(string evt, string script)
 {
-    NWNX_PushArgumentString("NWNX_Events", "SUBSCRIBE_EVENT", script);
-    NWNX_PushArgumentString("NWNX_Events", "SUBSCRIBE_EVENT", evt);
-    NWNX_CallFunction("NWNX_Events", "SUBSCRIBE_EVENT");
+    string sFunc = "SUBSCRIBE_EVENT";
+
+    NWNX_PushArgumentString(NWNX_Events, sFunc, script);
+    NWNX_PushArgumentString(NWNX_Events, sFunc, evt);
+    NWNX_CallFunction(NWNX_Events, sFunc);
 }
 
 void NWNX_Events_PushEventData(string tag, string data)
 {
-    NWNX_PushArgumentString("NWNX_Events", "PUSH_EVENT_DATA", data);
-    NWNX_PushArgumentString("NWNX_Events", "PUSH_EVENT_DATA", tag);
-    NWNX_CallFunction("NWNX_Events", "PUSH_EVENT_DATA");
+    string sFunc = "PUSH_EVENT_DATA";
+
+    NWNX_PushArgumentString(NWNX_Events, sFunc, data);
+    NWNX_PushArgumentString(NWNX_Events, sFunc, tag);
+    NWNX_CallFunction(NWNX_Events, sFunc);
 }
 
 int NWNX_Events_SignalEvent(string evt, object target)
 {
-    NWNX_PushArgumentObject("NWNX_Events", "SIGNAL_EVENT", target);
-    NWNX_PushArgumentString("NWNX_Events", "SIGNAL_EVENT", evt);
-    NWNX_CallFunction("NWNX_Events", "SIGNAL_EVENT");
-    return NWNX_GetReturnValueInt("NWNX_Events", "SIGNAL_EVENT");
+    string sFunc = "SIGNAL_EVENT";
+
+    NWNX_PushArgumentObject(NWNX_Events, sFunc, target);
+    NWNX_PushArgumentString(NWNX_Events, sFunc, evt);
+    NWNX_CallFunction(NWNX_Events, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Events, sFunc);
 }
 
 string NWNX_Events_GetEventData(string tag)
 {
-    NWNX_PushArgumentString("NWNX_Events", "GET_EVENT_DATA", tag);
-    NWNX_CallFunction("NWNX_Events", "GET_EVENT_DATA");
-    return NWNX_GetReturnValueString("NWNX_Events", "GET_EVENT_DATA");
+    string sFunc = "GET_EVENT_DATA";
+    
+    NWNX_PushArgumentString(NWNX_Events, sFunc, tag);
+    NWNX_CallFunction(NWNX_Events, sFunc);
+    return NWNX_GetReturnValueString(NWNX_Events, sFunc);
 }
 
 void NWNX_Events_SkipEvent()
 {
-    NWNX_CallFunction("NWNX_Events", "SKIP_EVENT");
+    string sFunc = "SKIP_EVENT";
+
+    NWNX_CallFunction(NWNX_Events, sFunc);
 }
 
 void NWNX_Events_SetEventResult(string data)
 {
-    NWNX_PushArgumentString("NWNX_Events", "EVENT_RESULT", data);
-    NWNX_CallFunction("NWNX_Events", "EVENT_RESULT");
+    string sFunc = "EVENT_RESULT";
+
+    NWNX_PushArgumentString(NWNX_Events, sFunc, data);
+    NWNX_CallFunction(NWNX_Events, sFunc);
 }
 
 string NWNX_Events_GetCurrentEvent()
 {
-    NWNX_CallFunction("NWNX_Events", "GET_CURRENT_EVENT");
-    return NWNX_GetReturnValueString("NWNX_Events", "GET_CURRENT_EVENT");
+    string sFunc = "GET_CURRENT_EVENT";
+
+    NWNX_CallFunction(NWNX_Events, sFunc);
+    return NWNX_GetReturnValueString(NWNX_Events, sFunc);
 }

--- a/Plugins/Feedback/NWScript/nwnx_feedback.nss
+++ b/Plugins/Feedback/NWScript/nwnx_feedback.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Feedback = "NWNX_Feedback";
+
 // Gets if feedback message nMessage is hidden.
 // Notes:
 // If oPC == OBJECT_INVALID it will return the global state:
@@ -96,9 +98,6 @@ void NWNX_Feedback_SetCombatLogMessageMode(int bWhitelist);
 // ***
 // For a list of the various combatlog / feedback messages see below.
 // ***
-
-const string NWNX_Feedback = "NWNX_Feedback";
-
 
 int NWNX_Feedback_GetFeedbackMessageHidden(int nMessage, object oPC = OBJECT_INVALID)
 {

--- a/Plugins/Item/NWScript/nwnx_item.nss
+++ b/Plugins/Item/NWScript/nwnx_item.nss
@@ -61,6 +61,7 @@ int NWNX_Item_GetBaseArmorClass(object oItem);
 // Get oItem's minimum level needed to equip
 int NWNX_Item_GetMinEquipLevel(object oItem);
 
+
 void NWNX_Item_SetWeight(object oItem, int w)
 {
     string sFunc = "SetWeight";

--- a/Plugins/ItemProperty/NWScript/nwnx_itemprop.nss
+++ b/Plugins/ItemProperty/NWScript/nwnx_itemprop.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_ItemProperty = "NWNX_ItemProperty";
+
 struct NWNX_IPUnpacked
 {
     int nItemPropertyId;
@@ -23,8 +25,6 @@ struct NWNX_IPUnpacked NWNX_ItemProperty_UnpackIP(itemproperty ip);
 // Convert unpacked itemproperty structure to native type
 itemproperty NWNX_ItemProperty_PackIP(struct NWNX_IPUnpacked ip);
 
-
-const string NWNX_ItemProperty = "NWNX_ItemProperty";
 
 struct NWNX_IPUnpacked NWNX_ItemProperty_UnpackIP(itemproperty ip)
 {

--- a/Plugins/JVM/NWScript/nwnx_jvm.nss
+++ b/Plugins/JVM/NWScript/nwnx_jvm.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_JVM = "NWNX_JVM";
+
 /*
   This sends event 'ev' to your JVM. Does not return anything.
 */
@@ -8,7 +10,9 @@ void NWNX_JVM_EVENT(string ev, object caller = OBJECT_SELF);
 
 void NWNX_JVM_EVENT(string ev, object caller = OBJECT_SELF)
 {
-    NWNX_PushArgumentObject("NWNX_JVM", "Event", caller);
-    NWNX_PushArgumentString("NWNX_JVM", "Event", ev);
-    NWNX_CallFunction("NWNX_JVM", "Event");
+    string sFunc = "Event";
+
+    NWNX_PushArgumentObject(NWNX_JVM, sFunc, caller);
+    NWNX_PushArgumentString(NWNX_JVM, sFunc, ev);
+    NWNX_CallFunction(NWNX_JVM, sFunc);
 }

--- a/Plugins/JVM/NWScript/nwnx_jvm_token.nss
+++ b/Plugins/JVM/NWScript/nwnx_jvm_token.nss
@@ -2,9 +2,10 @@
 
 void call_token(string token, object caller = OBJECT_SELF) 
 {
-    NWNX_PushArgumentObject("NWNX_JVM", "Event", caller);
-    NWNX_PushArgumentString("NWNX_JVM", "Event", token);
-    NWNX_CallFunction("NWNX_JVM", "Token");
+    string sFunc = "Event";
+    NWNX_PushArgumentObject(NWNX_JVM, sFunc, caller);
+    NWNX_PushArgumentString(NWNX_JVM, sFunc, token);
+    NWNX_CallFunction(NWNX_JVM, "Token");
 }
 
 void main() 

--- a/Plugins/Lua/NWScript/nwnx_lua.nss
+++ b/Plugins/Lua/NWScript/nwnx_lua.nss
@@ -1,22 +1,31 @@
 #include "nwnx"
 
+const string NWNX_Lua = "NWNX_Lua";
+
+
 void NWNX_Lua_EvalVoid(string sCode)
 {
-    NWNX_PushArgumentString("NWNX_Lua", "EVALVOID", sCode);
-    NWNX_CallFunction("NWNX_Lua", "EVALVOID");
+    string sFunc = "EVALVOID";
+
+    NWNX_PushArgumentString(NWNX_Lua, sFunc, sCode);
+    NWNX_CallFunction(NWNX_Lua, sFunc);
 }
 
 string NWNX_Lua_Eval(string sCode)
 {
-    NWNX_PushArgumentString("NWNX_Lua", "EVAL", sCode);
-    NWNX_CallFunction("NWNX_Lua", "EVAL");
-    return NWNX_GetReturnValueString("NWNX_Lua", "EVAL");
+    string sFunc = "EVAL";
+
+    NWNX_PushArgumentString(NWNX_Lua, sFunc, sCode);
+    NWNX_CallFunction(NWNX_Lua, sFunc);
+    return NWNX_GetReturnValueString(NWNX_Lua, sFunc);
 }
 
 void NWNX_Lua_RunEvent(string sEvent, object oObject, string sExtra="")
 {
-    NWNX_PushArgumentString("NWNX_Lua", "EVENT", sExtra);
-    NWNX_PushArgumentObject("NWNX_Lua", "EVENT", oObject);
-    NWNX_PushArgumentString("NWNX_Lua", "EVENT", sEvent);
-    NWNX_CallFunction("NWNX_Lua", "EVENT");
+    string sFunc = "EVENT";
+
+    NWNX_PushArgumentString(NWNX_Lua, sFunc, sExtra);
+    NWNX_PushArgumentObject(NWNX_Lua, sFunc, oObject);
+    NWNX_PushArgumentString(NWNX_Lua, sFunc, sEvent);
+    NWNX_CallFunction(NWNX_Lua, sFunc);
 }

--- a/Plugins/Object/NWScript/nwnx_object.nss
+++ b/Plugins/Object/NWScript/nwnx_object.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Object = "NWNX_Object";
+
 // Area event handlers
 const int NWNX_OBJECT_SCRIPT_AREA_ON_HEARTBEAT                  = 0;
 const int NWNX_OBJECT_SCRIPT_AREA_ON_USER_DEFINED               = 1;
@@ -176,9 +178,6 @@ void NWNX_Object_AddIconEffect(object obj, int nIcon, float fDuration=0.0);
 // Remove an icon effect from an object that was added by the
 // NWNX_Object_AddIconEffect function.
 void NWNX_Object_RemoveIconEffect(object obj, int nIcon);
-
-const string NWNX_Object = "NWNX_Object";
-
 
 int NWNX_Object_GetLocalVariableCount(object obj)
 {

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Player = "NWNX_Player";
+
 struct NWNX_Player_QuickBarSlot
 {
     object oItem;
@@ -170,12 +172,11 @@ void NWNX_Player_SetPlaceableNameOverride(object player, object placeable, strin
 // Returns -1 if they don't have the journal entry
 int NWNX_Player_GetQuestCompleted(object player, string sQuestName);
 
-const string NWNX_Player = "NWNX_Player";
-
 
 void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable)
 {
     string sFunc = "ForcePlaceableExamineWindow";
+
     NWNX_PushArgumentObject(NWNX_Player, sFunc, placeable);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
@@ -185,6 +186,7 @@ void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable)
 void NWNX_Player_ForcePlaceableInventoryWindow(object player, object placeable)
 {
     string sFunc = "ForcePlaceableInventoryWindow";
+
     NWNX_PushArgumentObject(NWNX_Player, sFunc, placeable);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
@@ -242,6 +244,7 @@ void NWNX_Player_StopGuiTimingBar(object player, string script = "")
 void NWNX_Player_SetAlwaysWalk(object player, int bWalk=TRUE)
 {
     string sFunc = "SetAlwaysWalk";
+
     NWNX_PushArgumentInt(NWNX_Player, sFunc, bWalk);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
@@ -300,6 +303,7 @@ void NWNX_Player_SetQuickBarSlot(object player, int slot, struct NWNX_Player_Qui
 string NWNX_Player_GetBicFileName(object player)
 {
     string sFunc = "GetBicFileName";
+
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
     NWNX_CallFunction(NWNX_Player, sFunc);
     return NWNX_GetReturnValueString(NWNX_Player, sFunc);
@@ -369,6 +373,7 @@ int NWNX_Player_GetVisibilityOverride(object player, object target)
 void NWNX_Player_ShowVisualEffect(object player, int effectId, vector position)
 {
     string sFunc = "ShowVisualEffect";
+
     NWNX_PushArgumentFloat(NWNX_Player, sFunc, position.x);
     NWNX_PushArgumentFloat(NWNX_Player, sFunc, position.y);
     NWNX_PushArgumentFloat(NWNX_Player, sFunc, position.z);
@@ -381,6 +386,7 @@ void NWNX_Player_ShowVisualEffect(object player, int effectId, vector position)
 void NWNX_Player_MusicBackgroundChangeDay(object player, int track)
 {
     string sFunc = "ChangeBackgroundMusic";
+
     NWNX_PushArgumentInt(NWNX_Player, sFunc, track);
     NWNX_PushArgumentInt(NWNX_Player, sFunc, TRUE); // bool day = TRUE
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
@@ -391,6 +397,7 @@ void NWNX_Player_MusicBackgroundChangeDay(object player, int track)
 void NWNX_Player_MusicBackgroundChangeNight(object player, int track)
 {
     string sFunc = "ChangeBackgroundMusic";
+
     NWNX_PushArgumentInt(NWNX_Player, sFunc, track);
     NWNX_PushArgumentInt(NWNX_Player, sFunc, FALSE); // bool day = FALSE
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
@@ -401,6 +408,7 @@ void NWNX_Player_MusicBackgroundChangeNight(object player, int track)
 void NWNX_Player_MusicBackgroundStart(object player)
 {
     string sFunc = "PlayBackgroundMusic";
+
     NWNX_PushArgumentInt(NWNX_Player, sFunc, TRUE); // bool play = TRUE
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
@@ -410,6 +418,7 @@ void NWNX_Player_MusicBackgroundStart(object player)
 void NWNX_Player_MusicBackgroundStop(object player)
 {
     string sFunc = "PlayBackgroundMusic";
+
     NWNX_PushArgumentInt(NWNX_Player, sFunc, FALSE); // bool play = FALSE
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
@@ -419,6 +428,7 @@ void NWNX_Player_MusicBackgroundStop(object player)
 void NWNX_Player_MusicBattleChange(object player, int track)
 {
     string sFunc = "ChangeBattleMusic";
+
     NWNX_PushArgumentInt(NWNX_Player, sFunc, track);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
@@ -428,6 +438,7 @@ void NWNX_Player_MusicBattleChange(object player, int track)
 void NWNX_Player_MusicBattleStart(object player)
 {
     string sFunc = "PlayBattleMusic";
+
     NWNX_PushArgumentInt(NWNX_Player, sFunc, TRUE); // bool play = TRUE
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
@@ -437,6 +448,7 @@ void NWNX_Player_MusicBattleStart(object player)
 void NWNX_Player_MusicBattleStop(object player)
 {
     string sFunc = "PlayBattleMusic";
+
     NWNX_PushArgumentInt(NWNX_Player, sFunc, FALSE); // bool play = FALSE
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
@@ -446,6 +458,7 @@ void NWNX_Player_MusicBattleStop(object player)
 void NWNX_Player_PlaySound(object player, string sound, object target = OBJECT_INVALID)
 {
     string sFunc = "PlaySound";
+
     NWNX_PushArgumentObject(NWNX_Player, sFunc, target);
     NWNX_PushArgumentString(NWNX_Player, sFunc, sound);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
@@ -456,6 +469,7 @@ void NWNX_Player_PlaySound(object player, string sound, object target = OBJECT_I
 void NWNX_Player_SetPlaceableUsable(object player, object placeable, int usable)
 {
     string sFunc = "SetPlaceableUsable";
+
     NWNX_PushArgumentInt(NWNX_Player, sFunc, usable);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, placeable);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
@@ -466,6 +480,7 @@ void NWNX_Player_SetPlaceableUsable(object player, object placeable, int usable)
 void NWNX_Player_SetRestDuration(object player, int duration)
 {
     string sFunc = "SetRestDuration";
+
     NWNX_PushArgumentInt(NWNX_Player, sFunc, duration);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
@@ -475,6 +490,7 @@ void NWNX_Player_SetRestDuration(object player, int duration)
 void NWNX_Player_ApplyInstantVisualEffectToObject(object player, object target, int visualeffect)
 {
     string sFunc = "ApplyInstantVisualEffectToObject";
+
     NWNX_PushArgumentInt(NWNX_Player, sFunc, visualeffect);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, target);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
@@ -485,6 +501,7 @@ void NWNX_Player_ApplyInstantVisualEffectToObject(object player, object target, 
 void NWNX_Player_UpdateCharacterSheet(object player)
 {
     string sFunc = "UpdateCharacterSheet";
+
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
     NWNX_CallFunction(NWNX_Player, sFunc);
@@ -504,6 +521,7 @@ void NWNX_Player_OpenInventory(object player, object target, int open = TRUE)
 string NWNX_Player_GetAreaExplorationState(object player, object area)
 {
     string sFunc = "GetAreaExplorationState";
+
     NWNX_PushArgumentObject(NWNX_Player, sFunc, area);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
@@ -514,6 +532,7 @@ string NWNX_Player_GetAreaExplorationState(object player, object area)
 void NWNX_Player_SetAreaExplorationState(object player, object area, string str)
 {
     string sFunc = "SetAreaExplorationState";
+
     NWNX_PushArgumentString(NWNX_Player, sFunc, str);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, area);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
@@ -546,6 +565,7 @@ void NWNX_Player_SetObjectVisualTransformOverride(object oPlayer, object oObject
 void NWNX_Player_ApplyLoopingVisualEffectToObject(object player, object target, int visualeffect)
 {
     string sFunc = "ApplyLoopingVisualEffectToObject";
+
     NWNX_PushArgumentInt(NWNX_Player, sFunc, visualeffect);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, target);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
@@ -567,6 +587,7 @@ void NWNX_Player_SetPlaceableNameOverride(object player, object placeable, strin
 int NWNX_Player_GetQuestCompleted(object player, string sQuestName)
 {
     string sFunc = "GetQuestCompleted";
+    
     NWNX_PushArgumentString(NWNX_Player, sFunc, sQuestName);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 

--- a/Plugins/Profiler/NWScript/nwnx_profiler.nss
+++ b/Plugins/Profiler/NWScript/nwnx_profiler.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Profiler = "NWNX_Profiler";
+
 // These functions are for advanced users to instrument their nwscript code.
 
 // Push a timing metric scope - note that every push must be matched by a corresponding pop.
@@ -24,20 +26,25 @@ void NWNX_Profiler_PushPerfScope(string name, string tag0_tag = "", string tag0_
 // Pops a timing metric - one must already be pushed.
 void NWNX_Profiler_PopPerfScope();
 
+
 void NWNX_Profiler_PushPerfScope(string name, string tag0_tag = "", string tag0_value = "")
 {
-    NWNX_PushArgumentString("NWNX_Profiler", "PUSH_PERF_SCOPE", name);
+    string sFunc = "PUSH_PERF_SCOPE";
+
+    NWNX_PushArgumentString(NWNX_Profiler, sFunc, name);
 
     if (tag0_value != "" && tag0_tag != "")
     {
-        NWNX_PushArgumentString("NWNX_Profiler", "PUSH_PERF_SCOPE", tag0_value);
-        NWNX_PushArgumentString("NWNX_Profiler", "PUSH_PERF_SCOPE", tag0_tag);
+        NWNX_PushArgumentString(NWNX_Profiler, sFunc, tag0_value);
+        NWNX_PushArgumentString(NWNX_Profiler, sFunc, tag0_tag);
     }
 
-    NWNX_CallFunction("NWNX_Profiler", "PUSH_PERF_SCOPE");
+    NWNX_CallFunction(NWNX_Profiler, sFunc);
 }
 
 void NWNX_Profiler_PopPerfScope()
 {
-    NWNX_CallFunction("NWNX_Profiler", "POP_PERF_SCOPE");
+    string sFunc = "POP_PERF_SCOPE";
+
+    NWNX_CallFunction(NWNX_Profiler, sFunc);
 }

--- a/Plugins/Race/NWScript/nwnx_race.nss
+++ b/Plugins/Race/NWScript/nwnx_race.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Race = "NWNX_Race";
+
 const int NWNX_RACE_MODIFIER_INVALID       = 0;
 const int NWNX_RACE_MODIFIER_AB            = 1;
 const int NWNX_RACE_MODIFIER_ABVSRACE      = 2;
@@ -29,8 +31,6 @@ void NWNX_Race_SetRacialModifier(int iRace, int iMod, int iParam1, int iParam2 =
 
 // Returns the parent race if applicable, if not it just returns the race passed in
 int NWNX_Race_GetParentRace(int iRace);
-
-const string NWNX_Race = "NWNX_Race";
 
 
 void NWNX_Race_SetRacialModifier(int iRace, int iMod, int iParam1, int iParam2 = 0xDEADBEEF, int iParam3 = 0xDEADBEEF)

--- a/Plugins/Regex/NWScript/nwnx_regex.nss
+++ b/Plugins/Regex/NWScript/nwnx_regex.nss
@@ -1,13 +1,13 @@
 #include "nwnx"
 
+const string NWNX_Regex = "NWNX_Regex";
+
 // Returns whether the string matches the regular expression
 int NWNX_Regex_Search(string str, string regex);
 
 // Replaces any matches of the regular expression with a string
 string NWNX_Regex_Replace(string str, string regex, string replace="", int firstOnly=0);
 
-
-const string NWNX_Regex = "NWNX_Regex";
 
 int NWNX_Regex_Search(string str, string regex)
 {

--- a/Plugins/Ruby/NWScript/nwnx_ruby.nss
+++ b/Plugins/Ruby/NWScript/nwnx_ruby.nss
@@ -1,10 +1,15 @@
 #include "nwnx"
 
+const string NWNX_Ruby = "NWNX_Ruby";
+
 string NWNX_Ruby_Evaluate (string sCode);
+
 
 string NWNX_Ruby_Evaluate (string sCode) 
 {
-    NWNX_PushArgumentString ("NWNX_Ruby", "EVALUATE", sCode);
-    NWNX_CallFunction ("NWNX_Ruby", "EVALUATE");
-    return NWNX_GetReturnValueString ("NWNX_Ruby", "EVALUATE");
+    string sFunc = "EVALUATE";
+
+    NWNX_PushArgumentString (NWNX_Ruby, sFunc, sCode);
+    NWNX_CallFunction (NWNX_Ruby, sFunc);
+    return NWNX_GetReturnValueString (NWNX_Ruby, sFunc);
 }

--- a/Plugins/SQL/NWScript/nwnx_sql.nss
+++ b/Plugins/SQL/NWScript/nwnx_sql.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_SQL = "NWNX_SQL";
+
 // Prepares the provided query for execution. Does not execute it! Clears any previous state.
 // Returns TRUE if the query was successfully prepared.
 int NWNX_SQL_PrepareQuery(string query);
@@ -60,17 +62,22 @@ string NWNX_SQL_GetLastError();
 // Returns -1 if no query is prepared.
 int NWNX_SQL_GetPreparedQueryParamCount();
 
+
 int NWNX_SQL_PrepareQuery(string query)
 {
-    NWNX_PushArgumentString("NWNX_SQL", "PREPARE_QUERY", query);
-    NWNX_CallFunction("NWNX_SQL", "PREPARE_QUERY");
-    return NWNX_GetReturnValueInt("NWNX_SQL", "PREPARE_QUERY");
+    string sFunc = "PREPARE_QUERY";
+
+    NWNX_PushArgumentString(NWNX_SQL, sFunc, query);
+    NWNX_CallFunction(NWNX_SQL, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_SQL, sFunc);
 }
 
 int NWNX_SQL_ExecutePreparedQuery()
 {
-    NWNX_CallFunction("NWNX_SQL", "EXECUTE_PREPARED_QUERY");
-    return NWNX_GetReturnValueInt("NWNX_SQL", "EXECUTE_PREPARED_QUERY");
+    string sFunc = "EXECUTE_PREPARED_QUERY";
+
+    NWNX_CallFunction(NWNX_SQL, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_SQL, sFunc);
 }
 
 int NWNX_SQL_ExecuteQuery(string query)
@@ -88,93 +95,121 @@ int NWNX_SQL_ExecuteQuery(string query)
 
 int NWNX_SQL_ReadyToReadNextRow()
 {
-    NWNX_CallFunction("NWNX_SQL", "READY_TO_READ_NEXT_ROW");
-    return NWNX_GetReturnValueInt("NWNX_SQL", "READY_TO_READ_NEXT_ROW");
+    string sFunc = "READY_TO_READ_NEXT_ROW";
+
+    NWNX_CallFunction(NWNX_SQL, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_SQL, sFunc);
 }
 
 void NWNX_SQL_ReadNextRow()
 {
-    NWNX_CallFunction("NWNX_SQL", "READ_NEXT_ROW");
+    string sFunc = "READ_NEXT_ROW";
+
+    NWNX_CallFunction(NWNX_SQL, sFunc);
 }
 
 string NWNX_SQL_ReadDataInActiveRow(int column = 0)
 {
-    NWNX_PushArgumentInt("NWNX_SQL", "READ_DATA_IN_ACTIVE_ROW", column);
-    NWNX_CallFunction("NWNX_SQL", "READ_DATA_IN_ACTIVE_ROW");
-    return NWNX_GetReturnValueString("NWNX_SQL", "READ_DATA_IN_ACTIVE_ROW");
+    string sFunc = "READ_DATA_IN_ACTIVE_ROW";
+
+    NWNX_PushArgumentInt(NWNX_SQL, sFunc, column);
+    NWNX_CallFunction(NWNX_SQL, sFunc);
+    return NWNX_GetReturnValueString(NWNX_SQL, sFunc);
 }
 
 
 void NWNX_SQL_PreparedInt(int position, int value)
 {
-    NWNX_PushArgumentInt("NWNX_SQL", "PREPARED_INT", value);
-    NWNX_PushArgumentInt("NWNX_SQL", "PREPARED_INT", position);
-    NWNX_CallFunction("NWNX_SQL", "PREPARED_INT");
+    string sFunc = "PREPARED_INT";
+
+    NWNX_PushArgumentInt(NWNX_SQL, sFunc, value);
+    NWNX_PushArgumentInt(NWNX_SQL, sFunc, position);
+    NWNX_CallFunction(NWNX_SQL, sFunc);
 }
 void NWNX_SQL_PreparedString(int position, string value)
 {
-    NWNX_PushArgumentString("NWNX_SQL", "PREPARED_STRING", value);
-    NWNX_PushArgumentInt("NWNX_SQL", "PREPARED_STRING", position);
-    NWNX_CallFunction("NWNX_SQL", "PREPARED_STRING");
+    string sFunc = "PREPARED_STRING";
+
+    NWNX_PushArgumentString(NWNX_SQL, sFunc, value);
+    NWNX_PushArgumentInt(NWNX_SQL, sFunc, position);
+    NWNX_CallFunction(NWNX_SQL, sFunc);
 
 }
 void NWNX_SQL_PreparedFloat(int position, float value)
 {
-    NWNX_PushArgumentFloat("NWNX_SQL", "PREPARED_FLOAT", value);
-    NWNX_PushArgumentInt("NWNX_SQL", "PREPARED_FLOAT", position);
-    NWNX_CallFunction("NWNX_SQL", "PREPARED_FLOAT");
+    string sFunc = "PREPARED_FLOAT";
+
+    NWNX_PushArgumentFloat(NWNX_SQL, sFunc, value);
+    NWNX_PushArgumentInt(NWNX_SQL, sFunc, position);
+    NWNX_CallFunction(NWNX_SQL, sFunc);
 
 }
 void NWNX_SQL_PreparedObjectId(int position, object value)
 {
-    NWNX_PushArgumentObject("NWNX_SQL", "PREPARED_OBJECT_ID", value);
-    NWNX_PushArgumentInt("NWNX_SQL", "PREPARED_OBJECT_ID", position);
-    NWNX_CallFunction("NWNX_SQL", "PREPARED_OBJECT_ID");
+    string sFunc = "PREPARED_OBJECT_ID";
+
+    NWNX_PushArgumentObject(NWNX_SQL, sFunc, value);
+    NWNX_PushArgumentInt(NWNX_SQL, sFunc, position);
+    NWNX_CallFunction(NWNX_SQL, sFunc);
 
 }
 void NWNX_SQL_PreparedObjectFull(int position, object value)
 {
-    NWNX_PushArgumentObject("NWNX_SQL", "PREPARED_OBJECT_FULL", value);
-    NWNX_PushArgumentInt("NWNX_SQL", "PREPARED_OBJECT_FULL", position);
-    NWNX_CallFunction("NWNX_SQL", "PREPARED_OBJECT_FULL");
+    string sFunc = "PREPARED_OBJECT_FULL";
+
+    NWNX_PushArgumentObject(NWNX_SQL, sFunc, value);
+    NWNX_PushArgumentInt(NWNX_SQL, sFunc, position);
+    NWNX_CallFunction(NWNX_SQL, sFunc);
 }
 
 object NWNX_SQL_ReadFullObjectInActiveRow(int column = 0, object owner = OBJECT_INVALID, float x = 0.0, float y = 0.0, float z = 0.0)
 {
-    NWNX_PushArgumentFloat("NWNX_SQL", "READ_FULL_OBJECT_IN_ACTIVE_ROW", z);
-    NWNX_PushArgumentFloat("NWNX_SQL", "READ_FULL_OBJECT_IN_ACTIVE_ROW", y);
-    NWNX_PushArgumentFloat("NWNX_SQL", "READ_FULL_OBJECT_IN_ACTIVE_ROW", x);
-    NWNX_PushArgumentObject("NWNX_SQL", "READ_FULL_OBJECT_IN_ACTIVE_ROW", owner);
-    NWNX_PushArgumentInt("NWNX_SQL", "READ_FULL_OBJECT_IN_ACTIVE_ROW", column);
-    NWNX_CallFunction("NWNX_SQL", "READ_FULL_OBJECT_IN_ACTIVE_ROW");
-    return NWNX_GetReturnValueObject("NWNX_SQL", "READ_FULL_OBJECT_IN_ACTIVE_ROW");
+    string sFunc = "READ_FULL_OBJECT_IN_ACTIVE_ROW";
+
+    NWNX_PushArgumentFloat(NWNX_SQL, sFunc, z);
+    NWNX_PushArgumentFloat(NWNX_SQL, sFunc, y);
+    NWNX_PushArgumentFloat(NWNX_SQL, sFunc, x);
+    NWNX_PushArgumentObject(NWNX_SQL, sFunc, owner);
+    NWNX_PushArgumentInt(NWNX_SQL, sFunc, column);
+    NWNX_CallFunction(NWNX_SQL, sFunc);
+    return NWNX_GetReturnValueObject(NWNX_SQL, sFunc);
 }
 
 int NWNX_SQL_GetAffectedRows()
 {
-    NWNX_CallFunction("NWNX_SQL", "GET_AFFECTED_ROWS");
-    return NWNX_GetReturnValueInt("NWNX_SQL", "GET_AFFECTED_ROWS");
+    string sFunc = "GET_AFFECTED_ROWS";
+
+    NWNX_CallFunction(NWNX_SQL, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_SQL, sFunc);
 }
 
 string NWNX_SQL_GetDatabaseType()
 {
-    NWNX_CallFunction("NWNX_SQL", "GET_DATABASE_TYPE");
-    return NWNX_GetReturnValueString("NWNX_SQL", "GET_DATABASE_TYPE");
+    string sFunc = "GET_DATABASE_TYPE";
+
+    NWNX_CallFunction(NWNX_SQL, sFunc);
+    return NWNX_GetReturnValueString(NWNX_SQL, sFunc);
 }
 
 void NWNX_SQL_DestroyPreparedQuery()
 {
-    NWNX_CallFunction("NWNX_SQL", "DESTROY_PREPARED_QUERY");
+    string sFunc = "DESTROY_PREPARED_QUERY";
+
+    NWNX_CallFunction(NWNX_SQL, sFunc);
 }
 
 string NWNX_SQL_GetLastError()
 {
-    NWNX_CallFunction("NWNX_SQL", "GET_LAST_ERROR");
-    return NWNX_GetReturnValueString("NWNX_SQL", "GET_LAST_ERROR");
+    string sFunc = "GET_LAST_ERROR";
+
+    NWNX_CallFunction(NWNX_SQL, sFunc);
+    return NWNX_GetReturnValueString(NWNX_SQL, sFunc);
 }
 
 int NWNX_SQL_GetPreparedQueryParamCount()
 {
-    NWNX_CallFunction("NWNX_SQL", "GET_PREPARED_QUERY_PARAM_COUNT");
-    return NWNX_GetReturnValueInt("NWNX_SQL", "GET_PREPARED_QUERY_PARAM_COUNT");
+    string sFunc = "GET_PREPARED_QUERY_PARAM_COUNT";
+
+    NWNX_CallFunction(NWNX_SQL, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_SQL, sFunc);
 }

--- a/Plugins/SpellChecker/NWScript/nwnx_spellcheck.nss
+++ b/Plugins/SpellChecker/NWScript/nwnx_spellcheck.nss
@@ -1,4 +1,7 @@
 #include "nwnx"
+
+const string NWNX_SpellChecker = "NWNX_SpellChecker";
+
 // The functions below can be performance heavy, do limit how many calls and/or how long of a sentence is passed
 // Make use of delaycommands and assign commands
 
@@ -11,8 +14,6 @@ string NWNX_SpellChecker_FindMisspell(string sentence);
 // Returns blank if no errors or if .so file is improperly installed
 string NWNX_SpellChecker_GetSuggestSpell(string word);
 
-
-const string NWNX_SpellChecker = "NWNX_SpellChecker";
 
 string NWNX_SpellChecker_FindMisspell(string sentence)
 {

--- a/Plugins/Time/NWScript/nwnx_time.nss
+++ b/Plugins/Time/NWScript/nwnx_time.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Time = "NWNX_Time";
+
 // Returns the current date in the format (mm/dd/yyyy)
 string NWNX_Time_GetSystemDate();
 
@@ -16,8 +18,6 @@ struct NWNX_Time_HighResTimestamp
 };
 struct NWNX_Time_HighResTimestamp NWNX_Time_GetHighResTimeStamp();
 
-
-const string NWNX_Time = "NWNX_Time";
 
 string NWNX_Time_GetSystemDate()
 {

--- a/Plugins/Util/NWScript/nwnx_util.nss
+++ b/Plugins/Util/NWScript/nwnx_util.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Util = "NWNX_Util";
+
 const int NWNX_UTIL_RESREF_TYPE_NSS       = 2009;
 const int NWNX_UTIL_RESREF_TYPE_NCS       = 2010;
 const int NWNX_UTIL_RESREF_TYPE_AREA_ARE  = 2012;
@@ -67,9 +69,6 @@ int NWNX_Util_GetServerTicksPerSecond();
 //                NWNX equivalent.
 // * Return value: The last created object. On error, this returns OBJECT_INVALID.
 object NWNX_Util_GetLastCreatedObject(int nObjectType, int nNthLast = 1);
-
-
-const string NWNX_Util = "NWNX_Util";
 
 
 string NWNX_Util_GetCurrentScriptName(int depth = 0)

--- a/Plugins/Visibility/NWScript/nwnx_visibility.nss
+++ b/Plugins/Visibility/NWScript/nwnx_visibility.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_Visibility = "NWNX_Visibility";
+
 const int NWNX_VISIBILITY_DEFAULT   = -1;
 const int NWNX_VISIBILITY_VISIBLE   = 0;
 const int NWNX_VISIBILITY_HIDDEN    = 1;
@@ -39,9 +41,6 @@ int NWNX_Visibility_GetVisibilityOverride(object player, object target);
 // to NWNX_VISIBILITY_HIDDEN or NWNX_VISIBILITY_DM_ONLY but the player's state is
 // set to NWNX_VISIBILITY_VISIBLE for the target, the object will be visible to the player
 void NWNX_Visibility_SetVisibilityOverride(object player, object target, int override);
-
-
-const string NWNX_Visibility = "NWNX_Visibility";
 
 
 int NWNX_Visibility_GetVisibilityOverride(object player, object target)

--- a/Plugins/WebHook/NWScript/nwnx_webhook.nss
+++ b/Plugins/WebHook/NWScript/nwnx_webhook.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_WebHook = "NWNX_WebHook";
+
 // Send a slack compatible webhook
 void NWNX_WebHook_SendWebHookHTTPS(string host, string path, string message, string username = "", int mrkdwn = 1);
 
@@ -7,15 +9,16 @@ void NWNX_WebHook_SendWebHookHTTPS(string host, string path, string message, str
 // is already constructed. So it just resends the WebHook with an optional delay
 void NWNX_WebHook_ResendWebHookHTTPS(string host, string path, string sMessage, float delay = 0.0f);
 
+
 void NWNX_WebHook_SendWebHookHTTPS(string host, string path, string message, string username = "", int mrkdwn = 1)
 {
     string sFunc = "SEND_WEBHOOK_HTTPS";
-    NWNX_PushArgumentInt("NWNX_WebHook", sFunc, mrkdwn);
-    NWNX_PushArgumentString("NWNX_WebHook", sFunc, username);
-    NWNX_PushArgumentString("NWNX_WebHook", sFunc, message);
-    NWNX_PushArgumentString("NWNX_WebHook", sFunc, path);
-    NWNX_PushArgumentString("NWNX_WebHook", sFunc, host);
-    NWNX_CallFunction("NWNX_WebHook", sFunc);
+    NWNX_PushArgumentInt(NWNX_WebHook, sFunc, mrkdwn);
+    NWNX_PushArgumentString(NWNX_WebHook, sFunc, username);
+    NWNX_PushArgumentString(NWNX_WebHook, sFunc, message);
+    NWNX_PushArgumentString(NWNX_WebHook, sFunc, path);
+    NWNX_PushArgumentString(NWNX_WebHook, sFunc, host);
+    NWNX_CallFunction(NWNX_WebHook, sFunc);
 }
 
 void NWNX_WebHook_ResendWebHookHTTPS(string host, string path, string sMessage, float delay = 0.0f)


### PR DESCRIPTION
- Prototypes weren't separated by a new line
- There was an extra new line between prototypes and implementations.

These are the coding style rules for nss that I've found so far:
- Two new lines between Prototypes / NWNX Plugin Constant / Implementations.
- NWNX Plugin name as a constant between Prototypes and Implementations.
- NWNX Plugin function name should be a string variable with name sFunc in their respective function.
- One new line separation for "unrelated" functions (Either prototypes/implementations) We consider functions "unrelated" if they do different things (I.E: GetPlayerPassword, SetPlayerPassword and ClearPlayerPassword are related, so they can be bundled)