### PR TITLE
Object: add AddIconEffect and RemoveIconEffect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ The following plugins were added:
 - Object: SetPlaceableIsStatic()
 - Object: {Get|Set}AutoRemoveKey()
 - Object: {Get|Set}TriggerGeometry()
+- Object: {Add|Remove}IconEffect()
 - Player: ShowVisualEffect()
 - Player: ForcePlaceableInventoryWindow()
 - Player: MusicBackgroundChangeDay()

--- a/Plugins/Object/NWScript/nwnx_object.nss
+++ b/Plugins/Object/NWScript/nwnx_object.nss
@@ -168,6 +168,14 @@ string NWNX_Object_GetTriggerGeometry(object oTrigger);
 // Example: "{1.0, 1.0, 0.0}{4.0, 1.0, 0.0}{4.0, 4.0, 0.0}{1.0, 4.0, 0.0}"
 void NWNX_Object_SetTriggerGeometry(object oTrigger, string sGeometry);
 
+// Add an effect to an object that displays an icon and has no other effect.
+// See effecticons.2da for a list of possible effect icons. If a duration is
+// specified, the effect is temporary, otherwise it's permanent.
+void NWNX_Object_AddIconEffect(object obj, int nIcon, float fDuration=0.0);
+
+// Remove an icon effect from an object that was added by the
+// NWNX_Object_AddIconEffect function.
+void NWNX_Object_RemoveIconEffect(object obj, int nIcon);
 
 const string NWNX_Object = "NWNX_Object";
 
@@ -461,5 +469,24 @@ void NWNX_Object_SetTriggerGeometry(object oTrigger, string sGeometry)
 
     NWNX_PushArgumentString(NWNX_Object, sFunc, sGeometry);
     NWNX_PushArgumentObject(NWNX_Object, sFunc, oTrigger);
+    NWNX_CallFunction(NWNX_Object, sFunc);
+}
+
+void NWNX_Object_AddIconEffect(object obj, int nIcon, float fDuration=0.0)
+{
+    string sFunc = "AddIconEffect";
+
+    NWNX_PushArgumentFloat(NWNX_Object, sFunc, fDuration);
+    NWNX_PushArgumentInt(NWNX_Object, sFunc, nIcon);
+    NWNX_PushArgumentObject(NWNX_Object, sFunc, obj);
+    NWNX_CallFunction(NWNX_Object, sFunc);
+}
+
+void NWNX_Object_RemoveIconEffect(object obj, int nIcon)
+{
+    string sFunc = "RemoveIconEffect";
+
+    NWNX_PushArgumentInt(NWNX_Object, sFunc, nIcon);
+    NWNX_PushArgumentObject(NWNX_Object, sFunc, obj);
     NWNX_CallFunction(NWNX_Object, sFunc);
 }

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -35,8 +35,6 @@ using namespace NWNXLib::API;
 
 static ViewPtr<Object::Object> g_plugin;
 
-const auto MODULE_OID = 0;
-
 NWNX_PLUGIN_ENTRY Plugin::Info* PluginInfo()
 {
     return new Plugin::Info
@@ -642,7 +640,7 @@ ArgumentStack Object::AddIconEffect(ArgumentStack&& args)
         }
 
         auto *effIcon = new API::CGameEffect(true);
-        effIcon->m_oidCreator = MODULE_OID;
+        effIcon->m_oidCreator = 0;
         effIcon->m_nType      = Constants::EffectTrueType::Icon;
         effIcon->m_nSubType   = Constants::EffectSubType::Supernatural;
         effIcon->m_bShowIcon  = true;

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -35,6 +35,8 @@ using namespace NWNXLib::API;
 
 static ViewPtr<Object::Object> g_plugin;
 
+const auto MODULE_OID = 0;
+
 NWNX_PLUGIN_ENTRY Plugin::Info* PluginInfo()
 {
     return new Plugin::Info
@@ -85,6 +87,8 @@ Object::Object(const Plugin::CreateParams& params)
     REGISTER(SetAutoRemoveKey);
     REGISTER(GetTriggerGeometry);
     REGISTER(SetTriggerGeometry);
+    REGISTER(RemoveIconEffect);
+    REGISTER(AddIconEffect);
 
 #undef REGISTER
 }
@@ -589,6 +593,74 @@ ArgumentStack Object::SetTriggerGeometry(ArgumentStack&& args)
         {
             LOG_WARNING("NWNX_Object_SetTriggerGeometry() called on non trigger object.");
         }
+    }
+
+    return stack;
+}
+
+ArgumentStack Object::RemoveIconEffect(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+
+    if (auto *pObject = object(args))
+    {
+        const auto nIcon = Services::Events::ExtractArgument<int32_t>(args);
+
+        for (int i = 0; i < pObject->m_appliedEffects.num; i++)
+        {
+            auto *eff = pObject->m_appliedEffects.element[i];
+
+            if (eff->m_sCustomTag == "NWNX_Object_IconEffect" && eff->m_nParamInteger[0] == nIcon)
+            {
+                pObject->RemoveEffect(eff);
+            }
+        }
+    }
+
+    return stack;
+}
+
+ArgumentStack Object::AddIconEffect(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+
+    if (auto *pObject = object(args))
+    {
+        const auto nIcon = Services::Events::ExtractArgument<int32_t>(args);
+        const auto fDuration = Services::Events::ExtractArgument<float>(args);
+
+        for (int i = 0; i < pObject->m_appliedEffects.num; i++)
+        {
+            auto *eff = pObject->m_appliedEffects.element[i];
+
+            if (eff->m_sCustomTag == "NWNX_Object_IconEffect" && eff->m_nParamInteger[0] == nIcon)
+            {
+                pObject->RemoveEffect(eff);
+            }
+        }
+
+        auto *effIcon = new API::CGameEffect(true);
+        effIcon->m_oidCreator = MODULE_OID;
+        effIcon->m_nType      = Constants::EffectTrueType::Icon;
+        effIcon->m_nSubType   = Constants::EffectSubType::Supernatural;
+        effIcon->m_bShowIcon  = true;
+        effIcon->m_bExpose    = true;
+        effIcon->m_sCustomTag = "NWNX_Object_IconEffect";
+
+        effIcon->SetNumIntegers(1);
+        effIcon->m_nParamInteger[0] = nIcon;
+
+        if (fDuration > 0.0)
+        {
+            effIcon->m_nSubType |= Constants::EffectDurationType::Temporary;
+            effIcon->m_fDuration = fDuration;
+        }
+        else
+        {
+            effIcon->m_nSubType |= Constants::EffectDurationType::Permanent;
+        }
+
+        pObject->ApplyEffect(effIcon, false, true);
     }
 
     return stack;

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -626,6 +626,7 @@ ArgumentStack Object::AddIconEffect(ArgumentStack&& args)
     if (auto *pObject = object(args))
     {
         const auto nIcon = Services::Events::ExtractArgument<int32_t>(args);
+        ASSERT_OR_THROW(nIcon > 0);
         const auto fDuration = Services::Events::ExtractArgument<float>(args);
 
         for (int i = 0; i < pObject->m_appliedEffects.num; i++)

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -613,6 +613,7 @@ ArgumentStack Object::RemoveIconEffect(ArgumentStack&& args)
             if (eff->m_sCustomTag == "NWNX_Object_IconEffect" && eff->m_nParamInteger[0] == nIcon)
             {
                 pObject->RemoveEffect(eff);
+                break;
             }
         }
     }
@@ -636,6 +637,7 @@ ArgumentStack Object::AddIconEffect(ArgumentStack&& args)
             if (eff->m_sCustomTag == "NWNX_Object_IconEffect" && eff->m_nParamInteger[0] == nIcon)
             {
                 pObject->RemoveEffect(eff);
+                break;
             }
         }
 

--- a/Plugins/Object/Object.hpp
+++ b/Plugins/Object/Object.hpp
@@ -38,6 +38,8 @@ private:
     ArgumentStack SetAutoRemoveKey      (ArgumentStack&& args);
     ArgumentStack GetTriggerGeometry    (ArgumentStack&& args);
     ArgumentStack SetTriggerGeometry    (ArgumentStack&& args);
+    ArgumentStack RemoveIconEffect      (ArgumentStack&& args);
+    ArgumentStack AddIconEffect         (ArgumentStack&& args);
 
     NWNXLib::API::CNWSObject *object(ArgumentStack& args);
 


### PR DESCRIPTION
This adds two new functions to the object plugin:

* `NWNX_Object_AddIconEffect(object obj, int nIcon, float fDuration=0.0)`
* `NWNX_Object_RemoveIconEffect(object obj, int nIcon)`

These functions add effect icons without the associated effect. This will be considerably more useful in the next version of NWN, when the hardcoded limit for effect icons is removed, but if there are some effects you know won't be used, you can replace their icons with custom ones in the `effecticons.2da`.

Icon effects work with `ApplyEffectToObject` and `RemoveEffect`, but don't seem to work with many other effect functions, such as `TagEffect`, `EffectLinkEffects`, `GetFirstEffect` and `GetNextEffect`. For this reason it seems reasonable to hide the implementation behind functions, and not to expose the actual `effect` pointer in NWScript.

Adding an icon effect overwrites any icon effect with the same icon already on the object. This means there's some code in common between `AddIconEffect` and `RemoveIconEffect` that I wasn't sure what to do with. Current the lines of code in common are duplicated, but they could be factored out into a common private function if that would be better design.