### PR TITLE
Area: add TestDirectLine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ The following plugins were added:
 - Area: {Get|Set}SunMoonColors()
 - Area: CreateTransition()
 - Area: {Get|Set}TileAnimationLoop()
+- Area: TestDirectLine()
 - Chat: GetChatHearingDistance()
 - Chat: SetChatHearingDistance()
 - Creature: GetAttackBonus()

--- a/Plugins/Area/Area.cpp
+++ b/Plugins/Area/Area.cpp
@@ -73,6 +73,7 @@ Area::Area(const Plugin::CreateParams& params)
     REGISTER(CreateTransition);
     REGISTER(GetTileAnimationLoop);
     REGISTER(SetTileAnimationLoop);
+    REGISTER(TestDirectLine);
 
 #undef REGISTER
 }
@@ -718,6 +719,33 @@ ArgumentStack Area::SetTileAnimationLoop(ArgumentStack&& args)
         {
             LOG_ERROR("NWNX_Area_SetTileAnimationLoop: invalid tile specified");
         }
+    }
+
+    return stack;
+}
+
+ArgumentStack Area::TestDirectLine(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+
+    if (auto *pArea = area(args))
+    {
+        const auto fStartX = Services::Events::ExtractArgument<float>(args);
+          ASSERT_OR_THROW(fStartX >= 0.0f);
+        const auto fStartY = Services::Events::ExtractArgument<float>(args);
+          ASSERT_OR_THROW(fStartY >= 0.0f);
+        const auto fEndX = Services::Events::ExtractArgument<float>(args);
+          ASSERT_OR_THROW(fEndX >= 0.0f);
+        const auto fEndY = Services::Events::ExtractArgument<float>(args);
+          ASSERT_OR_THROW(fEndY >= 0.0f);
+        const auto fPerSpace = Services::Events::ExtractArgument<float>(args);
+          ASSERT_OR_THROW(fPerSpace >= 0.0f);
+        const auto fHeight = Services::Events::ExtractArgument<float>(args);
+            ASSERT_OR_THROW(fHeight >= 0.0f);
+        const auto bIgnoreDoors = Services::Events::ExtractArgument<int32_t>(args);
+
+        int32_t bReturn = pArea->TestDirectLine(fStartX, fStartY, fEndX, fEndY, fPerSpace, fHeight, bIgnoreDoors);
+        Services::Events::InsertArgument(stack, bReturn);
     }
 
     return stack;

--- a/Plugins/Area/Area.hpp
+++ b/Plugins/Area/Area.hpp
@@ -41,6 +41,7 @@ private:
     ArgumentStack CreateTransition          (ArgumentStack&& args);
     ArgumentStack GetTileAnimationLoop      (ArgumentStack&& args);
     ArgumentStack SetTileAnimationLoop      (ArgumentStack&& args);
+    ArgumentStack TestDirectLine            (ArgumentStack&& args);
 
     NWNXLib::API::CNWSArea *area(ArgumentStack& args);
     static NWNXLib::API::CNWSTile *GetTile(NWNXLib::API::CNWSArea *pArea, float x, float y);

--- a/Plugins/Area/NWScript/nwnx_area.nss
+++ b/Plugins/Area/NWScript/nwnx_area.nss
@@ -126,6 +126,15 @@ int NWNX_Area_GetTileAnimationLoop(object oArea, float fTileX, float fTileY, int
 // NOTE: Requires clients to re-enter the area for it to take effect
 void NWNX_Area_SetTileAnimationLoop(object oArea, float fTileX, float fTileY, int nAnimLoop, int bEnabled);
 
+// Test to see if there's a direct, walkable line between two points in the area.
+// The personal space (fPerSpace) and height (fHeight) of a creature can be found in appearance.2da.
+//
+// Returns:
+//   1 if there is a direct walkable line.
+//   -1 if the line is blocked by terrain.
+//   -2 if the line is blocked by a placeable.
+//   -3 if the line is blocked by a creature.
+int NWNX_Area_TestDirectLine(object oArea, float fStartX, float fStartY, float fEndX, float fEndY, float fPerSpace, float fHeight, int bIgnoreDoors=FALSE);
 
 int NWNX_Area_GetNumberOfPlayersInArea(object area)
 {
@@ -393,4 +402,23 @@ void NWNX_Area_SetTileAnimationLoop(object oArea, float fTileX, float fTileY, in
     NWNX_PushArgumentObject(NWNX_Area, sFunc, oArea);
 
     NWNX_CallFunction(NWNX_Area, sFunc);
+}
+
+
+int NWNX_Area_TestDirectLine(object oArea, float fStartX, float fStartY, float fEndX, float fEndY, float fPerSpace, float fHeight, int bIgnoreDoors=FALSE)
+{
+    string sFunc = "TestDirectLine";
+
+    NWNX_PushArgumentInt(NWNX_Area, sFunc, bIgnoreDoors);
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, fHeight);
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, fPerSpace);
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, fEndY);
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, fEndX);
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, fStartY);
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, fStartX);
+    NWNX_PushArgumentObject(NWNX_Area, sFunc, oArea);
+
+    NWNX_CallFunction(NWNX_Area, sFunc);
+
+    return NWNX_GetReturnValueInt(NWNX_Area, sFunc);
 }


### PR DESCRIPTION
A function for testing whether there is a direct walkable line between two points in an area. Takes into account placeables and creatures as well as terrain.

My use-case for this is supporting @Daztek's "knockback" effect/hack that is stopped by placeables as well as terrain.