### PR TITLE
Fix spells known for Bard/Sorcs in MaxLevel

### DIFF
--- a/Plugins/MaxLevel/MaxLevel.cpp
+++ b/Plugins/MaxLevel/MaxLevel.cpp
@@ -210,21 +210,21 @@ void MaxLevel::LoadSpellGainTableHook(Services::Hooks::CallType type, CNWClass* 
     if (type == Services::Hooks::CallType::BEFORE_ORIGINAL)
         return;
 
-    auto *twoda = new C2DA(CResRef(pTable->CStr()), 1);
-    twoda->Load2DArray();
+    C2DA twoda(pTable->CStr(), true);
+    twoda.Load2DArray();
 
     for (int i = CORE_MAX_LEVEL; i < g_plugin->m_maxLevel; i++)
     {
         int32_t numSpellLevels = 0;
         uint8_t lastFoundSpellGainLevel = CORE_MAX_LEVEL;
-        twoda->GetINTEntry(i, "NumSpellLevels", &numSpellLevels);
+        twoda.GetINTEntry(i, "NumSpellLevels", &numSpellLevels);
 
         // If they don't have this set then default to the last found level
         if (!numSpellLevels)
         {
             LOG_WARNING("No spell gain row found for Level %d for %s Class. Defaulting to Level %d.",
                     1 + i, pClass->GetNameText(), lastFoundSpellGainLevel);
-            twoda->GetINTEntry(lastFoundSpellGainLevel - 1, "NumSpellLevels", &numSpellLevels);
+            twoda.GetINTEntry(lastFoundSpellGainLevel - 1, "NumSpellLevels", &numSpellLevels);
         }
         g_plugin->m_nSpellLevelsPerLevelAdded[pClass->m_nName][i] = numSpellLevels;
 
@@ -232,10 +232,10 @@ void MaxLevel::LoadSpellGainTableHook(Services::Hooks::CallType type, CNWClass* 
         for (int j = 0; j < numSpellLevels; j++)
         {
             int32_t iNumSpells = 0;
-            twoda->GetINTEntry(i, 2 + j, &iNumSpells);
+            twoda.GetINTEntry(i, 2 + j, &iNumSpells);
             if (!iNumSpells)
             {
-                twoda->GetINTEntry(lastFoundSpellGainLevel - 1, 2 + j, &iNumSpells);
+                twoda.GetINTEntry(lastFoundSpellGainLevel - 1, 2 + j, &iNumSpells);
             }
             else
             {
@@ -275,8 +275,8 @@ void MaxLevel::LoadSpellKnownTableHook(Services::Hooks::CallType type, CNWClass*
     if (type == Services::Hooks::CallType::BEFORE_ORIGINAL)
         return;
 
-    auto *twoda = new C2DA(CResRef(pTable->CStr()), 1);
-    twoda->Load2DArray();
+    C2DA twoda(pTable->CStr(), true);
+    twoda.Load2DArray();
 
     for (int i = CORE_MAX_LEVEL; i < g_plugin->m_maxLevel; i++)
     {
@@ -286,10 +286,10 @@ void MaxLevel::LoadSpellKnownTableHook(Services::Hooks::CallType type, CNWClass*
         for (int j = 0; j < g_plugin->m_nSpellLevelsPerLevelAdded[pClass->m_nName][i - 1]; j++)
         {
             int32_t iNumSpells = 0;
-            twoda->GetINTEntry(i, 2 + j, &iNumSpells);
+            twoda.GetINTEntry(i, 2 + j, &iNumSpells);
             if (!iNumSpells)
             {
-                twoda->GetINTEntry(lastFoundSpellKnownLevel - 1, 2 + j, &iNumSpells);
+                twoda.GetINTEntry(lastFoundSpellKnownLevel - 1, 2 + j, &iNumSpells);
             }
             else
             {

--- a/Plugins/MaxLevel/MaxLevel.cpp
+++ b/Plugins/MaxLevel/MaxLevel.cpp
@@ -77,6 +77,7 @@ MaxLevel::MaxLevel(const Plugin::CreateParams& params)
         GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWSCreature__SummonAssociate>(&SummonAssociateHook);
         m_SummonAssociateHook = GetServices()->m_hooks->FindHookByAddress(Functions::CNWSCreature__SummonAssociate);
         GetServices()->m_hooks->RequestSharedHook<Functions::CNWClass__LoadSpellGainTable, void, CNWClass *, CExoString *>(&LoadSpellGainTableHook);
+        GetServices()->m_hooks->RequestSharedHook<Functions::CNWClass__LoadSpellKnownTable, void, CNWClass *, CExoString *>(&LoadSpellKnownTableHook);
         GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWClass__GetSpellGain>(&GetSpellGainHook);
         GetServices()->m_hooks->RequestExclusiveHook<Functions::CNWClass__GetSpellsKnownPerLevel>( &GetSpellsKnownPerLevelHook);
     }
@@ -268,24 +269,60 @@ uint8_t MaxLevel::GetSpellGainHook(CNWClass *pClass, uint8_t nLevel, uint8_t nSp
     return result;
 }
 
-// If the player is at level 40 or lower we get the spell gain for that class from the normal array,
+// After the server loads 1-40 we populate our map with the values for 41+
+void MaxLevel::LoadSpellKnownTableHook(Services::Hooks::CallType type, CNWClass* pClass, CExoString *pTable)
+{
+    if (type == Services::Hooks::CallType::BEFORE_ORIGINAL)
+        return;
+
+    auto *twoda = new C2DA(CResRef(pTable->CStr()), 1);
+    twoda->Load2DArray();
+
+    for (int i = CORE_MAX_LEVEL; i < g_plugin->m_maxLevel; i++)
+    {
+        uint8_t lastFoundSpellKnownLevel = CORE_MAX_LEVEL;
+
+        // Now find the spells known per level for each spell level
+        for (int j = 0; j < g_plugin->m_nSpellLevelsPerLevelAdded[pClass->m_nName][i - 1]; j++)
+        {
+            int32_t iNumSpells = 0;
+            twoda->GetINTEntry(i, 2 + j, &iNumSpells);
+            if (!iNumSpells)
+            {
+                twoda->GetINTEntry(lastFoundSpellKnownLevel - 1, 2 + j, &iNumSpells);
+            }
+            else
+            {
+                lastFoundSpellKnownLevel = 1 + i;
+            }
+            g_plugin->m_nSpellKnownTableAdded[pClass->m_nName][i][j] = iNumSpells;
+        }
+    }
+}
+
+// If the player is at level 40 or lower we get the spell known for that class from the normal array,
 // otherwise we use our map
 uint8_t MaxLevel::GetSpellsKnownPerLevelHook(CNWClass *pClass, uint8_t nLevel, uint8_t nSpellLevel, uint8_t nClass,
                                              uint16_t nRace, uint8_t nCHABase)
 {
     uint8_t result = 0;
-    if (((nLevel <= CORE_MAX_LEVEL && nSpellLevel < pClass->m_lstSpellLevelsPerLevel[nLevel - 1]) ||
-         (nSpellLevel < g_plugin->m_nSpellLevelsPerLevelAdded[pClass->m_nName][nLevel - 1])) &&
+    auto spellLvlsPerLvl = pClass->m_lstSpellLevelsPerLevel[nLevel - 1];
+    auto spellLvlsPerLvlAdded = g_plugin->m_nSpellLevelsPerLevelAdded[pClass->m_nName][nLevel - 1];
+    auto raceChaAdjust = Globals::Rules()->m_lstRaces[nRace].m_nCHAAdjust;
+    if (((nLevel <= CORE_MAX_LEVEL && nSpellLevel < spellLvlsPerLvl) ||
+         (nLevel > CORE_MAX_LEVEL && nSpellLevel < spellLvlsPerLvlAdded)) && pClass->m_lstSpellKnownTable &&
         (nClass != API::Constants::ClassType::Bard ||
-         Globals::Rules()->m_lstRaces[nRace].m_nCHAAdjust + nCHABase > nSpellLevel + 10))
+         ((nLevel <= CORE_MAX_LEVEL && pClass->m_lstSpellKnownTable[nLevel - 1][nSpellLevel]) ||
+          (nLevel > CORE_MAX_LEVEL && g_plugin->m_nSpellKnownTableAdded[pClass->m_nName][nLevel - 1][nSpellLevel])) ||
+         raceChaAdjust + nCHABase > nSpellLevel + 10))
     {
         if (nLevel <= CORE_MAX_LEVEL)
         {
-            result = pClass->m_lstSpellLevelsPerLevel[nLevel - 1];
+            result = pClass->m_lstSpellKnownTable[nLevel - 1][nSpellLevel];
         }
         else
         {
-            result = g_plugin->m_nSpellLevelsPerLevelAdded[pClass->m_nName][nLevel - 1];
+            result = g_plugin->m_nSpellKnownTableAdded[pClass->m_nName][nLevel - 1][nSpellLevel];
         }
     }
     return result;

--- a/Plugins/MaxLevel/MaxLevel.hpp
+++ b/Plugins/MaxLevel/MaxLevel.hpp
@@ -15,6 +15,7 @@ private:
     uint8_t m_maxLevel;
     std::unordered_map<uint8_t, uint32_t> m_nExperienceTableAdded;
     std::unordered_map<uint16_t, std::unordered_map<uint8_t, std::unordered_map<uint8_t, uint8_t>>> m_nSpellGainTableAdded;
+    std::unordered_map<uint16_t, std::unordered_map<uint8_t, std::unordered_map<uint8_t, uint8_t>>> m_nSpellKnownTableAdded;
     std::unordered_map<uint16_t, std::unordered_map<uint8_t, uint8_t>> m_nSpellLevelsPerLevelAdded;
 
     NWNXLib::Hooking::FunctionHook* m_LevelDownHook;
@@ -22,6 +23,7 @@ private:
 
     static void ReloadAllHook(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWRules* rules);
     static void LoadSpellGainTableHook(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWClass* pClass, NWNXLib::API::CExoString *pTable);
+    static void LoadSpellKnownTableHook(NWNXLib::Services::Hooks::CallType type, NWNXLib::API::CNWClass* pClass, NWNXLib::API::CExoString *pTable);
     static uint8_t GetSpellGainHook(NWNXLib::API::CNWClass*, uint8_t, uint8_t);
     static uint8_t GetSpellsKnownPerLevelHook(NWNXLib::API::CNWClass *, uint8_t, uint8_t, uint8_t, uint16_t, uint8_t);
     static int32_t CanLevelUpHook(NWNXLib::API::CNWSCreatureStats*);


### PR DESCRIPTION
A rather large misunderstanding in the Spell Known logic for Bards/Sorcs has been corrected.