### PR TITLE
Docker: update Dockerfile for 64bit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ COPY --from=builder /nwnx/home/Binaries/* /nwn/nwnx/
 
 # Install plugin run dependencies
 RUN runDeps="hunspell \
-    libmariadbclient18 \
+    libmariadb3 \
     libpq-dev \
     libsqlite3-dev \
-    libruby2.3 \
+    libruby2.5 \
     luajit libluajit-5.1 \
     libssl1.1 \
     inotify-tools \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY ./ .
 # Compile nwnx
 RUN Scripts/buildnwnx.sh -j $(nproc)
 
-FROM beamdog/nwserver
+FROM beamdog/nwserver:8192
 RUN mkdir /nwn/nwnx
 COPY --from=builder /nwnx/home/Binaries/* /nwn/nwnx/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,15 @@ RUN runDeps="hunspell \
     luajit libluajit-5.1 \
     libssl1.1 \
     inotify-tools \
-    patch" \
+    patch \
+    dotnet-sdk-3.0" \
+    installDeps="ca-certificates wget gpg apt-transport-https" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends $installDeps \
+    && wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg \
+    && wget -q https://packages.microsoft.com/config/debian/10/prod.list \
+    && mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/ \
+    && mv prod.list /etc/apt/sources.list.d/microsoft-prod.list \
     && apt-get update \
     && apt-get -y install --no-install-recommends $runDeps \
     && rm -r /var/cache/apt /var/lib/apt/lists


### PR DESCRIPTION
Adds the .NET SDK

~~It's failing to run, due to the following error:~~

~~```./nwserver-linux: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.11' not found (required by /nwn/nwnx/NWNX_Core.so)```~~

~~I think because the beamdog/nwserver image is on debian-stretch, while we build nwnx on debian-buster.~~


