### PR TITLE
Tweaks: make PreserveDepletedItems preserve charged items only

### DIFF
--- a/Plugins/Tweaks/Tweaks/PreserveDepletedItems.cpp
+++ b/Plugins/Tweaks/Tweaks/PreserveDepletedItems.cpp
@@ -30,7 +30,7 @@ uint32_t PreserveDepletedItems::CNWSCreature__AIActionItemCastSpell_hook(CNWSCre
     // If at risk of destroying the item, set the item to plot, then set it back
     // afterwards to its original value.
     auto *pItem = Utils::AsNWSItem(Utils::GetGameObject((Types::ObjectID)pNode->m_pParameter[0]));
-    if (pItem && pItem->m_nNumCharges <= 5)
+    if (pItem && pItem->m_nNumCharges > 0 && pItem->m_nNumCharges <= 5)
     {
         int bPlot = pItem->m_bPlotObject;
         pItem->m_bPlotObject = true;


### PR DESCRIPTION
PR #539 fixed the display of charges on items, but it also affected items with single use spells, such as potions and scrolls.

While some people might want this functionality, my guess is that it's mostly going to be undesirable. This PR ensures that only items with at least 1 charge are affected.

If someone wants a single-use item that doesn't disappear after use, then they can set the item charges to 1 and add a 1-charge-per-use spell to the item.

I'm going to be trying this change out on our dev server over the next week to see if there are any other potential issues with this.