### PR TITLE
Event: Surface Material Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ NOTICE: The ABI has changed, please make sure to update your nwnx.nss and recomp
 - Events: Added PVP Attitude Change event
 - Events: Added SplitItem event to ItemEvents
 - Events: Added WalkToWaypoint event to InputEvents
+- Events: Added Surface Material Change events
 - Profiler: Support profiler perf scopes via nwscript
 - SQL: Added support for SQLite
 - Tweaks: DisableQuickSave

--- a/Plugins/Events/CMakeLists.txt
+++ b/Plugins/Events/CMakeLists.txt
@@ -22,4 +22,5 @@ add_plugin(Events
     "Events/TimingBarEvents.cpp"
     "Events/LevelEvents.cpp"
     "Events/PVPEvents.cpp"
-    "Events/InputEvents.cpp")
+    "Events/InputEvents.cpp"
+    "Events/MaterialChangeEvents.cpp")

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -26,6 +26,7 @@
 #include "Events/LevelEvents.hpp"
 #include "Events/PVPEvents.hpp"
 #include "Events/InputEvents.hpp"
+#include "Events/MaterialChangeEvents.hpp"
 #include "Services/Config/Config.hpp"
 #include "Services/Messaging/Messaging.hpp"
 #include "ViewPtr.hpp"
@@ -108,6 +109,7 @@ Events::Events(const Plugin::CreateParams& params)
     m_levelEvents       = std::make_unique<LevelEvents>(GetServices()->m_hooks);
     m_PVPEvents         = std::make_unique<PVPEvents>(GetServices()->m_hooks);
     m_inputEvents       = std::make_unique<InputEvents>(GetServices()->m_hooks);
+    m_matChangeEvents   = std::make_unique<MaterialChangeEvents>(GetServices()->m_hooks);
 }
 
 Events::~Events()

--- a/Plugins/Events/Events.hpp
+++ b/Plugins/Events/Events.hpp
@@ -33,6 +33,7 @@ class TimingBarEvents;
 class LevelEvents;
 class PVPEvents;
 class InputEvents;
+class MaterialChangeEvents;
 
 class Events : public NWNXLib::Plugin
 {
@@ -114,6 +115,7 @@ private:
     std::unique_ptr<LevelEvents> m_levelEvents;
     std::unique_ptr<PVPEvents> m_PVPEvents;
     std::unique_ptr<InputEvents> m_inputEvents;
+    std::unique_ptr<MaterialChangeEvents> m_matChangeEvents;
 };
 
 }

--- a/Plugins/Events/Events/MaterialChangeEvents.cpp
+++ b/Plugins/Events/Events/MaterialChangeEvents.cpp
@@ -28,6 +28,8 @@ void MaterialChangeEvents::SetPositionHook(Services::Hooks::CallType type, API::
     if (thisPtr->m_nObjectType == API::Constants::ObjectType::Creature)
     {
         auto oArea = API::Globals::AppManager()->m_pServerExoApp->GetAreaByGameObjectID(thisPtr->m_oidArea);
+        if (oArea == nullptr)
+            return;
         auto iMat = oArea->GetSurfaceMaterial(vPos);
         if (!m_objectCurrentMaterial.count(thisPtr->m_idSelf) || iMat != m_objectCurrentMaterial[thisPtr->m_idSelf])
         {

--- a/Plugins/Events/Events/MaterialChangeEvents.cpp
+++ b/Plugins/Events/Events/MaterialChangeEvents.cpp
@@ -27,10 +27,10 @@ void MaterialChangeEvents::SetPositionHook(Services::Hooks::CallType type, API::
     const bool before = type == Services::Hooks::CallType::BEFORE_ORIGINAL;
     if (thisPtr->m_nObjectType == API::Constants::ObjectType::Creature)
     {
-        auto oArea = API::Globals::AppManager()->m_pServerExoApp->GetAreaByGameObjectID(thisPtr->m_oidArea);
-        if (oArea == nullptr)
+        auto pArea = API::Globals::AppManager()->m_pServerExoApp->GetAreaByGameObjectID(thisPtr->m_oidArea);
+        if (pArea == nullptr)
             return;
-        auto iMat = oArea->GetSurfaceMaterial(vPos);
+        auto iMat = pArea->GetSurfaceMaterial(vPos);
         if (!m_objectCurrentMaterial.count(thisPtr->m_idSelf) || iMat != m_objectCurrentMaterial[thisPtr->m_idSelf])
         {
             Events::PushEventData("MATERIAL_TYPE", std::to_string(iMat));

--- a/Plugins/Events/Events/MaterialChangeEvents.cpp
+++ b/Plugins/Events/Events/MaterialChangeEvents.cpp
@@ -1,0 +1,41 @@
+#include "Events/MaterialChangeEvents.hpp"
+#include "API/CAppManager.hpp"
+#include "API/CServerExoApp.hpp"
+#include "API/CNWSArea.hpp"
+#include "API/CNWSObject.hpp"
+#include "API/Constants.hpp"
+#include "API/Functions.hpp"
+#include "API/Globals.hpp"
+#include "Events.hpp"
+
+namespace Events {
+
+using namespace NWNXLib;
+
+static std::unordered_map<API::Types::ObjectID, int32_t> m_objectCurrentMaterial;
+
+MaterialChangeEvents::MaterialChangeEvents(ViewPtr<Services::HooksProxy> hooker)
+{
+    Events::InitOnFirstSubscribe("NWNX_ON_MATERIALCHANGE_.*", [hooker]() {
+        hooker->RequestSharedHook<API::Functions::CNWSObject__SetPosition, void,
+                API::CNWSObject*, API::Vector, int32_t>(&SetPositionHook);
+    });
+}
+
+void MaterialChangeEvents::SetPositionHook(Services::Hooks::CallType type, API::CNWSObject* thisPtr, API::Vector vPos, int32_t)
+{
+    const bool before = type == Services::Hooks::CallType::BEFORE_ORIGINAL;
+    if (thisPtr->m_nObjectType == API::Constants::ObjectType::Creature)
+    {
+        auto oArea = API::Globals::AppManager()->m_pServerExoApp->GetAreaByGameObjectID(thisPtr->m_oidArea);
+        auto iMat = oArea->GetSurfaceMaterial(vPos);
+        if (!m_objectCurrentMaterial.count(thisPtr->m_idSelf) || iMat != m_objectCurrentMaterial[thisPtr->m_idSelf])
+        {
+            Events::PushEventData("MATERIAL_TYPE", std::to_string(iMat));
+            Events::SignalEvent(before ? "NWNX_ON_MATERIALCHANGE_BEFORE" : "NWNX_ON_MATERIALCHANGE_AFTER", thisPtr->m_idSelf);
+            m_objectCurrentMaterial[thisPtr->m_idSelf] = iMat;
+        }
+    }
+}
+
+}

--- a/Plugins/Events/Events/MaterialChangeEvents.hpp
+++ b/Plugins/Events/Events/MaterialChangeEvents.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "Common.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include "ViewPtr.hpp"
+
+namespace Events {
+
+class MaterialChangeEvents
+{
+public:
+    MaterialChangeEvents(NWNXLib::ViewPtr<NWNXLib::Services::HooksProxy> hooker);
+
+private:
+    static void SetPositionHook(NWNXLib::Services::Hooks::CallType, NWNXLib::API::CNWSObject*, NWNXLib::API::Vector, int32_t);
+};
+
+}

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -801,6 +801,10 @@ const string NWNX_Events = "NWNX_Events";
     Event data:
         Variable Name           Type        Notes
         MATERIAL_TYPE           int         See surfacemat.2da for values
+
+    Note:
+        After a PC transitions to a new area, a surface material change event
+        won't fire until after the PC moves.        
 *///////////////////////////////////////////////////////////////////////////////
 
 /*

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -791,6 +791,16 @@ const string NWNX_Events = "NWNX_Events";
         POS_Y                   float
         POS_Z                   float
         RUN_TO_POINT            int         TRUE if player is running, FALSE if player is walking (eg when shift clicking)
+////////////////////////////////////////////////////////////////////////////////
+    NWNX_ON_MATERIALCHANGE_BEFORE
+    NWNX_ON_MATERIALCHANGE_AFTER
+
+    Usage:
+        OBJECT_SELF = The creature walking on a different surface material
+
+    Event data:
+        Variable Name           Type        Notes
+        MATERIAL_TYPE           int         See surfacemat.2da for values
 *///////////////////////////////////////////////////////////////////////////////
 
 /*


### PR DESCRIPTION
Sends an event whenever the surface material under a creature changes.

Caveat: `SetPosition` doesn't fire when first entering an area, only after the creature moves the slightest will it then fire. So if a creature transitions from a grass area directly into a snowy area it won't change until they take their first step.