### PR TITLE
Plugin: MaxLevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The following plugins were added:
 - **Encounter**: Adds functions exposing additional encounter properties
 - **Feedback**: Allows combatlog, feedback and 'quest journal updated' messages to be hidden globally or per player
 - **ItemProperty**: Provides various utility functions to manipulate builtin itemproperty types
+- **MaxLevel**: Extends support for levels up to 60
 - **Race**: Provides the ability to specify a variety of inate modifiers for new or existing races or subraces via script or 2da
 - **Regex**: Adds functions to search and replace strings using regular expressions.
 - **Rename**: Adds functions to facilitate renaming, overriding and customization of player names

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -2,6 +2,7 @@
 
 #include "API/CAppManager.hpp"
 #include "API/CServerExoApp.hpp"
+#include "API/CServerInfo.hpp"
 #include "API/CNWSCreature.hpp"
 #include "API/CNWSCreatureStats.hpp"
 #include "API/CNWLevelStats.hpp"
@@ -180,7 +181,7 @@ ArgumentStack Creature::AddFeatByLevel(ArgumentStack&& args)
           ASSERT_OR_THROW(feat <= Constants::Feat::MAX);
         const auto level = Services::Events::ExtractArgument<int32_t>(args);
           ASSERT_OR_THROW(level >= 1);
-          ASSERT_OR_THROW(level <= 40);
+          ASSERT_OR_THROW(level <= Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_JoiningRestrictions.nMaxLevel);
 
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
@@ -232,7 +233,7 @@ ArgumentStack Creature::GetFeatCountByLevel(ArgumentStack&& args)
     {
         const auto level = Services::Events::ExtractArgument<int32_t>(args);
           ASSERT_OR_THROW(level >= 1);
-          ASSERT_OR_THROW(level <= 40);
+          ASSERT_OR_THROW(level <= Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_JoiningRestrictions.nMaxLevel);
 
         if (level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
@@ -253,7 +254,7 @@ ArgumentStack Creature::GetFeatByLevel(ArgumentStack&& args)
     {
         const auto level = Services::Events::ExtractArgument<int32_t>(args);
           ASSERT_OR_THROW(level >= 1);
-          ASSERT_OR_THROW(level <= 40);
+          ASSERT_OR_THROW(level <= Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_JoiningRestrictions.nMaxLevel);
         const auto index = Services::Events::ExtractArgument<int32_t>(args);
 
         if (level <= pCreature->m_pStats->m_lstLevelStats.num)
@@ -450,7 +451,7 @@ ArgumentStack Creature::GetClassByLevel(ArgumentStack&& args)
     {
         const auto level = Services::Events::ExtractArgument<int32_t>(args);
           ASSERT_OR_THROW(level >= 1);
-          ASSERT_OR_THROW(level <= 40);
+          ASSERT_OR_THROW(level <= Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_JoiningRestrictions.nMaxLevel);
 
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
@@ -1005,7 +1006,7 @@ ArgumentStack Creature::GetMaxHitPointsByLevel(ArgumentStack&& args)
     {
         const auto level = Services::Events::ExtractArgument<int32_t>(args);
           ASSERT_OR_THROW(level >= 1);
-          ASSERT_OR_THROW(level <= 40);
+          ASSERT_OR_THROW(level <= Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_JoiningRestrictions.nMaxLevel);
         if (level > 0 && level <= pCreature->m_pStats->m_lstLevelStats.num)
         {
             auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[level-1];
@@ -1025,7 +1026,7 @@ ArgumentStack Creature::SetMaxHitPointsByLevel(ArgumentStack&& args)
     {
         const auto level = Services::Events::ExtractArgument<int32_t>(args);
           ASSERT_OR_THROW(level >= 1);
-          ASSERT_OR_THROW(level <= 40);
+          ASSERT_OR_THROW(level <= Globals::AppManager()->m_pServerExoApp->GetServerInfo()->m_JoiningRestrictions.nMaxLevel);
         const auto value = Services::Events::ExtractArgument<int32_t>(args);
           ASSERT_OR_THROW(value >= 0);
           ASSERT_OR_THROW(value <= 255);

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -1584,33 +1584,40 @@ ArgumentStack Creature::LevelUp(ArgumentStack&& args)
     static NWNXLib::Hooking::FunctionHook* pCanLevelUp_hook;
     static NWNXLib::Hooking::FunctionHook* pValidateLevelUp_hook;
     static bool bSkipLevelUpValidation = false;
-    if (!pCanLevelUp_hook)
+    if (!pValidateLevelUp_hook)
     {
-        GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWSCreatureStats__CanLevelUp>(
-            +[](CNWSCreatureStats *pThis) -> int32_t
-            {
-                if (bSkipLevelUpValidation)
-                {
-                    // NPCs can have at most 60 levels
-                    ASSERT(!pThis->m_bIsPC);
-                    return pThis->GetLevel(false) < 60;
-                }
-                return pCanLevelUp_hook->CallOriginal<int32_t>(pThis);
-            });
-        pCanLevelUp_hook = GetServices()->m_hooks->FindHookByAddress(Functions::CNWSCreatureStats__CanLevelUp);
+        try
+        {
+            GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWSCreatureStats__CanLevelUp>(
+                    +[](CNWSCreatureStats *pThis) -> int32_t
+                    {
+                        if (bSkipLevelUpValidation)
+                        {
+                            // NPCs can have at most 60 levels
+                            ASSERT(!pThis->m_bIsPC);
+                            return pThis->GetLevel(false) < 60;
+                        }
+                        return pCanLevelUp_hook->CallOriginal<int32_t>(pThis);
+                    });
+            pCanLevelUp_hook = GetServices()->m_hooks->FindHookByAddress(Functions::CNWSCreatureStats__CanLevelUp);
+        }
+        catch (...)
+        {
+            LOG_NOTICE("NWNX_MaxLevel will manage CanLevelUp.");
+        }
 
         GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWSCreatureStats__ValidateLevelUp>(
-            +[](CNWSCreatureStats *pThis, CNWLevelStats *pLevelStats, uint8_t nDomain1, uint8_t nDomain2, uint8_t nSchool) -> uint32_t
-            {
-                if (bSkipLevelUpValidation)
+                +[](CNWSCreatureStats *pThis, CNWLevelStats *pLevelStats, uint8_t nDomain1, uint8_t nDomain2, uint8_t nSchool) -> uint32_t
                 {
-                    ASSERT(!pThis->m_bIsPC);
-                    pThis->LevelUp(pLevelStats, nDomain1, nDomain2, nSchool, true);
-                    pThis->UpdateCombatInformation();
-                    return 0;
-                }
-                return pValidateLevelUp_hook->CallOriginal<uint32_t>(pThis, pLevelStats, nDomain1, nDomain2, nSchool);
-            });
+                    if (bSkipLevelUpValidation)
+                    {
+                        ASSERT(!pThis->m_bIsPC);
+                        pThis->LevelUp(pLevelStats, nDomain1, nDomain2, nSchool, true);
+                        pThis->UpdateCombatInformation();
+                        return 0;
+                    }
+                    return pValidateLevelUp_hook->CallOriginal<uint32_t>(pThis, pLevelStats, nDomain1, nDomain2, nSchool);
+                });
         pValidateLevelUp_hook = GetServices()->m_hooks->FindHookByAddress(Functions::CNWSCreatureStats__ValidateLevelUp);
     }
 

--- a/Plugins/MaxLevel/CMakeLists.txt
+++ b/Plugins/MaxLevel/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_plugin(MaxLevel
+        "MaxLevel.cpp")

--- a/Plugins/MaxLevel/Documentation/README.md
+++ b/Plugins/MaxLevel/Documentation/README.md
@@ -16,6 +16,7 @@ This plugin extends the maximum level possibility from 40 to 60. The plugin prov
 
 * Spellcasters may not change spells when levelling up
 * Next Level XP on Character Sheet shows an incorrect value
+* The hook to `CNWSCreatureStats::CanLevelUp` used in this plugin conflicts with its usage in the `NWNX_Creature_LevelUp` function. There are workarounds for this but would require changing some source, removing the hook in NWNX_Creature.
 
 ## Setup
 * Define your max levels variable in your server environment. 

--- a/Plugins/MaxLevel/Documentation/README.md
+++ b/Plugins/MaxLevel/Documentation/README.md
@@ -1,0 +1,34 @@
+# MaxLevel Plugin Reference
+
+## Description
+
+This plugin extends the maximum level possibility from 40 to 60. The plugin provides normal level up alerting and procedure with a few minor issues. Feats and Ability Points follow their normal progression. Spell counts known and gained can be configured for the additional levels.
+
+## Environment Variables
+| Variable Name | Value | Default | Notes |
+| ------------- | :---: | :-----: | ----- |
+| `NWNX_MAXLEVEL_MAX` | 41-60 | null | Maximum level you wish to support.
+
+## Issues
+
+* Spellcasters may not change spells when levelling up
+* Next Level XP on Character Sheet shows an incorrect value
+
+## Setup
+* Define your max levels variable in your server environment. 
+```
+export NWNX_MAXLEVEL_MAX=45
+```
+* If you provide a `-maxlevel` argument in your server start up or have `MaxCharLevel` defined in your **nwnplayer.ini** make sure those values are changed as well.
+
+* Add your XP thresholds to your **exptable.2da**
+```csv
+...
+40	41	35935000	
+41	42	39935000	
+42	43	45935000	
+43	44	53935000	
+44	45	63935000	
+45	46	0xFFFFFFF	
+```
+* (Optional) Edit the class spell gain and spell known 2da files to provide more spells as levels progress. These are **cls_spgn_???.2da** and **cls_spkn_???.2da**.

--- a/Plugins/MaxLevel/Documentation/README.md
+++ b/Plugins/MaxLevel/Documentation/README.md
@@ -9,6 +9,9 @@ This plugin extends the maximum level possibility from 40 to 60. The plugin prov
 | ------------- | :---: | :-----: | ----- |
 | `NWNX_MAXLEVEL_MAX` | 41-60 | null | Maximum level you wish to support.
 
+## Required Plugins
+* The `NWNX_ELC` plugin is also needed to bypass the level restriction. No configuration is necessary though, merely loading this plugin is sufficient.
+
 ## Issues
 
 * Spellcasters may not change spells when levelling up

--- a/Plugins/MaxLevel/MaxLevel.cpp
+++ b/Plugins/MaxLevel/MaxLevel.cpp
@@ -1,0 +1,294 @@
+#include "MaxLevel.hpp"
+
+#include "Utils.hpp"
+#include "API/C2DA.hpp"
+#include "API/CTwoDimArrays.hpp"
+#include "API/CNWClass.hpp"
+#include "API/CNWRules.hpp"
+#include "API/CExoIni.hpp"
+#include "API/CExoResMan.hpp"
+#include "API/CServerExoAppInternal.hpp"
+#include "API/CServerInfo.hpp"
+#include "API/CNWSCreatureStats.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/CNWRace.hpp"
+#include "API/CNWSpellArray.hpp"
+#include "API/CNWLevelStats.hpp"
+#include "API/Functions.hpp"
+#include "API/Globals.hpp"
+#include "API/Constants.hpp"
+#include "Services/Events/Events.hpp"
+#include "Services/Config/Config.hpp"
+#include "ViewPtr.hpp"
+#include <regex>
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+using namespace NWNXLib::API::Constants;
+
+const int CORE_MAX_LEVEL = 40;
+const int MAX_LEVEL_MAX = 60;
+
+static ViewPtr<MaxLevel::MaxLevel> g_plugin;
+
+NWNX_PLUGIN_ENTRY Plugin::Info* PluginInfo()
+{
+    return new Plugin::Info
+            {
+                    "MaxLevel",
+                    "Support for Levels 41 - 60",
+                    "orth",
+                    "plenarius@gmail.com",
+                    1,
+                    true,
+                    0,
+                    8186
+            };
+}
+
+NWNX_PLUGIN_ENTRY Plugin* PluginLoad(Plugin::CreateParams params)
+{
+    g_plugin = new MaxLevel::MaxLevel(params);
+    return g_plugin;
+}
+
+namespace MaxLevel {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+using namespace NWNXLib::API::Constants;
+
+
+MaxLevel::MaxLevel(const Plugin::CreateParams& params)
+        : Plugin(params)
+{
+    m_maxLevel = GetServices()->m_config->Get<int>("MAX", 40);
+    if (m_maxLevel > MAX_LEVEL_MAX)
+        m_maxLevel = MAX_LEVEL_MAX;
+
+    if (m_maxLevel > 40)
+    {
+        GetServices()->m_hooks->RequestSharedHook<Functions::CServerExoAppInternal__GetServerInfoFromIniFile, void, CServerExoAppInternal *>(&GetServerInfoFromIniFileHook);
+        GetServices()->m_hooks->RequestSharedHook<Functions::CNWRules__ReloadAll, void, CNWRules *>(&ReloadAllHook);
+        GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWSCreatureStats__CanLevelUp>(&CanLevelUpHook);
+        GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWSCreatureStats__GetExpNeededForLevelUp>(&GetExpNeededForLevelUpHook);
+        GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWSCreatureStats__LevelDown>(&LevelDownHook);
+        m_LevelDownHook = GetServices()->m_hooks->FindHookByAddress(Functions::CNWSCreatureStats__LevelDown);
+        GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWSCreature__SummonAssociate>(&SummonAssociateHook);
+        m_SummonAssociateHook = GetServices()->m_hooks->FindHookByAddress(Functions::CNWSCreature__SummonAssociate);
+        GetServices()->m_hooks->RequestSharedHook<Functions::CNWClass__LoadSpellGainTable, void, CNWClass *, CExoString *>(&LoadSpellGainTableHook);
+        GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWClass__GetSpellGain>(&GetSpellGainHook);
+        GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWClass__GetSpellsKnownPerLevel>( &GetSpellsKnownPerLevelHook);
+    }
+}
+
+MaxLevel::~MaxLevel()
+{
+}
+
+void MaxLevel::GetServerInfoFromIniFileHook(Services::Hooks::CallType type, CServerExoAppInternal* pServer)
+{
+    if (type == Services::Hooks::CallType::AFTER_ORIGINAL)
+    {
+        pServer->m_pServerInfo->m_JoiningRestrictions.nMaxLevel = g_plugin->m_maxLevel;
+    }
+}
+
+// After Rules aggregates all its information we add to our custom experience table map
+void MaxLevel::ReloadAllHook(Services::Hooks::CallType type, CNWRules* pRules)
+{
+    if (type == Services::Hooks::CallType::BEFORE_ORIGINAL || !pRules)
+        return;
+
+    auto *twoda = Globals::Rules()->m_p2DArrays->GetCached2DA("EXPTABLE", true);
+    twoda->Load2DArray();
+    for (int i = CORE_MAX_LEVEL; i < g_plugin->m_maxLevel; i++)
+    {
+        int32_t xpLevel = 0;
+        twoda->GetINTEntry(i, 1, &xpLevel);
+        if (!xpLevel)
+        {
+            LOG_ERROR("No xp threshold set for level %d!. Max level reverted to 40.", 1 + i);
+            g_plugin->m_maxLevel = CORE_MAX_LEVEL;
+            return;
+        }
+        else
+        {
+            g_plugin->m_nExperienceTableAdded[i] = xpLevel;
+        }
+    }
+}
+
+// If level is greater than 40 seek the xp_threshold from our custom map
+int32_t MaxLevel::CanLevelUpHook(CNWSCreatureStats* pStats)
+{
+    auto pCreature = pStats->m_pBaseCreature;
+    if ((pCreature->m_nAssociateType >= 5 && pCreature->m_nAssociateType <= 8) || pCreature->m_nAssociateType == 2)
+        return 0;
+
+    int32_t totalLevels = pStats->GetLevel(false);
+
+    if (totalLevels >= g_plugin->m_maxLevel)
+        return 0;
+
+    if (!pStats->m_bIsPC)
+        return 1;
+
+    auto xp = pStats->m_nExperience;
+    uint32_t xp_threshold = 0;
+    if (totalLevels <= CORE_MAX_LEVEL)
+    {
+        xp_threshold = Globals::Rules()->m_nExperienceTable[totalLevels];
+    }
+    else
+    {
+        xp_threshold = g_plugin->m_nExperienceTableAdded[totalLevels];
+    }
+
+    if (xp < xp_threshold)
+        return 0;
+
+    return 1;
+}
+
+// If the player is at level 39 or lower we get the XP required from the normal array, otherwise we use our map
+uint32_t MaxLevel::GetExpNeededForLevelUpHook(CNWSCreatureStats *pStats)
+{
+    uint32_t xp_threshold = 0;
+    int32_t totalLevels = pStats->GetLevel(false);
+    if (totalLevels < CORE_MAX_LEVEL)
+    {
+        xp_threshold = Globals::Rules()->m_nExperienceTable[totalLevels + 1];
+    }
+    else
+    {
+        xp_threshold = g_plugin->m_nExperienceTableAdded[totalLevels];
+    }
+    return xp_threshold;
+}
+
+// Instead of rewriting SetExperience we just make sure if the call to LevelDown is not necessary we skip it
+// If the player is at level 40 or lower we get the XP required from the normal array, otherwise we use our map
+void MaxLevel::LevelDownHook(CNWSCreatureStats *pStats, CNWLevelStats *pLevelStats)
+{
+    auto nXP = pStats->m_nExperience;
+    int32_t totalLevels = pStats->GetLevel(false);
+    uint32_t xp_threshold = 0;
+    if (totalLevels <= CORE_MAX_LEVEL)
+    {
+        xp_threshold = Globals::Rules()->m_nExperienceTable[totalLevels - 1];
+    }
+    else
+    {
+        xp_threshold = g_plugin->m_nExperienceTableAdded[totalLevels - 1];
+    }
+    if (nXP < xp_threshold)
+        g_plugin->m_LevelDownHook->CallOriginal<void>(pStats, pLevelStats);
+}
+
+// The resref passed into SummonAssociate has the template utc with the character's level appended to it, just
+// swap that level back to 40 if that utc doesn't exist. This is easier than rewriting SummonFamilar and
+// SummonAnimalCompanion completely
+void MaxLevel::SummonAssociateHook(CNWSCreature *pCreature, CResRef cResRef, CExoString *p_sAssociateName,
+                                   uint16_t nAssociateType)
+{
+    auto cUsedResRef = cResRef;
+    std::string sResRef = cResRef.GetResRef();
+    if (!Globals::ExoResMan()->Exists(cResRef, 2027, nullptr))
+    {
+        std::regex re("(.*)[4-9][0-9]");
+        std::string sNewResRef = std::regex_replace(sResRef,re,"$0140");
+        cUsedResRef = CResRef(sNewResRef.c_str());
+    }
+    g_plugin->m_SummonAssociateHook->CallOriginal<void>(pCreature, cUsedResRef, p_sAssociateName, nAssociateType);
+}
+
+// After the server loads 1-40 we populate our map with the values for 41+
+void MaxLevel::LoadSpellGainTableHook(Services::Hooks::CallType type, CNWClass* pClass, CExoString *pTable)
+{
+    if (type == Services::Hooks::CallType::BEFORE_ORIGINAL)
+        return;
+
+    auto *twoda = new C2DA(CResRef(pTable->CStr()), 1);
+    twoda->Load2DArray();
+
+    for (int i = CORE_MAX_LEVEL; i < g_plugin->m_maxLevel; i++)
+    {
+        int32_t numSpellLevels = 0;
+        uint8_t lastFoundSpellGainLevel = CORE_MAX_LEVEL;
+        twoda->GetINTEntry(i, "NumSpellLevels", &numSpellLevels);
+
+        // If they don't have this set then default to the last found level
+        if (!numSpellLevels)
+        {
+            LOG_WARNING("No spell gain row found for Level %d for %s Class. Defaulting to Level %d.",
+                    1 + i, pClass->GetNameText(), lastFoundSpellGainLevel);
+            twoda->GetINTEntry(lastFoundSpellGainLevel - 1, "NumSpellLevels", &numSpellLevels);
+        }
+        g_plugin->m_nSpellLevelsPerLevelAdded[pClass->m_nName][i] = numSpellLevels;
+
+        // Now find the spells gained per level for each spell level
+        for (int j = 0; j < numSpellLevels; j++)
+        {
+            int32_t iNumSpells = 0;
+            twoda->GetINTEntry(i, 2 + j, &iNumSpells);
+            if (!iNumSpells)
+            {
+                twoda->GetINTEntry(lastFoundSpellGainLevel - 1, 2 + j, &iNumSpells);
+            }
+            else
+            {
+                lastFoundSpellGainLevel = 1 + i;
+            }
+            g_plugin->m_nSpellGainTableAdded[pClass->m_nName][i][j] = iNumSpells;
+        }
+    }
+}
+
+// If the player is at level 40 or lower we get the spell gain for that class from the normal array,
+// otherwise we use our map
+uint8_t MaxLevel::GetSpellGainHook(CNWClass *pClass, uint8_t nLevel, uint8_t nSpellLevel)
+{
+    uint8_t result = -1;
+
+    if ( nLevel <= CORE_MAX_LEVEL )
+    {
+        if ( nSpellLevel < pClass->m_lstSpellLevelsPerLevel[nLevel - 1] )
+        {
+            result = pClass->m_lstSpellGainTable[nLevel - 1][nSpellLevel];
+        }
+    }
+    else
+    {
+        if ( nSpellLevel < g_plugin->m_nSpellLevelsPerLevelAdded[pClass->m_nName][nLevel - 1] )
+        {
+            result = g_plugin->m_nSpellGainTableAdded[pClass->m_nName][nLevel - 1][nSpellLevel];
+        }
+    }
+    return result;
+}
+
+// If the player is at level 40 or lower we get the spell gain for that class from the normal array,
+// otherwise we use our map
+uint8_t MaxLevel::GetSpellsKnownPerLevelHook(CNWClass *pClass, uint8_t nLevel, uint8_t nSpellLevel, uint8_t nClass,
+                                             uint16_t nRace, uint8_t nCHABase)
+{
+    uint8_t result = 0;
+    if (((nLevel <= CORE_MAX_LEVEL && nSpellLevel < pClass->m_lstSpellLevelsPerLevel[nLevel - 1]) ||
+         (nSpellLevel < g_plugin->m_nSpellLevelsPerLevelAdded[pClass->m_nName][nLevel - 1])) &&
+        (nClass != API::Constants::ClassType::Bard ||
+         Globals::Rules()->m_lstRaces[nRace].m_nCHAAdjust + nCHABase > nSpellLevel + 10))
+    {
+        if (nLevel <= CORE_MAX_LEVEL)
+        {
+            result = pClass->m_lstSpellLevelsPerLevel[nLevel - 1];
+        }
+        else
+        {
+            result = g_plugin->m_nSpellLevelsPerLevelAdded[pClass->m_nName][nLevel - 1];
+        }
+    }
+    return result;
+}
+
+}

--- a/Plugins/MaxLevel/MaxLevel.cpp
+++ b/Plugins/MaxLevel/MaxLevel.cpp
@@ -128,7 +128,7 @@ int32_t MaxLevel::CanLevelUpHook(CNWSCreatureStats* pStats)
 
     int32_t totalLevels = pStats->GetLevel(false);
 
-    if ((!pStats->m_bIsPC && totalLevels >= 60) || totalLevels >= g_plugin->m_maxLevel)
+    if ((!pStats->m_bIsPC && totalLevels >= MAX_LEVEL_MAX) || (pStats->m_bIsPC && totalLevels >= g_plugin->m_maxLevel))
         return 0;
 
     if (!pStats->m_bIsPC)

--- a/Plugins/MaxLevel/MaxLevel.cpp
+++ b/Plugins/MaxLevel/MaxLevel.cpp
@@ -62,11 +62,11 @@ using namespace NWNXLib::API::Constants;
 MaxLevel::MaxLevel(const Plugin::CreateParams& params)
         : Plugin(params)
 {
-    m_maxLevel = GetServices()->m_config->Get<int>("MAX", 40);
+    m_maxLevel = GetServices()->m_config->Get<int>("MAX", CORE_MAX_LEVEL);
     if (m_maxLevel > MAX_LEVEL_MAX)
         m_maxLevel = MAX_LEVEL_MAX;
 
-    if (m_maxLevel > 40)
+    if (m_maxLevel > CORE_MAX_LEVEL)
     {
         GetServices()->m_hooks->RequestSharedHook<Functions::CServerExoAppInternal__GetServerInfoFromIniFile, void, CServerExoAppInternal *>(&GetServerInfoFromIniFileHook);
         GetServices()->m_hooks->RequestSharedHook<Functions::CNWRules__ReloadAll, void, CNWRules *>(&ReloadAllHook);

--- a/Plugins/MaxLevel/MaxLevel.cpp
+++ b/Plugins/MaxLevel/MaxLevel.cpp
@@ -62,7 +62,7 @@ using namespace NWNXLib::API::Constants;
 MaxLevel::MaxLevel(const Plugin::CreateParams& params)
         : Plugin(params)
 {
-    m_maxLevel = GetServices()->m_config->Get<int>("MAX", CORE_MAX_LEVEL);
+    m_maxLevel = GetServices()->m_config->Get<int>("MAX", (uint8_t)CORE_MAX_LEVEL);
     if (m_maxLevel > MAX_LEVEL_MAX)
         m_maxLevel = MAX_LEVEL_MAX;
 

--- a/Plugins/MaxLevel/MaxLevel.cpp
+++ b/Plugins/MaxLevel/MaxLevel.cpp
@@ -123,12 +123,12 @@ void MaxLevel::ReloadAllHook(Services::Hooks::CallType type, CNWRules* pRules)
 int32_t MaxLevel::CanLevelUpHook(CNWSCreatureStats* pStats)
 {
     auto pCreature = pStats->m_pBaseCreature;
-    if ((pCreature->m_nAssociateType >= 5 && pCreature->m_nAssociateType <= 8) || pCreature->m_nAssociateType == 2)
+    if ((pCreature->m_nAssociateType >= 5 && pCreature->m_nAssociateType <= 8) || pCreature->m_nAssociateType == 3)
         return 0;
 
     int32_t totalLevels = pStats->GetLevel(false);
 
-    if (totalLevels >= g_plugin->m_maxLevel)
+    if ((!pStats->m_bIsPC && totalLevels >= 60) || totalLevels >= g_plugin->m_maxLevel)
         return 0;
 
     if (!pStats->m_bIsPC)

--- a/Plugins/MaxLevel/MaxLevel.hpp
+++ b/Plugins/MaxLevel/MaxLevel.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "Plugin.hpp"
+#include "Services/Hooks/Hooks.hpp"
+
+namespace MaxLevel {
+
+class MaxLevel : public NWNXLib::Plugin
+{
+public:
+    MaxLevel(const Plugin::CreateParams& params);
+    virtual ~MaxLevel();
+
+private:
+    uint8_t m_maxLevel;
+    std::unordered_map<uint8_t, uint32_t> m_nExperienceTableAdded;
+    std::unordered_map<uint16_t, std::unordered_map<uint8_t, std::unordered_map<uint8_t, uint8_t>>> m_nSpellGainTableAdded;
+    std::unordered_map<uint16_t, std::unordered_map<uint8_t, uint8_t>> m_nSpellLevelsPerLevelAdded;
+
+    NWNXLib::Hooking::FunctionHook* m_LevelDownHook;
+    NWNXLib::Hooking::FunctionHook* m_SummonAssociateHook;
+
+    static void ReloadAllHook(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWRules* rules);
+    static void LoadSpellGainTableHook(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWClass* pClass, NWNXLib::API::CExoString *pTable);
+    static uint8_t GetSpellGainHook(NWNXLib::API::CNWClass*, uint8_t, uint8_t);
+    static uint8_t GetSpellsKnownPerLevelHook(NWNXLib::API::CNWClass *, uint8_t, uint8_t, uint8_t, uint16_t, uint8_t);
+    static int32_t CanLevelUpHook(NWNXLib::API::CNWSCreatureStats*);
+    static void SummonAssociateHook(NWNXLib::API::CNWSCreature *, NWNXLib::API::CResRef, NWNXLib::API::CExoString *, uint16_t);
+    static void LevelDownHook(NWNXLib::API::CNWSCreatureStats *, NWNXLib::API::CNWLevelStats *);
+    static uint32_t GetExpNeededForLevelUpHook(NWNXLib::API::CNWSCreatureStats *);
+    static void GetServerInfoFromIniFileHook(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CServerExoAppInternal *);
+};
+
+}


### PR DESCRIPTION
Resolves #473 - Extends maximum level from 40 to 60. 

More information in [README.md](https://github.com/plenarius/unified/blob/a4a1c71baedf141dc69f880ca11e31e88fd63b38/Plugins/MaxLevel/Documentation/README.md)

Technically level 61+ could work (though not as coded) but the maximum levels a PC would be able to have in a class would be 60 otherwise a lot more hooking, some I'm not even sure is possible, would be necessary. Either way this is a start.