### PR TITLE
Player: Possess NPC using familiar functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ N/A
 - Administration: {Get|Set}DebugValue()
 - Data: Array_Set()
 - Object: Export()
+- Player: PossessCreature()
 - Util: AddScript()
 
 ### Changed

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -234,6 +234,22 @@ void NWNX_Player_SetPersistentLocation(string sCDKeyOrCommunityName, string sBic
 /// @param oItem The item object.
 void NWNX_Player_UpdateItemName(object oPlayer, object oItem);
 
+/// @brief Possesses a creature by temporarily making them a familiar
+/// @details This command allows a PC to possess an NPC by temporarily adding them as a familiar. It will work
+/// if the player already has an existing familiar. The creatures must be in the same area. Unpossession can be
+/// done with the regular @nwn{UnpossessFamiliar} commands.
+/// @note The possessed creature will send automap data back to the possessor.
+/// If you wish to prevent this you may wish to use NWNX_Player_GetAreaExplorationState() and
+/// NWNX_Player_SetAreaExplorationState() before and after the possession.
+/// @note The possessing creature will be left wherever they were when beginning the possession. You may wish
+/// to use @nwn{EffectCutsceneImmobilize} and @nwn{EffectCutsceneGhost} to hide them.
+/// @param oPossessor The possessor player object.
+/// @param oPossessed The possessed creature object. Only works on NPCs.
+/// @param bMindImmune If FALSE will remove the mind immunity effect on the possessor.
+/// @param bCreateDefaultQB If TRUE will populate the quick bar with default buttons.
+/// @return TRUE if possession succeeded.
+int NWNX_Player_PossessCreature(object oPossessor, object oPossessed, int bMindImmune = TRUE, int bCreateDefaultQB = FALSE);
+
 /// @}
 
 void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable)
@@ -593,7 +609,7 @@ int NWNX_Player_GetQuestCompleted(object player, string sQuestName)
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);
 
     NWNX_CallFunction(NWNX_Player, sFunc);
-    return  NWNX_GetReturnValueInt(NWNX_Player, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Player, sFunc);
 }
 
 void NWNX_Player_SetPersistentLocation(string sCDKeyOrCommunityName, string sBicFileName, object oWP, int bFirstConnectOnly = TRUE)
@@ -616,4 +632,17 @@ void NWNX_Player_UpdateItemName(object oPlayer, object oItem)
     NWNX_PushArgumentObject(NWNX_Player, sFunc, oPlayer);
 
     NWNX_CallFunction(NWNX_Player, sFunc);
+}
+
+int NWNX_Player_PossessCreature(object oPossessor, object oPossessed, int bMindImmune = TRUE, int bCreateDefaultQB = FALSE)
+{
+    string sFunc = "PossessCreature";
+
+    NWNX_PushArgumentInt(NWNX_Player, sFunc, bCreateDefaultQB);
+    NWNX_PushArgumentInt(NWNX_Player, sFunc, bMindImmune);
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, oPossessed);
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, oPossessor);
+
+    NWNX_CallFunction(NWNX_Player, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Player, sFunc);
 }

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -1256,7 +1256,7 @@ ArgumentStack Player::PossessCreature(ArgumentStack&& args)
         pUnsummonMyselfHook = GetServices()->m_hooks->FindHookByAddress(Functions::_ZN12CNWSCreature14UnsummonMyselfEv);
 
         GetServices()->m_hooks->RequestExclusiveHook<Functions::_ZN12CNWSCreature15PossessFamiliarEv>(
-                +[](CNWSCreature *pPossessor, Types::ObjectID possessedOidPOS) -> void
+                +[](CNWSCreature *pPossessor) -> void
                 {
                     auto *pPOS = g_plugin->GetServices()->m_perObjectStorage.get();
                     auto possessorOidPOS = *pPOS->Get<int>(pPossessor->m_idSelf, "possessorOid");
@@ -1266,7 +1266,7 @@ ArgumentStack Player::PossessCreature(ArgumentStack&& args)
                     }
                     else
                     {
-                        pPossessFamiliarHook->CallOriginal<void>(pPossessor, possessedOidPOS);
+                        pPossessFamiliarHook->CallOriginal<void>(pPossessor);
                     }
                 });
         pPossessFamiliarHook = GetServices()->m_hooks->FindHookByAddress(Functions::_ZN12CNWSCreature15PossessFamiliarEv);

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -101,6 +101,7 @@ Player::Player(const Plugin::CreateParams& params)
     REGISTER(GetQuestCompleted);
     REGISTER(SetPersistentLocation);
     REGISTER(UpdateItemName);
+    REGISTER(PossessCreature);
 
 #undef REGISTER
 
@@ -1181,6 +1182,151 @@ ArgumentStack Player::UpdateItemName(ArgumentStack&& args)
             pMessage->SendServerToPlayerUpdateItemName(pPlayer, pItem);
         }
     }
+    return stack;
+}
+
+ArgumentStack Player::PossessCreature(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    const auto possessorId = Services::Events::ExtractArgument<Types::ObjectID>(args);
+    const auto possessedId = Services::Events::ExtractArgument<Types::ObjectID>(args);
+    const auto bMindImmune = Services::Events::ExtractArgument<int>(args);
+    const auto bCreateQB = Services::Events::ExtractArgument<int>(args);
+
+    auto pServer = Globals::AppManager()->m_pServerExoApp;
+    auto *pPossessor = pServer->GetCreatureByGameObjectID(possessorId);
+    if (!pPossessor || !pPossessor->m_bPlayerCharacter)
+    {
+        LOG_ERROR("Attempt to possess a creature with an invalid possessor.");
+        Services::Events::InsertArgument(stack, 0);
+        return stack;
+    }
+    auto *pPossessed = pServer->GetCreatureByGameObjectID(possessedId);
+    if (!pPossessed || pPossessed->m_bPlayerCharacter)
+    {
+        LOG_ERROR("Attempt to possess an invalid creature.");
+        Services::Events::InsertArgument(stack, 0);
+        return stack;
+    }
+    if (pPossessor->m_oidArea != pPossessed->m_oidArea)
+    {
+        LOG_ERROR("Attempt to possess a creature not in the current area.");
+        Services::Events::InsertArgument(stack, 0);
+        return stack;
+    }
+    if (pServer->GetIsControlledByPlayer(possessedId))
+    {
+        LOG_ERROR("Attempt to possess a creature already possessed.");
+        Services::Events::InsertArgument(stack, 0);
+        return stack;
+    }
+    auto *pPOS = g_plugin->GetServices()->m_perObjectStorage.get();
+    auto possessedOidPOS = *pPOS->Get<int>(pPossessor->m_idSelf, "possessedOid");
+    if (possessedOidPOS)
+    {
+        LOG_ERROR("Attempt to possess a creature while already possessing.");
+        Services::Events::InsertArgument(stack, 0);
+        return stack;
+    }
+    static NWNXLib::Hooking::FunctionHook* pUnsummonMyselfHook;
+    static NWNXLib::Hooking::FunctionHook* pPossessFamiliarHook;
+
+    if (!pUnsummonMyselfHook)
+    {
+        // When a PC is logging off we don't want this creature to unsummon themselves
+        GetServices()->m_hooks->RequestExclusiveHook<Functions::_ZN12CNWSCreature14UnsummonMyselfEv>(
+                +[](CNWSCreature *pPossessed) -> void
+                {
+                    auto *pPOS = g_plugin->GetServices()->m_perObjectStorage.get();
+                    auto possessorOidPOS = *pPOS->Get<int>(pPossessed->m_idSelf, "possessorOid");
+                    auto pServer = Globals::AppManager()->m_pServerExoApp;
+                    auto *pPossessor = pServer->GetCreatureByGameObjectID(possessorOidPOS);
+                    if (pPossessor)
+                    {
+                        pPossessor->UnpossessFamiliar();
+                        pPossessor->RemoveAssociate(pPossessed->m_idSelf);
+                        pPOS->Remove(pPossessor->m_idSelf, "possessedOid");
+                        pPOS->Remove(pPossessed->m_idSelf, "possessorOid");
+                    }
+                    else
+                    {
+                        pUnsummonMyselfHook->CallOriginal<void>(pPossessed);
+                    }
+                });
+        pUnsummonMyselfHook = GetServices()->m_hooks->FindHookByAddress(Functions::_ZN12CNWSCreature14UnsummonMyselfEv);
+
+        GetServices()->m_hooks->RequestExclusiveHook<Functions::_ZN12CNWSCreature15PossessFamiliarEv>(
+                +[](CNWSCreature *pPossessor, Types::ObjectID possessedOidPOS) -> void
+                {
+                    auto *pPOS = g_plugin->GetServices()->m_perObjectStorage.get();
+                    auto possessorOidPOS = *pPOS->Get<int>(pPossessor->m_idSelf, "possessorOid");
+                    if (possessorOidPOS)
+                    {
+                        LOG_ERROR("Attempt to possess a familiar while already possessing.");
+                    }
+                    else
+                    {
+                        pPossessFamiliarHook->CallOriginal<void>(pPossessor, possessedOidPOS);
+                    }
+                });
+        pPossessFamiliarHook = GetServices()->m_hooks->FindHookByAddress(Functions::_ZN12CNWSCreature15PossessFamiliarEv);
+
+        GetServices()->m_hooks->RequestSharedHook<Functions::_ZN12CNWSCreature17UnpossessFamiliarEv, int32_t>(
+                +[](Services::Hooks::CallType type, CNWSCreature *pPossessor) -> void
+                {
+                    if (type == Services::Hooks::CallType::AFTER_ORIGINAL)
+                    {
+                        auto *pPOS = g_plugin->GetServices()->m_perObjectStorage.get();
+                        auto possessedOidPOS = *pPOS->Get<int>(pPossessor->m_idSelf, "possessedOid");
+                        if (possessedOidPOS)
+                        {
+                            pPossessor->RemoveAssociate(possessedOidPOS);
+                            pPOS->Remove(pPossessor->m_idSelf, "possessedOid");
+                            pPOS->Remove(possessedOidPOS, "possessorOid");
+                        }
+                    }
+                });
+    }
+
+    // If they already have a familiar we temporarily remove it as an associate
+    // then we add the possessed creature as a familiar. We then add the regular familiar back.
+    // This is because PossessFamiliar looks for the first associate of type familiar.
+    auto pFamiliarId = pPossessor->GetAssociateId(3, 1);
+    if (pFamiliarId)
+        pPossessor->RemoveAssociate(pFamiliarId);
+
+    pPossessor->AddAssociate(possessedId, 3);
+    pPossessor->PossessFamiliar();
+
+    if (pFamiliarId)
+        pPossessor->AddAssociate(pFamiliarId, 3);
+
+    if (bCreateQB)
+        pPossessed->CreateDefaultQuickButtons();
+
+    pPOS->Set(possessorId, "possessedOid", (int32_t)possessedId);
+    pPOS->Set(possessedId, "possessorOid", (int32_t)possessorId);
+
+    // Familiar possession gives the possessor mind immunity, we remove it if we don't want that
+    if (!bMindImmune)
+    {
+        for (int i = 0; i < pPossessor->m_appliedEffects.num; i++)
+        {
+            auto *eff = pPossessor->m_appliedEffects.element[i];
+            if (eff->m_nType == Constants::EffectTrueType::Immunity &&
+                eff->m_nSubType == Constants::EffectSubType::Magical &&
+                eff->m_oidCreator == pPossessor->m_idSelf &&
+                eff->m_fDuration == 4.0f &&
+                eff->m_nCasterLevel == -1 &&
+                eff->m_nParamInteger[0] == Constants::ImmunityType::MindSpells &&
+                eff->m_nParamInteger[1] == Constants::RacialType::Invalid)
+            {
+                pPossessor->RemoveEffectById(eff->m_nID);
+                break;
+            }
+        }
+    }
+    Services::Events::InsertArgument(stack, 1);
     return stack;
 }
 

--- a/Plugins/Player/Player.hpp
+++ b/Plugins/Player/Player.hpp
@@ -46,6 +46,7 @@ private:
     ArgumentStack GetQuestCompleted                 (ArgumentStack&& args);
     ArgumentStack SetPersistentLocation             (ArgumentStack&& args);
     ArgumentStack UpdateItemName                    (ArgumentStack&& args);
+    ArgumentStack PossessCreature                   (ArgumentStack&& args);
 
     CNWSPlayer *player(ArgumentStack& args);
 


### PR DESCRIPTION
Resolves #231. Adds the NPC as a player's familiar momentarily and then possesses the NPC. It works if the player already has a familiar summoned. Only PCs can possess, and only NPCs can be possessed.

To unpossess via script just use stock NWN `UnpossessFamiliar()`. PCs can unpossess with regular radial dial/hot keys.