### PR TITLE
Events: added WalkToWaypoint Input Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Events: Added UseLoreOnItem and PayToIdentifyItem events
 - Events: Added {Add|Remove}Gold events to InventoryEvents
 - Events: Added PVP Attitude Change event
+- Events: Added WalkToWaypoint Input event
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite
 - Tweaks: DisableQuickSave

--- a/Plugins/Events/CMakeLists.txt
+++ b/Plugins/Events/CMakeLists.txt
@@ -21,4 +21,5 @@ add_plugin(Events
     "Events/TrapEvents.cpp"
     "Events/TimingBarEvents.cpp"
     "Events/LevelEvents.cpp"
-    "Events/PVPEvents.cpp")
+    "Events/PVPEvents.cpp"
+    "Events/InputEvents.cpp")

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -25,6 +25,7 @@
 #include "Events/TimingBarEvents.hpp"
 #include "Events/LevelEvents.hpp"
 #include "Events/PVPEvents.hpp"
+#include "Events/InputEvents.hpp"
 #include "Services/Config/Config.hpp"
 #include "Services/Messaging/Messaging.hpp"
 #include "ViewPtr.hpp"
@@ -106,6 +107,7 @@ Events::Events(const Plugin::CreateParams& params)
     m_timingBarEvents   = std::make_unique<TimingBarEvents>(GetServices()->m_hooks);
     m_levelEvents       = std::make_unique<LevelEvents>(GetServices()->m_hooks);
     m_PVPEvents         = std::make_unique<PVPEvents>(GetServices()->m_hooks);
+    m_inputEvents       = std::make_unique<InputEvents>(GetServices()->m_hooks);
 }
 
 Events::~Events()

--- a/Plugins/Events/Events.hpp
+++ b/Plugins/Events/Events.hpp
@@ -32,6 +32,7 @@ class TrapEvents;
 class TimingBarEvents;
 class LevelEvents;
 class PVPEvents;
+class InputEvents;
 
 class Events : public NWNXLib::Plugin
 {
@@ -112,6 +113,7 @@ private:
     std::unique_ptr<TimingBarEvents> m_timingBarEvents;
     std::unique_ptr<LevelEvents> m_levelEvents;
     std::unique_ptr<PVPEvents> m_PVPEvents;
+    std::unique_ptr<InputEvents> m_inputEvents;
 };
 
 }

--- a/Plugins/Events/Events/InputEvents.cpp
+++ b/Plugins/Events/Events/InputEvents.cpp
@@ -1,0 +1,58 @@
+#include "Events/InputEvents.hpp"
+#include "API/CNWSPlayer.hpp"
+#include "API/CNWSMessage.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/Functions.hpp"
+#include "API/Constants.hpp"
+#include "Events.hpp"
+#include "Utils.hpp"
+
+
+namespace Events {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+using namespace NWNXLib::API::Constants;
+
+InputEvents::InputEvents(ViewPtr<Services::HooksProxy> hooker)
+{
+    Events::InitOnFirstSubscribe("NWNX_ON_INPUT_WALK_TO_WAYPOINT_.*", [hooker]() {
+        hooker->RequestSharedHook<API::Functions::CNWSMessage__HandlePlayerToServerInputWalkToWaypoint, int32_t>(&HandlePlayerToServerInputWalkToWaypointHook);
+    });
+}
+
+void InputEvents::HandlePlayerToServerInputWalkToWaypointHook(Services::Hooks::CallType type, CNWSMessage *pMessage, CNWSPlayer *pPlayer)
+{
+    const bool before = type == Services::Hooks::CallType::BEFORE_ORIGINAL;
+
+    static std::string oidArea;
+    static std::string posX;
+    static std::string posY;
+    static std::string posZ;
+    static std::string runToPoint;
+
+    if (before)
+    {
+        int offset = 0;
+        oidArea = Utils::ObjectIDToString(Utils::PeekMessage<Types::ObjectID>(pMessage, offset) & 0x7FFFFFFF);
+            offset += sizeof(Types::ObjectID);
+        posX = std::to_string(Utils::PeekMessage<float>(pMessage, offset));
+            offset += sizeof(float);
+        posY = std::to_string(Utils::PeekMessage<float>(pMessage, offset));
+            offset += sizeof(float);
+        posZ = std::to_string(Utils::PeekMessage<float>(pMessage, offset));
+            offset += sizeof(float) + sizeof(int32_t) + sizeof(int16_t); // Yep
+        runToPoint = std::to_string((bool)(Utils::PeekMessage<uint8_t>(pMessage, offset) & 0x10));
+    }
+
+    Events::PushEventData("AREA", oidArea);
+    Events::PushEventData("POS_X", posX);
+    Events::PushEventData("POS_Y", posY);
+    Events::PushEventData("POS_Z", posZ);
+    Events::PushEventData("RUN_TO_POINT", runToPoint);
+
+    Events::SignalEvent(before ? "NWNX_ON_INPUT_WALK_TO_WAYPOINT_BEFORE" : "NWNX_ON_INPUT_WALK_TO_WAYPOINT_AFTER", pPlayer->m_oidNWSObject);
+}
+
+}
+

--- a/Plugins/Events/Events/InputEvents.hpp
+++ b/Plugins/Events/Events/InputEvents.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "API/Vector.hpp"
+#include "Common.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include "ViewPtr.hpp"
+
+namespace Events {
+
+class InputEvents
+{
+public:
+    InputEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
+
+private:
+    static void HandlePlayerToServerInputWalkToWaypointHook(NWNXLib::Services::Hooks::CallType,
+            NWNXLib::API::CNWSMessage*, NWNXLib::API::CNWSPlayer*);
+};
+
+}

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -764,6 +764,20 @@
         Variable Name           Type        Notes
         TARGET_OBJECT_ID        object      Convert to object with NWNX_Object_StringToObject()
         ATTITUDE                int         0 = Dislike, 1 = Like
+////////////////////////////////////////////////////////////////////////////////
+    NWNX_ON_INPUT_WALK_TO_WAYPOINT_BEFORE
+    NWNX_ON_INPUT_WALK_TO_WAYPOINT_AFTER
+
+    Usage:
+        OBJECT_SELF = The player clicking somewhere
+
+    Event data:
+        Variable Name           Type        Notes
+        AREA                    object      Convert to object with NWNX_Object_StringToObject()
+        POS_X                   float
+        POS_Y                   float
+        POS_Z                   float
+        RUN_TO_POINT            int         TRUE if player is running, FALSE if player is walking (eg when shift clicking)
 *///////////////////////////////////////////////////////////////////////////////
 
 /*


### PR DESCRIPTION
Lets you hijack a player's click to move event, best used when the player is immobilized with `EffectCutsceneImmobilize()` for example.