### PR TITLE
Player: add UpdateItemName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@ The following plugins were added:
 - Player: SetPlaceableNameOverride()
 - Player: GetQuestCompleted()
 - Player: SetPersistentLocation()
+- Player: UpdateItemName()
 - Race: SetRacialModifier()
 - Race: GetParentRace()
 - Regex: Search()

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -178,6 +178,9 @@ int NWNX_Player_GetQuestCompleted(object player, string sQuestName);
 // persistent method. (OnRest, OnAreaEnter, OnClentExit)
 void NWNX_Player_SetPersistentLocation(string sCDKeyOrCommunityName, string sBicFileName, object oWP, int bFirstConnectOnly = TRUE);
 
+// Force a item name to be updated. Workaround for bug that occurs
+// when updating item names in open containers.
+void NWNX_Player_UpdateItemName(object oPlayer, object oItem);
 
 void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable)
 {
@@ -609,6 +612,16 @@ void NWNX_Player_SetPersistentLocation(string sCDKeyOrCommunityName, string sBic
     NWNX_PushArgumentObject(NWNX_Player, sFunc, oWP);
     NWNX_PushArgumentString(NWNX_Player, sFunc, sBicFileName);
     NWNX_PushArgumentString(NWNX_Player, sFunc, sCDKeyOrCommunityName);
+
+    NWNX_CallFunction(NWNX_Player, sFunc);
+}
+
+void NWNX_Player_UpdateItemName(object oPlayer, object oItem)
+{
+    string sFunc = "UpdateItemName";
+
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, oItem);
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, oPlayer);
 
     NWNX_CallFunction(NWNX_Player, sFunc);
 }

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -100,6 +100,7 @@ Player::Player(const Plugin::CreateParams& params)
     REGISTER(SetPlaceableNameOverride);
     REGISTER(GetQuestCompleted);
     REGISTER(SetPersistentLocation);
+    REGISTER(UpdateItemName);
 
 #undef REGISTER
 
@@ -1140,6 +1141,25 @@ ArgumentStack Player::SetPersistentLocation(ArgumentStack&& args)
     std::string sKey = sCDKeyOrCommunityName + "!" + sBicFileName;
     g_plugin->m_PersistentLocationWP[sKey] = std::make_pair(wpOid, bFirstConnectOnly);
 
+    return stack;
+}
+
+ArgumentStack Player::UpdateItemName(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto *pPlayer = player(args))
+    {
+        auto oidItem = Services::Events::ExtractArgument<Types::ObjectID>(args);
+          ASSERT_OR_THROW(oidItem != Constants::OBJECT_INVALID);
+
+        auto *pItem = Utils::AsNWSItem(Utils::GetGameObject(oidItem));
+        auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
+
+        if (pItem && pMessage)
+        {
+            pMessage->SendServerToPlayerUpdateItemName(pPlayer, pItem);
+        }
+    }
     return stack;
 }
 

--- a/Plugins/Player/Player.hpp
+++ b/Plugins/Player/Player.hpp
@@ -45,6 +45,7 @@ private:
     ArgumentStack SetPlaceableNameOverride          (ArgumentStack&& args);
     ArgumentStack GetQuestCompleted                 (ArgumentStack&& args);
     ArgumentStack SetPersistentLocation             (ArgumentStack&& args);
+    ArgumentStack UpdateItemName                    (ArgumentStack&& args);    
 
     NWNXLib::API::CNWSPlayer *player(ArgumentStack& args);
 


### PR DESCRIPTION
Workaround for `SetName` not updating items in open containers.

When a player has a container open, renaming the items in it via `SetName` doesn't correctly send a name update from the server to the client. This function is a workaround, allowing the user to force the update.

This will likely be obsolete when the bug is fixed, but in case anyone else needs it, here's a PR for it :)