### PR TITLE
Events: Make {Enter|Exit}StealthEvent Skippable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Core: Added the environment variable `NWNX_CORE_SHUTDOWN_SCRIPT=scriptname` which lets you set a nwscript that runs when the server shuts down
 - Core: Added Util functions to call various script events
 - Events: New events: SkillEvents, MapEvents, EffectEvents, QuickChatEvents, InventoryEvents, BarterEvents, TrapEvents, TimingBarEvents, LevelEvents, WebHookEvents
-- Events: The following events are now skippable: FeatEvents, ItemEvents, HealersKitEvents, CombatModeEvents, PartyEvents, SkillEvents, MapEvents, PolymorphEvents, DMActionEvents, ClientConnectEvents, SpellEvents, QuickChatEvents, InventoryEvents, BarterEvents (START only), TrapEvents, StickyPlayerNameReservedEvent
+- Events: The following events are now skippable: FeatEvents, ItemEvents, HealersKitEvents, CombatModeEvents, PartyEvents, SkillEvents, MapEvents, PolymorphEvents, DMActionEvents, ClientConnectEvents, SpellEvents, QuickChatEvents, InventoryEvents, BarterEvents (START only), TrapEvents, StickyPlayerNameReservedEvent, StealthEvent
 - Events: You can now get the current event name with a nwscript function
 - Events: Added On{Listen/Spot}Detection events to StealthEvents
 - Events: Added On{Un}Polymorph events as PolymorphEvents

--- a/Plugins/Events/Events/StealthEvents.hpp
+++ b/Plugins/Events/Events/StealthEvents.hpp
@@ -12,7 +12,7 @@ public:
     StealthEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
 
 private:
-    static void SetStealthModeHook(NWNXLib::Services::Hooks::CallType, NWNXLib::API::CNWSCreature*, uint8_t);
+    static void SetStealthModeHook(NWNXLib::API::CNWSCreature*, uint8_t);
     static int32_t HandleDetectionHook(const std::string&, NWNXLib::Hooking::FunctionHook*, NWNXLib::API::CNWSCreature*, NWNXLib::API::CNWSCreature*, int32_t);
     static int32_t DoListenDetectionHook(NWNXLib::API::CNWSCreature*, NWNXLib::API::CNWSCreature*, int32_t);
     static int32_t DoSpotDetectionHook(NWNXLib::API::CNWSCreature*, NWNXLib::API::CNWSCreature*, int32_t);

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -860,6 +860,7 @@ string NWNX_Events_GetEventData(string tag);
 // - Sticky Player Name event
 // - Add/RemoveGold events
 // - PVP Attitude Change events
+// - {Enter|Exit}Stealth events
 void NWNX_Events_SkipEvent();
 
 // Set the return value of the event.
@@ -911,7 +912,7 @@ int NWNX_Events_SignalEvent(string evt, object target)
 string NWNX_Events_GetEventData(string tag)
 {
     string sFunc = "GET_EVENT_DATA";
-    
+
     NWNX_PushArgumentString(NWNX_Events, sFunc, tag);
     NWNX_CallFunction(NWNX_Events, sFunc);
     return NWNX_GetReturnValueString(NWNX_Events, sFunc);


### PR DESCRIPTION
Resolves #550

Wasn't as simple as just skipping the original call, but I think I made it work.