### PR TITLE
Racial Skill Rank modifiers should not be applied to the base skill rank

### DIFF
--- a/Plugins/SkillRanks/SkillRanks.cpp
+++ b/Plugins/SkillRanks/SkillRanks.cpp
@@ -1,5 +1,4 @@
 #include "SkillRanks.hpp"
-#include "API/C2DA.hpp"
 #include "API/CNWSModule.hpp"
 #include "API/CNWRules.hpp"
 #include "API/CNWSArea.hpp"
@@ -51,6 +50,7 @@ NWNX_PLUGIN_ENTRY Plugin::Info* PluginInfo()
 
 NWNX_PLUGIN_ENTRY Plugin* PluginLoad(Plugin::CreateParams params)
 {
+    //TODO-64bit: This plugin will have to undergo a thorough review/rework due to the new ruleset.2da
     g_plugin = new SkillRanks::SkillRanks(params);
     return g_plugin;
 }
@@ -79,30 +79,12 @@ SkillRanks::SkillRanks(const Plugin::CreateParams& params)
     GetServices()->m_hooks->RequestSharedHook<Functions::CNWRules__LoadSkillInfo, void, CNWRules*>(&LoadSkillInfoHook);
     GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWSCreatureStats__GetSkillRank,
         int32_t, CNWSCreatureStats*, uint8_t, CNWSObject*, int32_t>(&GetSkillRankHook);
-    GetServices()->m_hooks->RequestSharedHook<Functions::CNWSCreatureStats__SaveClassInfo, void, CNWSCreatureStats*, CResGFF*, CResStruct*>(&SaveClassInfoHook);
-    GetServices()->m_hooks->RequestSharedHook<Functions::CNWSPlayer__ValidateCharacter, int32_t, CNWSPlayer*, int32_t*>(&ValidateCharacterHook);
 
     m_blindnessMod = 4;
 }
 
 SkillRanks::~SkillRanks()
 {
-}
-
-void SkillRanks::ValidateCharacterHook(
-        Services::Hooks::CallType cType,
-        CNWSPlayer *,
-        int32_t*)
-{
-    g_plugin->m_ValidatingOrSaving = cType == Services::Hooks::CallType::BEFORE_ORIGINAL;
-}
-
-void SkillRanks::SaveClassInfoHook(
-        Services::Hooks::CallType cType,
-        CNWSCreatureStats *,
-        CResGFF *, CResStruct *)
-{
-    g_plugin->m_ValidatingOrSaving = cType == Services::Hooks::CallType::BEFORE_ORIGINAL;
 }
 
 void SkillRanks::LoadSkillInfoHook(Services::Hooks::CallType type, API::CNWRules* pRules)
@@ -593,10 +575,6 @@ int32_t SkillRanks::GetSkillRankHook(
 
     int32_t baseRank = thisPtr->m_lstSkillRanks[nSkill];
 
-    // We want the base rank to be affected by our racial adjustments in all cases but validating or saving the PC
-    if (!g_plugin->m_ValidatingOrSaving)
-        baseRank += g_plugin->m_skillRaceMod[nSkill][thisPtr->m_nRace];
-
     if (bBaseOnly)
         return baseRank;
 
@@ -604,6 +582,9 @@ int32_t SkillRanks::GetSkillRankHook(
         return 0;
 
     int32_t retVal = baseRank + thisPtr->m_pBaseCreature->GetTotalEffectBonus(5, pVersus, 0, 0, 0, 0, nSkill, -1, 0);
+
+    // Add any racial modifiers broadcasted from the Race plugin
+    retVal += g_plugin->m_skillRaceMod[nSkill][thisPtr->m_nRace];
 
     auto *pArea = Globals::AppManager()->m_pServerExoApp->GetAreaByGameObjectID(thisPtr->m_pBaseCreature->m_oidArea);
 

--- a/Plugins/SkillRanks/SkillRanks.hpp
+++ b/Plugins/SkillRanks/SkillRanks.hpp
@@ -29,11 +29,8 @@ private:
 
     static void LoadSkillInfoHook(NWNXLib::Services::Hooks::CallType, NWNXLib::API::CNWRules*);
     static int32_t GetSkillRankHook(NWNXLib::API::CNWSCreatureStats*, uint8_t, NWNXLib::API::CNWSObject*, int32_t);
-    static void SaveClassInfoHook(NWNXLib::Services::Hooks::CallType, NWNXLib::API::CNWSCreatureStats*, NWNXLib::API::CResGFF*, NWNXLib::API::CResStruct*);
-    static void ValidateCharacterHook(NWNXLib::Services::Hooks::CallType, NWNXLib::API::CNWSPlayer*, int32_t*);
 
     uint8_t m_blindnessMod;
-    bool m_ValidatingOrSaving;
 
     struct SkillFeats {
         int8_t nModifier;


### PR DESCRIPTION
This was discussed in Discord. Racial feats for example like Stonecunning do not impact the base skill rank and so the SkillRanks plugin should not either. Feats/Class skill rank qualifications are about points put into the skill.