### PR TITLE
Serialization: Save locals/effects for objects other than items

### DIFF
--- a/NWNXLib/Serialize.cpp
+++ b/NWNXLib/Serialize.cpp
@@ -46,6 +46,7 @@ std::vector<uint8_t> SerializeGameObject(API::CGameObject *pObject, bool bStripP
                     std::swap(bIsPC, pCreature->m_pStats->m_bIsPC);
                 }
 
+                pCreature->SaveObjectState(&resGff, &resStruct);
                 if (pCreature->SaveCreature(&resGff, &resStruct, 0, 0, 0, 0))
                     resGff.WriteGFFToPointer((void**)&pData, /*ref*/dataLength);
 
@@ -63,6 +64,7 @@ std::vector<uint8_t> SerializeGameObject(API::CGameObject *pObject, bool bStripP
             API::CNWS##_type *p = static_cast<API::CNWS##_type*>(pObject);       \
             if (resGff.CreateGFFFile(&resStruct, _gff_header, "V2.0"))           \
             {                                                                    \
+                p->SaveObjectState(&resGff, &resStruct);                         \
                 if (p->Save##_type(&resGff, &resStruct, ##__VA_ARGS__))          \
                     resGff.WriteGFFToPointer((void**)&pData, /*ref*/dataLength); \
             }                                                                    \
@@ -118,6 +120,7 @@ API::CGameObject *DeserializeGameObject(const std::vector<uint8_t>& serialized)
             delete pCreature;
             return nullptr;
         }
+        pCreature->LoadObjectState(&resGff, &resStruct);
         return static_cast<API::CGameObject*>(pCreature);
     }
 
@@ -129,6 +132,7 @@ API::CGameObject *DeserializeGameObject(const std::vector<uint8_t>& serialized)
             delete p;                                                                       \
             return nullptr;                                                                 \
         }                                                                                   \
+        p->LoadObjectState(&resGff, &resStruct);                                            \
         return static_cast<API::CGameObject*>(p);                                           \
     } while(0)
 

--- a/NWNXLib/Serialize.cpp
+++ b/NWNXLib/Serialize.cpp
@@ -64,7 +64,8 @@ std::vector<uint8_t> SerializeGameObject(API::CGameObject *pObject, bool bStripP
             API::CNWS##_type *p = static_cast<API::CNWS##_type*>(pObject);       \
             if (resGff.CreateGFFFile(&resStruct, _gff_header, "V2.0"))           \
             {                                                                    \
-                if(!Utils::AsNWSItem(p))                                         \
+                /* CNWSItem already makes this call in SaveItem */               \
+                if (!Utils::AsNWSItem(p))                                        \
                     p->SaveObjectState(&resGff, &resStruct);                     \
                 if (p->Save##_type(&resGff, &resStruct, ##__VA_ARGS__))          \
                     resGff.WriteGFFToPointer((void**)&pData, /*ref*/dataLength); \
@@ -72,9 +73,9 @@ std::vector<uint8_t> SerializeGameObject(API::CGameObject *pObject, bool bStripP
         } while(0)
 
         case API::Constants::ObjectType::Item:      SERIALIZE(Item,      "UTI ", 0); break;
-        case API::Constants::ObjectType::Placeable: SERIALIZE(Placeable, "UTP ", 0);    break;
+        case API::Constants::ObjectType::Placeable: SERIALIZE(Placeable, "UTP ", 0); break;
         case API::Constants::ObjectType::Waypoint:  SERIALIZE(Waypoint,  "UTW ");    break;
-        case API::Constants::ObjectType::Store:     SERIALIZE(Store,     "UTM ", 0);    break;
+        case API::Constants::ObjectType::Store:     SERIALIZE(Store,     "UTM ", 0); break;
         case API::Constants::ObjectType::Door:      SERIALIZE(Door,      "UTD ");    break;
         case API::Constants::ObjectType::Trigger:   SERIALIZE(Trigger,   "UTT ");    break;
 #undef SERIALIZE
@@ -133,6 +134,7 @@ API::CGameObject *DeserializeGameObject(const std::vector<uint8_t>& serialized)
             delete p;                                                                       \
             return nullptr;                                                                 \
         }                                                                                   \
+        /* CNWSItem already makes this call in LoadItem */                                  \
         if (!Utils::AsNWSItem(p))                                                           \
             p->LoadObjectState(&resGff, &resStruct);                                        \
         return static_cast<API::CGameObject*>(p);                                           \

--- a/NWNXLib/Serialize.cpp
+++ b/NWNXLib/Serialize.cpp
@@ -64,7 +64,8 @@ std::vector<uint8_t> SerializeGameObject(API::CGameObject *pObject, bool bStripP
             API::CNWS##_type *p = static_cast<API::CNWS##_type*>(pObject);       \
             if (resGff.CreateGFFFile(&resStruct, _gff_header, "V2.0"))           \
             {                                                                    \
-                p->SaveObjectState(&resGff, &resStruct);                         \
+                if(!Utils::AsNWSItem(pObject))                                   \
+                    p->SaveObjectState(&resGff, &resStruct);                     \
                 if (p->Save##_type(&resGff, &resStruct, ##__VA_ARGS__))          \
                     resGff.WriteGFFToPointer((void**)&pData, /*ref*/dataLength); \
             }                                                                    \
@@ -132,7 +133,8 @@ API::CGameObject *DeserializeGameObject(const std::vector<uint8_t>& serialized)
             delete p;                                                                       \
             return nullptr;                                                                 \
         }                                                                                   \
-        p->LoadObjectState(&resGff, &resStruct);                                            \
+        if (!Utils::AsNWSItem(p))                                                           \
+            p->LoadObjectState(&resGff, &resStruct);                                        \
         return static_cast<API::CGameObject*>(p);                                           \
     } while(0)
 

--- a/NWNXLib/Serialize.cpp
+++ b/NWNXLib/Serialize.cpp
@@ -64,7 +64,7 @@ std::vector<uint8_t> SerializeGameObject(API::CGameObject *pObject, bool bStripP
             API::CNWS##_type *p = static_cast<API::CNWS##_type*>(pObject);       \
             if (resGff.CreateGFFFile(&resStruct, _gff_header, "V2.0"))           \
             {                                                                    \
-                if(!Utils::AsNWSItem(pObject))                                   \
+                if(!Utils::AsNWSItem(p))                                         \
                     p->SaveObjectState(&resGff, &resStruct);                     \
                 if (p->Save##_type(&resGff, &resStruct, ##__VA_ARGS__))          \
                     resGff.WriteGFFToPointer((void**)&pData, /*ref*/dataLength); \


### PR DESCRIPTION
Serialization now saves locals and effects for all objects, instead of only items.