### PR TITLE
services: Remove ServicesBase

### DIFF
--- a/NWNXLib/Services/Commands/Commands.hpp
+++ b/NWNXLib/Services/Commands/Commands.hpp
@@ -10,7 +10,7 @@
 namespace NWNXLib {
 namespace Services {
 
-class Commands : public ServiceBase
+class Commands
 {
 public:
     using CommandFunc = void (*)(std::string&);

--- a/NWNXLib/Services/Config/Config.hpp
+++ b/NWNXLib/Services/Config/Config.hpp
@@ -9,7 +9,7 @@ namespace NWNXLib {
 
 namespace Services {
 
-class Config : public ServiceBase
+class Config
 {
 public:
     Config();

--- a/NWNXLib/Services/Events/Events.hpp
+++ b/NWNXLib/Services/Events/Events.hpp
@@ -17,7 +17,7 @@ namespace NWNXLib {
 
 namespace Services {
 
-class Events : public ServiceBase
+class Events
 {
 public: // Structures
     struct Argument

--- a/NWNXLib/Services/Hooks/Hooks.hpp
+++ b/NWNXLib/Services/Hooks/Hooks.hpp
@@ -22,7 +22,7 @@ namespace Services {
 // In the case of shared hook mode, a landing site is magically generated (using thiscall
 // calling convention) and events are dispatched to each hook one-by-one.
 
-class Hooks : public ServiceBase
+class Hooks
 {
 public: // Structures
     enum class Type

--- a/NWNXLib/Services/Messaging/Messaging.hpp
+++ b/NWNXLib/Services/Messaging/Messaging.hpp
@@ -12,7 +12,7 @@ namespace NWNXLib {
 
 namespace Services {
 
-class Messaging : public ServiceBase
+class Messaging
 {
 public: // Structures
     using Tag = std::string;

--- a/NWNXLib/Services/Metrics/Metrics.hpp
+++ b/NWNXLib/Services/Metrics/Metrics.hpp
@@ -16,7 +16,7 @@ namespace Services {
 
 class Tasks;
 
-class Metrics : public ServiceBase
+class Metrics
 {
 public: // Structures
     using MetricDataCallback = std::function<void(const std::vector<MetricData>&)>;

--- a/NWNXLib/Services/PerObjectStorage/PerObjectStorage.hpp
+++ b/NWNXLib/Services/PerObjectStorage/PerObjectStorage.hpp
@@ -15,7 +15,7 @@ namespace NWNXLib {
 
 namespace Services {
 
-class PerObjectStorage : public ServiceBase
+class PerObjectStorage
 {
 public:
     using CleanupFunc = void (*)(void*);

--- a/NWNXLib/Services/Plugins/Plugins.hpp
+++ b/NWNXLib/Services/Plugins/Plugins.hpp
@@ -12,7 +12,7 @@
 
 namespace NWNXLib::Services {
 
-class Plugins : public ServiceBase
+class Plugins
 {
 public: // Structures
     using PluginID = uint8_t;

--- a/NWNXLib/Services/Services.hpp
+++ b/NWNXLib/Services/Services.hpp
@@ -38,12 +38,6 @@ struct ProxyServiceList
     std::unique_ptr<CommandsProxy> m_commands;
 };
 
-struct ServiceBase
-{
-public:
-    ServiceBase() { }
-};
-
 template <typename T>
 struct ServiceProxy
 {

--- a/NWNXLib/Services/Tasks/Tasks.hpp
+++ b/NWNXLib/Services/Tasks/Tasks.hpp
@@ -38,7 +38,7 @@ private:
     bool m_finished;
 };
 
-class Tasks : public ServiceBase
+class Tasks
 {
 public: // Structures
     using ThreadWorkItem = std::function<void()>;


### PR DESCRIPTION
It seems to serve no purpose.  I can't imagine runtime polymorphism being very useful here.  I could be wrong tho.