### PR TITLE
Fix Trap Event Crash

### DIFF
--- a/Plugins/Events/Events/TrapEvents.cpp
+++ b/Plugins/Events/Events/TrapEvents.cpp
@@ -55,7 +55,7 @@ uint32_t TrapEvents::HandleTrapHook(
     }
     else
     {
-        retVal = std::stoul(sAux);
+        retVal = atoi(sAux.c_str());
         if(retVal == 0)
             retVal = 3; //CNWSObject::ACTION_FAILED;
     }


### PR DESCRIPTION
When no event result is passed back atoi will return 0 which is what we want anyway.