### PR TITLE
Util: add NWNX_UTIL_PRE_MODULE_START_SCRIPT environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Tweaks: StringToIntBaseToAuto
 - Weapon: Feat and Base Item names were added to LOG_INFO feedback
 - WebHook: Added support for richer Slack-compatible messages
+- Util: Added the environment variable `NWNX_UTIL_PRE_MODULE_START_SCRIPT=scriptname` which lets you set a nwscript that runs before the OnModuleLoad event
 ##### New Plugins
 The following plugins were added:
 - **Appearance**: Allows the appearance and some other things of creatures to be overridden per player

--- a/Plugins/Util/Documentation/README.md
+++ b/Plugins/Util/Documentation/README.md
@@ -5,3 +5,7 @@
 Provide various utility functions that don't have a better home
 
 ## Environment Variables
+
+| Variable Name | Value | Default | Notes |
+| ------------- | :---: | ------- | ----- |
+| `NWNX_UTIL_PRE_MODULE_START_SCRIPT` | string | Unset | Allows you to set a NWScript that runs before the OnModuleLoad event

--- a/Plugins/Util/Util.cpp
+++ b/Plugins/Util/Util.cpp
@@ -19,6 +19,7 @@
 #include "API/Functions.hpp"
 #include "Utils.hpp"
 #include "ViewPtr.hpp"
+#include "Services/Config/Config.hpp"
 
 #include <string>
 #include <stdio.h>
@@ -97,6 +98,19 @@ Util::Util(const Plugin::CreateParams& params)
                         g_plugin->m_tickCount = ticks;
                         previous = current;
                         ticks = 1;
+                    }
+                }
+            });
+
+    GetServices()->m_hooks->RequestSharedHook<API::Functions::CNWSModule__LoadModuleFinish, uint32_t>(
+            +[](Services::Hooks::CallType type, CNWSModule*)
+            {
+                if (type == Services::Hooks::CallType::BEFORE_ORIGINAL)
+                {
+                    if (auto startScript = g_plugin->GetServices()->m_config->Get<std::string>("PRE_MODULE_START_SCRIPT"))
+                    {
+                        LOG_NOTICE("Running module start script: %s", startScript->c_str());
+                        Utils::ExecuteScript(*startScript, 0);
                     }
                 }
             });


### PR DESCRIPTION
Adds the `NWNX_UTIL_PRE_MODULE_START_SCRIPT` environment variable which lets me do dumb stuff before OnModuleLoad fires.