### PR TITLE
gitignore: Add some lines for Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 Binaries/
 build-nwnx/
 Documentation/
+
+# Visual Studio
+.vs/
+out/
+CMakeSettings.json


### PR DESCRIPTION
I think it's support for Linux projects and the coming .net core makes VS Community Edition a pretty compelling choice for nwnx:ee development.