### PR TITLE
scripts: Redirect zip stdout to /dev/null

### DIFF
--- a/Scripts/packageNWScript.sh
+++ b/Scripts/packageNWScript.sh
@@ -15,7 +15,8 @@ done
 
 pushd Binaries
 
-zip -r NWScript.zip NWScript
+echo "Zipping NWScripts..."
+zip -r NWScript.zip NWScript > /dev/null
 
 pushd NWScript
 for i in `find . -name *.nss`; do


### PR DESCRIPTION
Redirect zip stdout to /dev/null, having to scroll through its output to see compilation errors is frustrating especially if using docker on Windows.