### PR TITLE
 Events: add {Add|Remove}Gold InventoryEvents 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Events: Added Level{Up|UpAutomatic|Down} events to LevelEvents
 - Events: Added WebHook Success/Failure events with rate limit feedback
 - Events: Added UseLoreOnItem and PayToIdentifyItem events
+- Events: Added {Add|Remove}Gold events to InventoryEvents
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite
 - Tweaks: DisableQuickSave

--- a/Plugins/Events/Events/InventoryEvents.cpp
+++ b/Plugins/Events/Events/InventoryEvents.cpp
@@ -27,7 +27,7 @@ static NWNXLib::Hooking::FunctionHook* m_RemoveGoldHook = nullptr;
 
 InventoryEvents::InventoryEvents(ViewPtr<Services::HooksProxy> hooker)
 {
-    Events::InitOnFirstSubscribe("NWNX_ON_INVENTORY_.*", [hooker]()
+    Events::InitOnFirstSubscribe("NWNX_ON_INVENTORY_(SELECT|OPEN)_.*", [hooker]()
     {
         hooker->RequestExclusiveHook<API::Functions::CNWSMessage__HandlePlayerToServerGuiInventoryMessage>(
                 &HandlePlayerToServerGuiInventoryMessageHook);

--- a/Plugins/Events/Events/InventoryEvents.cpp
+++ b/Plugins/Events/Events/InventoryEvents.cpp
@@ -6,6 +6,7 @@
 #include "API/CNWSPlayerInventoryGUI.hpp"
 #include "API/CItemRepository.hpp"
 #include "API/CNWSItem.hpp"
+#include "API/CNWSCreature.hpp"
 #include "API/Functions.hpp"
 #include "API/Constants.hpp"
 #include "API/Globals.hpp"
@@ -21,6 +22,8 @@ using namespace NWNXLib::API::Constants;
 
 static NWNXLib::Hooking::FunctionHook* m_HandlePlayerToServerGuiInventoryMessageHook = nullptr;
 static NWNXLib::Hooking::FunctionHook* m_AddItemHook = nullptr;
+static NWNXLib::Hooking::FunctionHook* m_AddGoldHook = nullptr;
+static NWNXLib::Hooking::FunctionHook* m_RemoveGoldHook = nullptr;
 
 InventoryEvents::InventoryEvents(ViewPtr<Services::HooksProxy> hooker)
 {
@@ -41,6 +44,16 @@ InventoryEvents::InventoryEvents(ViewPtr<Services::HooksProxy> hooker)
 
     Events::InitOnFirstSubscribe("NWNX_ON_ITEM_INVENTORY_REMOVE_ITEM_.*", [hooker]() {
         hooker->RequestSharedHook<API::Functions::CItemRepository__RemoveItem, int32_t>(&RemoveItemHook);
+    });
+
+    Events::InitOnFirstSubscribe("NWNX_ON_INVENTORY_ADD_GOLD_.*", [hooker]() {
+        hooker->RequestExclusiveHook<API::Functions::CNWSCreature__AddGold>(&AddGoldHook);
+        m_AddGoldHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__AddGold);
+    });
+
+    Events::InitOnFirstSubscribe("NWNX_ON_INVENTORY_REMOVE_GOLD_.*", [hooker]() {
+        hooker->RequestExclusiveHook<API::Functions::CNWSCreature__RemoveGold>(&RemoveGoldHook);
+        m_RemoveGoldHook = hooker->FindHookByAddress(API::Functions::CNWSCreature__RemoveGold);
     });
 }
 
@@ -191,6 +204,36 @@ void InventoryEvents::RemoveItemHook(Services::Hooks::CallType type, CItemReposi
     const bool before = type == Services::Hooks::CallType::BEFORE_ORIGINAL;
     Events::PushEventData("ITEM", Utils::ObjectIDToString(pItem ? pItem->m_idSelf : OBJECT_INVALID));
     Events::SignalEvent(before ? "NWNX_ON_ITEM_INVENTORY_REMOVE_ITEM_BEFORE" : "NWNX_ON_ITEM_INVENTORY_REMOVE_ITEM_AFTER", thisPtr->m_oidParent);
+}
+
+void InventoryEvents::AddGoldHook(CNWSCreature *pCreature, int32_t nGold, int32_t bDisplayFeedBack)
+{
+    auto PushAndSignal = [&](const std::string &ev) -> bool {
+        Events::PushEventData("GOLD", std::to_string(nGold));
+        return Events::SignalEvent(ev, pCreature->m_idSelf);
+    };
+
+    if (PushAndSignal("NWNX_ON_INVENTORY_ADD_GOLD_BEFORE"))
+    {
+        m_AddGoldHook->CallOriginal<void>(pCreature, nGold, bDisplayFeedBack);
+    }
+
+    PushAndSignal("NWNX_ON_INVENTORY_ADD_GOLD_AFTER");
+}
+
+void InventoryEvents::RemoveGoldHook(CNWSCreature *pCreature, int32_t nGold, int32_t bDisplayFeedBack)
+{
+    auto PushAndSignal = [&](const std::string &ev) -> bool {
+        Events::PushEventData("GOLD", std::to_string(nGold));
+        return Events::SignalEvent(ev, pCreature->m_idSelf);
+    };
+
+    if (PushAndSignal("NWNX_ON_INVENTORY_REMOVE_GOLD_BEFORE"))
+    {
+        m_RemoveGoldHook->CallOriginal<void>(pCreature, nGold, bDisplayFeedBack);
+    }
+
+    PushAndSignal("NWNX_ON_INVENTORY_REMOVE_GOLD_AFTER");
 }
 
 }

--- a/Plugins/Events/Events/InventoryEvents.hpp
+++ b/Plugins/Events/Events/InventoryEvents.hpp
@@ -17,6 +17,8 @@ private:
     static int32_t HandlePlayerToServerGuiInventoryMessageHook(NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*, uint8_t);
     static int32_t AddItemHook(NWNXLib::API::CItemRepository*, NWNXLib::API::CNWSItem**, uint8_t, uint8_t, int32_t, int32_t);
     static void RemoveItemHook(NWNXLib::Services::Hooks::CallType, NWNXLib::API::CItemRepository*, NWNXLib::API::CNWSItem*);
+    static void AddGoldHook(NWNXLib::API::CNWSCreature*, int32_t, int32_t);
+    static void RemoveGoldHook(NWNXLib::API::CNWSCreature*, int32_t, int32_t);
 };
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -738,6 +738,21 @@
 
     Event data:
         Variable Name           Type        Notes
+////////////////////////////////////////////////////////////////////////////////
+    NWNX_ON_INVENTORY_ADD_GOLD_BEFORE
+    NWNX_ON_INVENTORY_ADD_GOLD_BEFORE
+    NWNX_ON_INVENTORY_REMOVE_GOLD_BEFORE
+    NWNX_ON_INVENTORY_REMOVE_GOLD_BEFORE
+
+    WARNING: While these events are skippable, you should be very careful about doing so.
+             It's very easy to create situations where players can dupe their gold or worse.
+
+    Usage:
+        OBJECT_SELF = The creature gaining or losing gold
+
+    Event data:
+        Variable Name           Type        Notes
+        GOLD                    INT         The amount of gold added or removed
 *///////////////////////////////////////////////////////////////////////////////
 
 /*
@@ -805,6 +820,7 @@ string NWNX_Events_GetEventData(string tag);
 // - Barter event (START only)
 // - Trap events
 // - Sticky Player Name event
+// - Add/RemoveGold events
 void NWNX_Events_SkipEvent();
 
 // Set the return value of the event.

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -740,9 +740,9 @@
         Variable Name           Type        Notes
 ////////////////////////////////////////////////////////////////////////////////
     NWNX_ON_INVENTORY_ADD_GOLD_BEFORE
-    NWNX_ON_INVENTORY_ADD_GOLD_BEFORE
+    NWNX_ON_INVENTORY_ADD_GOLD_AFTER
     NWNX_ON_INVENTORY_REMOVE_GOLD_BEFORE
-    NWNX_ON_INVENTORY_REMOVE_GOLD_BEFORE
+    NWNX_ON_INVENTORY_REMOVE_GOLD_AFTER
 
     WARNING: While these events are skippable, you should be very careful about doing so.
              It's very easy to create situations where players can dupe their gold or worse.


### PR DESCRIPTION
Adds the following events:
```
NWNX_ON_INVENTORY_ADD_GOLD_BEFORE
NWNX_ON_INVENTORY_ADD_GOLD_AFTER
NWNX_ON_INVENTORY_REMOVE_GOLD_BEFORE
NWNX_ON_INVENTORY_REMOVE_GOLD_AFTER
```
While these events are skippable, you should be very careful about doing so. It's very easy to create situations where players can dupe their gold or worse.