### PR TITLE
Fix depleted items tweak

### DIFF
--- a/Plugins/Tweaks/Tweaks/PreserveDepletedItems.cpp
+++ b/Plugins/Tweaks/Tweaks/PreserveDepletedItems.cpp
@@ -27,14 +27,15 @@ PreserveDepletedItems::PreserveDepletedItems(ViewPtr<Services::HooksProxy> hooke
 
 uint32_t PreserveDepletedItems::CNWSCreature__AIActionItemCastSpell_hook(CNWSCreature *pThis, CNWSObjectActionNode *pNode)
 {
-    // If at risk of destroying the item, inflate charge count temporarily to bypass the destroy
-    // event, then set it back to mark the spells as unusable.
+    // If at risk of destroying the item, set the item to plot, then set it back
+    // afterwards to its original value.
     auto *pItem = Utils::AsNWSItem(Utils::GetGameObject((Types::ObjectID)pNode->m_pParameter[0]));
     if (pItem && pItem->m_nNumCharges <= 5)
     {
-        pItem->m_nNumCharges += 10;
+        int bPlot = pItem->m_bPlotObject;
+        pItem->m_bPlotObject = true;
         int32_t ret = pAIActionItemCastSpell_hook->CallOriginal<uint32_t>(pThis, pNode);
-        pItem->SetNumCharges(pItem->m_nNumCharges - 10, true /* update which properties are usable */);
+        pItem->m_bPlotObject = bPlot;
         return ret;
     }
     return pAIActionItemCastSpell_hook->CallOriginal<uint32_t>(pThis, pNode);


### PR DESCRIPTION
The current depleted items tweak works by increasing the number of charges of an item by 10 prior to item usage, then reducing the number of charges by 10. Unfortunately this results in some odd behavior in the user's client, as the item charges are not always reset.

For example, the current screenshot shows what happens when a 3 charge item is used once. Rather than showing 2 charges left, it shows 12:

![screenshot](https://i.gyazo.com/7809b2761eb1117b9b922bbf34da57fb.png)

If the item is on the quickbar it seems to show the correct number of charges, and internally the number of charges is always correct - a 3 charge item will last only 3 times - but in the radial menu the number of charges is displayed inconsistently.

A solution is to use the plot flag instead of increasing the number of charges. Items marked as plot do not disappear at 0 charges, so by marking the item as plot before use, then resetting the plot flag back to its original value, we stop depleted items from being destroyed, without any iffiness around charges in the client.