### PR TITLE
Copy any linked effects since DestroyGameEffect deletes the original ones

### DIFF
--- a/Plugins/Effect/Effect.cpp
+++ b/Plugins/Effect/Effect.cpp
@@ -143,10 +143,26 @@ ArgumentStack Effect::UnpackEffect(ArgumentStack&& args)
     Services::Events::InsertArgument(stack, (int32_t)eff->m_bExpose);
     Services::Events::InsertArgument(stack, (int32_t)eff->m_bShowIcon);
     Services::Events::InsertArgument(stack, (int32_t)eff->m_nCasterLevel);
-    Services::Events::InsertArgument(stack, (API::CGameEffect*)eff->m_pLinkLeft);
-    Services::Events::InsertArgument(stack, (int32_t)(eff->m_pLinkLeft != nullptr));
-    Services::Events::InsertArgument(stack, (API::CGameEffect*)eff->m_pLinkRight);
-    Services::Events::InsertArgument(stack, (int32_t)(eff->m_pLinkRight != nullptr));
+
+    // The DestroyGameEffect at the end of this function will delete any linked effects
+    // as well so we make a copy of the linked effects and send those for unpacking
+    API::CGameEffect *leftLinkEff = nullptr;
+    if (eff->m_pLinkLeft != nullptr)
+    {
+        leftLinkEff = new API::CGameEffect(true);
+        leftLinkEff->CopyEffect(eff->m_pLinkLeft, 0);
+    }
+    Services::Events::InsertArgument(stack, leftLinkEff);
+    Services::Events::InsertArgument(stack, eff->m_pLinkLeft != nullptr);
+
+    API::CGameEffect *rightLinkEff = nullptr;
+    if (eff->m_pLinkRight != nullptr)
+    {
+        rightLinkEff = new API::CGameEffect(true);
+        rightLinkEff->CopyEffect(eff->m_pLinkRight, 0);
+    }
+    Services::Events::InsertArgument(stack, rightLinkEff);
+    Services::Events::InsertArgument(stack, eff->m_pLinkRight != nullptr);
 
     Services::Events::InsertArgument(stack, (int32_t)eff->m_nNumIntegers);
     Services::Events::InsertArgument(stack, (int32_t)(eff->m_nNumIntegers > 0 ? eff->m_nParamInteger[0] : -1));

--- a/Plugins/Effect/NWScript/nwnx_effect_t.nss
+++ b/Plugins/Effect/NWScript/nwnx_effect_t.nss
@@ -18,7 +18,11 @@ void printeff(struct NWNX_EffectUnpacked n)
     s += "nCasterLevel = " + IntToString(n.nCasterLevel) + "\n";
 
     s += "bLinkLeftValid = " + IntToString(n.bLinkLeftValid) + "\n";
+    struct NWNX_EffectUnpacked link = NWNX_Effect_UnpackEffect(n.eLinkLeft);
+    s += "bLinkLeft (nType) = " + IntToString(link.nType) + "\n";
     s += "bLinkRightValid = " + IntToString(n.bLinkRightValid) + "\n";
+    link = NWNX_Effect_UnpackEffect(n.eLinkRight);
+    s += "bLinkRight (nType) = " + IntToString(link.nType) + "\n";
 
     s += "nNumIntegers = " + IntToString(n.nNumIntegers) + "\n";
     s += "nParam0 = " + IntToString(n.nParam0) + "\n";
@@ -61,7 +65,9 @@ void main()
 {
     WriteTimestampedLogEntry("NWNX_Effect unit test begin..");
 
-    effect e = EffectCurse(1, 2, 3, 4, 5, 6);
+    effect eCurse = EffectCurse(1, 2, 3, 4, 5, 6);
+    effect eVis = EffectVisualEffect(VFX_DUR_PROT_STONESKIN);
+    effect e = EffectLinkEffects(eCurse, eVis);
     e = TagEffect(e, "NWNX_EFFECT_TEST");
 
     struct NWNX_EffectUnpacked unpacked = NWNX_Effect_UnpackEffect(e);


### PR DESCRIPTION
Fixes #594 