### PR TITLE
metrics: Resamplers::Discard doesn't need to be a template

### DIFF
--- a/NWNXLib/Services/Metrics/Resamplers.cpp
+++ b/NWNXLib/Services/Metrics/Resamplers.cpp
@@ -228,44 +228,7 @@ std::vector<MetricData> Resamplers::Max<float>(std::vector<MetricData>&& data)
         [](const float& val) -> std::string { return std::to_string(val); });
 }
 
-template <>
-std::vector<MetricData> Resamplers::Discard<std::chrono::nanoseconds>(std::vector<MetricData>&&)
-{
-    return std::vector<MetricData>();
-}
-
-template <>
-std::vector<MetricData> Resamplers::Discard<int64_t>(std::vector<MetricData>&&)
-{
-    return std::vector<MetricData>();
-}
-
-template <>
-std::vector<MetricData> Resamplers::Discard<uint64_t>(std::vector<MetricData>&&)
-{
-    return std::vector<MetricData>();
-}
-
-template<>
-std::vector<MetricData> Resamplers::Discard<double>(std::vector<MetricData>&&)
-{
-    return std::vector<MetricData>();
-}
-
-template<>
-std::vector<MetricData> Resamplers::Discard<int32_t>(std::vector<MetricData>&&)
-{
-    return std::vector<MetricData>();
-}
-
-template<>
-std::vector<MetricData> Resamplers::Discard<uint32_t>(std::vector<MetricData>&&)
-{
-    return std::vector<MetricData>();
-}
-
-template<>
-std::vector<MetricData> Resamplers::Discard<float>(std::vector<MetricData>&&)
+std::vector<MetricData> Resamplers::Discard(std::vector<MetricData>&&)
 {
     return std::vector<MetricData>();
 }

--- a/NWNXLib/Services/Metrics/Resamplers.hpp
+++ b/NWNXLib/Services/Metrics/Resamplers.hpp
@@ -28,7 +28,6 @@ public:
     template <typename T>
     static std::vector<MetricData> Max(std::vector<MetricData>&& data);
 
-    template <typename T>
     static std::vector<MetricData> Discard(std::vector<MetricData>&& data);
 
     template <typename T>

--- a/NWNXLib/Services/Metrics/Resamplers.inl
+++ b/NWNXLib/Services/Metrics/Resamplers.inl
@@ -30,15 +30,6 @@ template<> std::vector<MetricData> Resamplers::Max<int32_t>(std::vector<MetricDa
 template<> std::vector<MetricData> Resamplers::Max<uint32_t>(std::vector<MetricData>&&);
 template<> std::vector<MetricData> Resamplers::Max<float>(std::vector<MetricData>&&);
 
-template<> std::vector<MetricData> Resamplers::Discard<std::chrono::nanoseconds>(std::vector<MetricData>&&);
-template<> std::vector<MetricData> Resamplers::Discard<int64_t>(std::vector<MetricData>&&);
-template<> std::vector<MetricData> Resamplers::Discard<uint64_t>(std::vector<MetricData>&&);
-template<> std::vector<MetricData> Resamplers::Discard<double>(std::vector<MetricData>&&);
-template<> std::vector<MetricData> Resamplers::Discard<int32_t>(std::vector<MetricData>&&);
-template<> std::vector<MetricData> Resamplers::Discard<uint32_t>(std::vector<MetricData>&&);
-template<> std::vector<MetricData> Resamplers::Discard<float>(std::vector<MetricData>&&);
-
-
 template <typename T>
 std::vector<MetricData> Resamplers::Sum(std::vector<MetricData>&& data,
     std::function<T(const std::string&)>&& fromString,

--- a/Plugins/Profiler/Timing.cpp
+++ b/Plugins/Profiler/Timing.cpp
@@ -53,7 +53,7 @@ void FastTimer::Calibrate(const size_t runs, ViewPtr<HooksProxy> hooks, ViewPtr<
     g_metricsForCalibration = metrics;
 
     // Set up a discard resampler for this one.
-    auto resampler = &Resamplers::template Discard<int64_t>;
+    auto resampler = &Resamplers::Discard;
     metrics->SetResampler("FAST_TIMER_OVERHEAD_CALIBRATION", resampler, std::chrono::seconds(10));
 
     const auto runTest = [](const size_t targetRuns) -> std::chrono::nanoseconds


### PR DESCRIPTION
It doesn't depend on the template parameter and is just a null function.