### PR TITLE
services/events: Change Events::Push value param from const& to T&&

### DIFF
--- a/NWNXLib/Services/Events/Events.hpp
+++ b/NWNXLib/Services/Events/Events.hpp
@@ -58,7 +58,7 @@ public:
     ~Events();
 
     template <typename T>
-    void Push(const std::string& pluginName, const std::string& eventName, const T& value);
+    void Push(const std::string& pluginName, const std::string& eventName, T&& value);
 
     template <typename T>
     Maybe<T> Pop(const std::string& pluginName, const std::string& eventName);

--- a/NWNXLib/Services/Events/Events.inl
+++ b/NWNXLib/Services/Events/Events.inl
@@ -1,10 +1,10 @@
 
 template <typename T>
-void Events::Push(const std::string& pluginName, const std::string& eventName, const T& value)
+void Events::Push(const std::string& pluginName, const std::string& eventName, T&& value)
 {
     if (auto* event = GetEventData(pluginName, eventName))
     {
-        event->m_arguments.push(Events::Argument(value));
+        event->m_arguments.push(Events::Argument(std::forward<T>(value)));
         LOG_DEBUG("Pushing argument '%s'. Event '%s', Plugin: '%s'.",
             event->m_arguments.top(), eventName, pluginName);
     }


### PR DESCRIPTION
By binding to const& every NWNX Push string event is incurring an extra copy when passed a temporary (which the CoreVM does).  Change it from const& to T&& and use perfect forwarding.