### PR TITLE
Rename: Add env var allowing for DMs to be included in functionality

### DIFF
--- a/Plugins/Rename/Documentation/README.md
+++ b/Plugins/Rename/Documentation/README.md
@@ -22,6 +22,7 @@ Due to the conflict with this plugin and the Tweaks plugin to hide classes on th
 | -------------   | :----: | :----: |----------------------------- |
 | `NWNX_RENAME_ON_MODULE_CHAR_LIST` | 0-3 | 0 | This is the listing of players from the character selection screen before entering the server. Setting the value to 1 overrides their names if a global rename has been set, 2 also hides class information, 3 hides class information but keeps names as their original.
 | `NWNX_RENAME_ON_PLAYER_LIST` | true or false | true | Renames the player name on the player list as well.
+| `NWNX_RENAME_ALLOW_DM` | true or false | false | DM observers will see global or personal overrides as well as being able to have their own name overridden for other observers.
 
 ## Sample Include
 

--- a/Plugins/Rename/Rename.hpp
+++ b/Plugins/Rename/Rename.hpp
@@ -23,6 +23,7 @@ public:
 private:
     int32_t m_RenameOnModuleCharList;
     bool m_RenameOnPlayerList;
+    bool m_RenameAllowDM;
 
     static void WriteGameObjUpdate_UpdateObjectHook(
             Services::Hooks::CallType,


### PR DESCRIPTION
Gives builders the option to control more with respect to Rename and DMs through scripting.