### PR TITLE
Rename tweaks

### DIFF
--- a/Plugins/Rename/Documentation/README.md
+++ b/Plugins/Rename/Documentation/README.md
@@ -22,7 +22,6 @@ Due to the conflict with this plugin and the Tweaks plugin to hide classes on th
 | -------------   | :----: | :----: |----------------------------- |
 | `NWNX_RENAME_ON_MODULE_CHAR_LIST` | 0-3 | 0 | This is the listing of players from the character selection screen before entering the server. Setting the value to 1 overrides their names if a global rename has been set, 2 also hides class information, 3 hides class information but keeps names as their original.
 | `NWNX_RENAME_ON_PLAYER_LIST` | true or false | true | Renames the player name on the player list as well.
-| `NWNX_RENAME_ON_SELF` | true or false | true | Global overrides will impact how the PC sees their own character name as well. Note: If you set this to `false` but set a personal override where the observer and target are the same then that personal override will function.
 
 ## Sample Include
 

--- a/Plugins/Rename/Documentation/README.md
+++ b/Plugins/Rename/Documentation/README.md
@@ -22,6 +22,7 @@ Due to the conflict with this plugin and the Tweaks plugin to hide classes on th
 | -------------   | :----: | :----: |----------------------------- |
 | `NWNX_RENAME_ON_MODULE_CHAR_LIST` | 0-3 | 0 | This is the listing of players from the character selection screen before entering the server. Setting the value to 1 overrides their names if a global rename has been set, 2 also hides class information, 3 hides class information but keeps names as their original.
 | `NWNX_RENAME_ON_PLAYER_LIST` | true or false | true | Renames the player name on the player list as well.
+| `NWNX_RENAME_ON_SELF` | true or false | true | Global overrides will impact how the PC sees their own character name as well. Note: If you set this to `false` but set a personal override where the observer and target are the same then that personal override will function.
 
 ## Sample Include
 

--- a/Plugins/Rename/Rename.cpp
+++ b/Plugins/Rename/Rename.cpp
@@ -82,6 +82,7 @@ Rename::Rename(const Plugin::CreateParams& params)
 
     m_RenameOnModuleCharList = GetServices()->m_config->Get<int32_t>("ON_MODULE_CHAR_LIST", 0);
     m_RenameOnPlayerList = GetServices()->m_config->Get<bool>("ON_PLAYER_LIST", true);
+    m_RenameOnSelf = GetServices()->m_config->Get<bool>("ON_SELF", true);
 
     GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__WriteGameObjUpdate_UpdateObject,
             int32_t, CNWSMessage *, CNWSPlayer *, CNWSObject *, CLastUpdateObject *, uint32_t, uint32_t>(
@@ -150,11 +151,9 @@ CNWSPlayer *Rename::player(Types::ObjectID playerId)
 }
 
 void Rename::SetOrRestorePlayerName(NWNXLib::Services::Hooks::CallType cType,
-                                    CNWSPlayer *targetPlayer, CNWSPlayer *observerPlayer)
+                                    CNWSPlayer *targetPlayer, CNWSPlayer *observerPlayer, bool playerList)
 {
-    if (targetPlayer == nullptr ||
-        observerPlayer == nullptr ||
-        targetPlayer == observerPlayer)
+    if (targetPlayer == nullptr || observerPlayer == nullptr)
         return;
 
     auto *targetCreature = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(targetPlayer->m_oidNWSObject);
@@ -183,13 +182,13 @@ void Rename::SetOrRestorePlayerName(NWNXLib::Services::Hooks::CallType cType,
     }
 
     if (cType == Services::Hooks::CallType::BEFORE_ORIGINAL)
-        SetPlayerNameAsObservedBy(targetCreature, observerOid);
+        SetPlayerNameAsObservedBy(targetCreature, observerOid, playerList);
     else
-        RestorePlayerName(targetCreature);
+        RestorePlayerName(targetCreature, playerList);
 
 }
 
-void Rename::SetPlayerNameAsObservedBy(CNWSCreature *targetCreature, Types::ObjectID observerOid)
+void Rename::SetPlayerNameAsObservedBy(CNWSCreature *targetCreature, Types::ObjectID observerOid, bool playerList)
 {
     Rename &plugin = *g_plugin;
     auto targetOid = targetCreature->m_idSelf;
@@ -200,27 +199,33 @@ void Rename::SetPlayerNameAsObservedBy(CNWSCreature *targetCreature, Types::Obje
     std::string overrideName = *pPOS->Get<std::string>(targetOid, overrideNameKeyObserver);
     if (!displayName.empty())
     {
-        targetCreature->m_pStats->m_lsFirstName = plugin.ContainString(overrideName);
-        targetCreature->m_pStats->m_lsLastName = plugin.ContainString("");
+        if (playerList)
+        {
+            targetCreature->m_pStats->m_lsFirstName = plugin.ContainString(overrideName);
+            targetCreature->m_pStats->m_lsLastName = plugin.ContainString("");
+        }
         targetCreature->m_sDisplayName = displayName.c_str();
         LOG_DEBUG("Observer %x will see %x as %s due to personal override", observerOid, targetOid, overrideName.c_str());
     }
     else
     {
         std::string allClients = Utils::ObjectIDToString(Constants::PLAYERID_ALL_CLIENTS);
-        displayName = *pPOS->Get<std::string>(targetOid, displayNameKey + ":" + allClients);
+        if (plugin.m_RenameOnSelf || targetOid != observerOid)
+            displayName = *pPOS->Get<std::string>(targetOid, displayNameKey + ":" + allClients);
+        else
+            displayName = "";
         overrideName = *pPOS->Get<std::string>(targetOid, overrideNameKey + ":" + allClients);
-        if (!displayName.empty())
+        if (playerList)
         {
             targetCreature->m_pStats->m_lsFirstName = plugin.ContainString(overrideName);
             targetCreature->m_pStats->m_lsLastName = plugin.ContainString("");
-            targetCreature->m_sDisplayName = displayName.c_str();
-            LOG_DEBUG("Observer %x will see %x as %s due to global override", observerOid, targetOid, overrideName.c_str());
         }
+        targetCreature->m_sDisplayName = displayName.c_str();
+        LOG_DEBUG("Observer %x will see %x as %s due to global override", observerOid, targetOid, overrideName.c_str());
     }
 }
 
-void Rename::RestorePlayerName(CNWSCreature *targetCreature)
+void Rename::RestorePlayerName(CNWSCreature *targetCreature, bool playerList)
 {
     Rename &plugin = *g_plugin;
     auto *pPOS = plugin.GetServices()->m_perObjectStorage.get();
@@ -228,9 +233,14 @@ void Rename::RestorePlayerName(CNWSCreature *targetCreature)
     std::string lsLastName = *pPOS->Get<std::string>(targetCreature->m_idSelf, lastNameKey);
     if (!lsFirstName.empty())
     {
-        targetCreature->m_pStats->m_lsFirstName = plugin.ContainString(lsFirstName);
-        targetCreature->m_pStats->m_lsLastName = plugin.ContainString(lsLastName);
-        targetCreature->m_sDisplayName = "";
+        std::string allClients = Utils::ObjectIDToString(Constants::PLAYERID_ALL_CLIENTS);
+        std::string displayName = *pPOS->Get<std::string>(targetCreature->m_idSelf, displayNameKey + ":" + allClients);
+        if (playerList)
+        {
+            targetCreature->m_pStats->m_lsFirstName = plugin.ContainString(lsFirstName);
+            targetCreature->m_pStats->m_lsLastName = plugin.ContainString(lsLastName);
+        }
+        targetCreature->m_sDisplayName = displayName.c_str();
     }
 }
 
@@ -501,7 +511,7 @@ void Rename::GlobalNameChange(
                 }
             }
             if (m_RenameOnPlayerList)
-                SetOrRestorePlayerName(cType, targetPlayer, observerPlayer);
+                SetOrRestorePlayerName(cType, targetPlayer, observerPlayer, true);
         }
     }
 }
@@ -602,13 +612,12 @@ ArgumentStack Rename::SetPCNameOverride(ArgumentStack&& args)
 
         if (observerPlayerId == Constants::PLAYERID_ALL_CLIENTS)
         {
-            // Get all the connected players except the targetPlayerId, we don't update their own name with ALL_CLIENTS
             auto *playerList = server->m_pcExoAppInternal->m_pNWSPlayerList->m_pcExoLinkedListInternal;
 
             for (auto *head = playerList->pHead; head; head = head->pNext)
             {
                 auto *client = static_cast<API::CNWSClient*>(head->pObject);
-                if (client && client->m_nPlayerID != targetPlayerId)
+                if (client)
                     playersToNotify.emplace_back(client->m_nPlayerID);
             }
         }

--- a/Plugins/Rename/Rename.cpp
+++ b/Plugins/Rename/Rename.cpp
@@ -82,7 +82,6 @@ Rename::Rename(const Plugin::CreateParams& params)
 
     m_RenameOnModuleCharList = GetServices()->m_config->Get<int32_t>("ON_MODULE_CHAR_LIST", 0);
     m_RenameOnPlayerList = GetServices()->m_config->Get<bool>("ON_PLAYER_LIST", true);
-    m_RenameOnSelf = GetServices()->m_config->Get<bool>("ON_SELF", true);
 
     GetServices()->m_hooks->RequestSharedHook<Functions::CNWSMessage__WriteGameObjUpdate_UpdateObject,
             int32_t, CNWSMessage *, CNWSPlayer *, CNWSObject *, CLastUpdateObject *, uint32_t, uint32_t>(
@@ -210,10 +209,7 @@ void Rename::SetPlayerNameAsObservedBy(CNWSCreature *targetCreature, Types::Obje
     else
     {
         std::string allClients = Utils::ObjectIDToString(Constants::PLAYERID_ALL_CLIENTS);
-        if (plugin.m_RenameOnSelf || targetOid != observerOid)
-            displayName = *pPOS->Get<std::string>(targetOid, displayNameKey + ":" + allClients);
-        else
-            displayName = "";
+        displayName = *pPOS->Get<std::string>(targetOid, displayNameKey + ":" + allClients);
         overrideName = *pPOS->Get<std::string>(targetOid, overrideNameKey + ":" + allClients);
         if (playerList)
         {

--- a/Plugins/Rename/Rename.hpp
+++ b/Plugins/Rename/Rename.hpp
@@ -23,6 +23,7 @@ public:
 private:
     int32_t m_RenameOnModuleCharList;
     bool m_RenameOnPlayerList;
+    bool m_RenameOnSelf;
 
     static void WriteGameObjUpdate_UpdateObjectHook(
             Services::Hooks::CallType,
@@ -67,9 +68,9 @@ private:
             Types::ObjectID,
             int32_t, int32_t, int32_t, int32_t, CExoString*);
 
-    static void SetOrRestorePlayerName(NWNXLib::Services::Hooks::CallType, CNWSPlayer*, CNWSPlayer*);
-    static void SetPlayerNameAsObservedBy(CNWSCreature *targetCreature, Types::ObjectID);
-    static void RestorePlayerName(CNWSCreature *targetCreature);
+    static void SetOrRestorePlayerName(NWNXLib::Services::Hooks::CallType, CNWSPlayer*, CNWSPlayer*, bool playerList=false);
+    static void SetPlayerNameAsObservedBy(CNWSCreature *targetCreature, Types::ObjectID, bool playerList=false);
+    static void RestorePlayerName(CNWSCreature *targetCreature, bool playerList=false);
     void GlobalNameChange(NWNXLib::Services::Hooks::CallType, Types::PlayerID, Types::PlayerID);
 
     CExoLocString ContainString(const std::string& str);

--- a/Plugins/Rename/Rename.hpp
+++ b/Plugins/Rename/Rename.hpp
@@ -23,7 +23,6 @@ public:
 private:
     int32_t m_RenameOnModuleCharList;
     bool m_RenameOnPlayerList;
-    bool m_RenameOnSelf;
 
     static void WriteGameObjUpdate_UpdateObjectHook(
             Services::Hooks::CallType,


### PR DESCRIPTION
Rename now changes how PC sees their own name when a global override is set. Builders should set a personal override if they do not wish this functionality
Fixed it so `GetName` honours the `bOriginalName` second argument

These changes should put the plugin back in line with its original functionality.