### PR TITLE
Events: Add DispatchListMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,9 @@ The following plugins were added:
 - ELC: GetValidationFailureFeatID();
 - ELC: GetValidationFailureSpellID();
 - Events: GetCurrentEvent()
+- Events: ToggleDispatchListMode()
+- Events: AddObjectToDispatchList()
+- Events: RemoveObjectFromDispatchList()
 - Feedback: Get{Feedback|CombatLog|JournalUpdated}MessageHidden()
 - Feedback: Set{Feedback|CombatLog|JournalUpdated}MessageHidden()
 - Feedback: Set{Feedback|CombatLog}MessageMode()

--- a/Plugins/Events/Events.hpp
+++ b/Plugins/Events/Events.hpp
@@ -7,6 +7,9 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <set>
+
+using ArgumentStack = NWNXLib::Services::Events::ArgumentStack;
 
 namespace Events {
 
@@ -71,13 +74,16 @@ private: // Structures
     using EventMapType = std::unordered_map<std::string, std::vector<std::string>>;
 
 private:
-    NWNXLib::Services::Events::ArgumentStack OnSubscribeEvent(NWNXLib::Services::Events::ArgumentStack&& args);
-    NWNXLib::Services::Events::ArgumentStack OnPushEventData(NWNXLib::Services::Events::ArgumentStack&& args);
-    NWNXLib::Services::Events::ArgumentStack OnSignalEvent(NWNXLib::Services::Events::ArgumentStack&& args);
-    NWNXLib::Services::Events::ArgumentStack OnGetEventData(NWNXLib::Services::Events::ArgumentStack&& args);
-    NWNXLib::Services::Events::ArgumentStack OnSkipEvent(NWNXLib::Services::Events::ArgumentStack&& args);
-    NWNXLib::Services::Events::ArgumentStack OnEventResult(NWNXLib::Services::Events::ArgumentStack&& args);
-    NWNXLib::Services::Events::ArgumentStack OnGetCurrentEvent(NWNXLib::Services::Events::ArgumentStack&& args);
+    ArgumentStack OnSubscribeEvent(ArgumentStack&& args);
+    ArgumentStack OnPushEventData(ArgumentStack&& args);
+    ArgumentStack OnSignalEvent(ArgumentStack&& args);
+    ArgumentStack OnGetEventData(ArgumentStack&& args);
+    ArgumentStack OnSkipEvent(ArgumentStack&& args);
+    ArgumentStack OnEventResult(ArgumentStack&& args);
+    ArgumentStack OnGetCurrentEvent(ArgumentStack&& args);
+    ArgumentStack ToggleDispatchListMode(ArgumentStack&& args);
+    ArgumentStack AddObjectToDispatchList(ArgumentStack&& args);
+    ArgumentStack RemoveObjectFromDispatchList(ArgumentStack&& args);
 
     // Pushes a brand new event data onto the event data stack, set up with the correct defaults.
     // Only does it if needed though, based on the current event depth!
@@ -90,6 +96,7 @@ private:
     uint8_t m_eventDepth;
 
     std::unordered_map<std::string, std::function<void(void)>> m_initList;
+    std::unordered_map<std::string, std::set<NWNXLib::API::Types::ObjectID>> m_dispatchList;
 
     std::unique_ptr<AssociateEvents> m_associateEvents;
     std::unique_ptr<BarterEvents> m_barterEvents;

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -880,6 +880,16 @@ void NWNX_Events_SetEventResult(string data);
 // Returns "" on error
 string NWNX_Events_GetCurrentEvent();
 
+// Toggles DispatchListMode for sEvent+sScript
+// If enabled, sEvent for sScript will only be signalled if the target object is on its dispatch list.
+void NWNX_Events_ToggleDispatchListMode(string sEvent, string sScript, int bEnable);
+
+// Add oObject to the dispatch list for sEvent+sScript.
+void NWNX_Events_AddObjectToDispatchList(string sEvent, string sScript, object oObject);
+
+// Remove oObject from the dispatch list for sEvent+sScript.
+void NWNX_Events_RemoveObjectFromDispatchList(string sEvent, string sScript, object oObject);
+
 
 void NWNX_Events_SubscribeEvent(string evt, string script)
 {
@@ -939,4 +949,34 @@ string NWNX_Events_GetCurrentEvent()
 
     NWNX_CallFunction(NWNX_Events, sFunc);
     return NWNX_GetReturnValueString(NWNX_Events, sFunc);
+}
+
+void NWNX_Events_ToggleDispatchListMode(string sEvent, string sScript, int bEnable)
+{
+    string sFunc = "ToggleDispatchListMode";
+
+    NWNX_PushArgumentInt(NWNX_Events, sFunc, bEnable);
+    NWNX_PushArgumentString(NWNX_Events, sFunc, sScript);
+    NWNX_PushArgumentString(NWNX_Events, sFunc, sEvent);
+    NWNX_CallFunction(NWNX_Events, sFunc);
+}
+
+void NWNX_Events_AddObjectToDispatchList(string sEvent, string sScript, object oObject)
+{
+    string sFunc = "AddObjectToDispatchList";
+
+    NWNX_PushArgumentObject(NWNX_Events, sFunc, oObject);
+    NWNX_PushArgumentString(NWNX_Events, sFunc, sScript);
+    NWNX_PushArgumentString(NWNX_Events, sFunc, sEvent);
+    NWNX_CallFunction(NWNX_Events, sFunc);
+}
+
+void NWNX_Events_RemoveObjectFromDispatchList(string sEvent, string sScript, object oObject)
+{
+    string sFunc = "RemoveObjectFromDispatchList";
+
+    NWNX_PushArgumentObject(NWNX_Events, sFunc, oObject);
+    NWNX_PushArgumentString(NWNX_Events, sFunc, sScript);
+    NWNX_PushArgumentString(NWNX_Events, sFunc, sEvent);
+    NWNX_CallFunction(NWNX_Events, sFunc);
 }


### PR DESCRIPTION
Adds DispatchListMode for Events.

This lets you toggle DispatchListMode for Event+Script combos. If enabled, `Event` for `Script` will only be signaled if the target object is on its dispatch list. 

This is pretty useful for events that can be called a lot, for example `NWNX_ON_INPUT_WALK_TO_WAYPOINT_{BEFORE|AFTER}`.
Previously it would signal an event for every player whenever they click to move somewhere.
Now, you can enable DispatchListMode for it and only get signaled for specific target objects.

```
// Subscribe to an event like normal
NWNX_Events_SubscribeEvent("NWNX_ON_INPUT_WALK_TO_WAYPOINT_BEFORE", "evt_script");
// Enable DispatchListMode for the event
NWNX_Events_ToggleDispatchListMode("NWNX_ON_INPUT_WALK_TO_WAYPOINT_BEFORE", "evt_script", TRUE);
// Add oPlayer to the dispatch list
NWNX_Events_AddObjectToDispatchList("NWNX_ON_INPUT_WALK_TO_WAYPOINT_BEFORE", "evt_script", oPlayer);

// Now, when oPlayer clicks somewhere to move, `evt_script` will get called, for all other players that aren't on the list it won't.
```