### PR TITLE
Make sure only the title <h3> is hidden

### DIFF
--- a/docgen/custom.css
+++ b/docgen/custom.css
@@ -341,4 +341,5 @@ img.footer {
 /**             NWNX:EE Custom              **/
 /*********************************************/
 .contents h3 {display:none}
+.contents .textblock h3 {display:block}
 .headertitle .title {font-size: 200%}


### PR DESCRIPTION
Doxygen takes the README.md file name and puts the word "Readme" as the page title. We don't want this so I hid the `.contents h3` tag. That's too greedy though, so we make sure `.contents .textblock h3` displays properly.