### PR TITLE
ELC: Broadcast ValidateCharacter BEFORE/AFTER messages

### DIFF
--- a/Plugins/ELC/ELC.cpp
+++ b/Plugins/ELC/ELC.cpp
@@ -2,10 +2,7 @@
 
 #include "API/CAppManager.hpp"
 #include "API/CServerExoApp.hpp"
-#include "API/CTlkTable.hpp"
 #include "API/CServerInfo.hpp"
-#include "API/CJoiningRestrictions.hpp"
-#include "API/CPlayOptions.hpp"
 #include "API/CExoString.hpp"
 #include "API/CExoLocString.hpp"
 #include "API/Constants.hpp"
@@ -14,7 +11,6 @@
 #include "API/CNWSCreature.hpp"
 #include "API/CNWSPlayer.hpp"
 #include "API/CNWSCreatureStats.hpp"
-#include "API/CNWSCreatureStats_ClassInfo.hpp"
 #include "API/CNWLevelStats.hpp"
 #include "API/CNWSInventory.hpp"
 #include "API/CNWSItem.hpp"
@@ -30,6 +26,7 @@
 #include "API/C2DA.hpp"
 #include "Services/Events/Events.hpp"
 #include "Services/Config/Config.hpp"
+#include "Services/Messaging/Messaging.hpp"
 #include "ViewPtr.hpp"
 
 #include <set>
@@ -205,6 +202,9 @@ int32_t ELC::ValidateCharacterHook(CNWSPlayer *pPlayer, int32_t *bFailedServerRe
 
         return g_plugin->m_validationFailureMessageStrRef;
     };
+
+    g_plugin->GetServices()->m_messaging->BroadcastMessage("NWNX_ELC_SIGNAL",
+            {"VALIDATE_CHARACTER_BEFORE", NWNXLib::Utils::ObjectIDToString(pPlayer->m_oidNWSObject)});
 
     // *** Server Restrictions **********************************************************************************************
     CServerInfo *pServerInfo = Globals::AppManager()->m_pServerExoApp->GetServerInfo();
@@ -1840,6 +1840,9 @@ int32_t ELC::ValidateCharacterHook(CNWSPlayer *pPlayer, int32_t *bFailedServerRe
             LOG_WARNING("NWNX_ELC: Skipping Custom ELC Check because an ELC script is not set!");
         }
     }
+
+    g_plugin->GetServices()->m_messaging->BroadcastMessage("NWNX_ELC_SIGNAL",
+            {"VALIDATE_CHARACTER_AFTER", NWNXLib::Utils::ObjectIDToString(pPlayer->m_oidNWSObject)});
 
     return 0;
 }

--- a/Plugins/ELC/NWScript/nwnx_elc.nss
+++ b/Plugins/ELC/NWScript/nwnx_elc.nss
@@ -1,5 +1,7 @@
 #include "nwnx"
 
+const string NWNX_ELC = "NWNX_ELC";
+
 const int NWNX_ELC_VALIDATION_FAILURE_TYPE_NONE                     = 0;
 const int NWNX_ELC_VALIDATION_FAILURE_TYPE_CHARACTER                = 1;
 const int NWNX_ELC_VALIDATION_FAILURE_TYPE_ITEM                     = 2;
@@ -139,9 +141,6 @@ int NWNX_ELC_GetValidationFailureFeatID();
 // NOTE: Only to be called in the ELC Script during a
 // NWNX_ELC_VALIDATION_FAILURE_TYPE_SPELL validation failure.
 int NWNX_ELC_GetValidationFailureSpellID();
-
-
-const string NWNX_ELC = "NWNX_ELC";
 
 
 void NWNX_ELC_SetELCScript(string sScript)

--- a/Plugins/Race/Documentation/README.md
+++ b/Plugins/Race/Documentation/README.md
@@ -13,10 +13,6 @@ This plugin allows for the builder to add new races or subraces and define many 
 * `NWNX_SkillRanks` - Needed if you're modifying skill ranks.
 * `NWNX_Util` - Needed if you're using the 2da method which requires new `NWNX_Util_Get2DARowCount()`.
 
-## Conflicting NWNX Plugins
-
-* `NWNX_ELC` - This plugin hooks `ValidateCharacter` to allow for awarding Feats to Races. This conflicts with `NWNX_Race` but only if you award feats to races. If you do not then these plugins can coexist.
-
 ## Setup
 Adding new races is beyond the scope of this documentation. The builder should know how to add new races by adding a new entry in the `racialtypes.2da` as well as adding the appropriate TLK reference identifiers for that new race then adjusting the appropriate columns for their race, including the Ability Score modifications. 
 

--- a/Plugins/Race/Race.hpp
+++ b/Plugins/Race/Race.hpp
@@ -83,13 +83,16 @@ private:
     static void DoEffect(CNWSCreature*, uint16_t, int32_t, int32_t = 0, int32_t = 0, int32_t = 0, int32_t = 0, int32_t = 0);
     static void ApplyRaceEffects(CNWSCreature*);
     static void SetOrRestoreRace(Hooks::CallType, CNWSCreatureStats*, CNWSCreatureStats* = nullptr);
-    void SetRaceModifier(int32_t, RaceModifier, int32_t, int32_t, int32_t);
+    static void SetRaceModifier(int32_t, RaceModifier, int32_t, int32_t, int32_t);
 
     static void ResolveInitiativeHook(CNWSCreature*);
 
     static void PostProcessHook(Hooks::CallType, CNWSCreature*);
     static void ResetFeatRemainingUsesHook(Hooks::CallType, CNWSCreatureStats*);
     static void CreateDefaultQuickButtonsHook(Hooks::CallType, CNWSCreature*);
+    static void HandleValidateCharacter(Types::ObjectID, bool);
+    static void ValidateCharacterHook(Hooks::CallType, CNWSPlayer*, int32_t*);
+
     static void SendServerToPlayerLevelUp_ConfirmationHook(Hooks::CallType, CNWSMessage*, Types::PlayerID, int32_t);
     static void LevelUpAutomaticHook(Hooks::CallType, CNWSCreatureStats*, uint8_t, int32_t, uint8_t);
     static void GetFavoredEnemyBonusHook(Hooks::CallType, CNWSCreatureStats*, CNWSCreature*);


### PR DESCRIPTION
NWNX_ELC now broadcasts a VALIDATE_CHARACTER_BEFORE/AFTER message, other plugins can subscribe to it to do stuff.

Changed NWNX_Race to make use of this functionality, which means NWNX_ELC and NWNX_Race do not conflict anymore.