### PR TITLE
Fix issues with ExecuteScript{Chunk} in DotNET

### DIFF
--- a/NWNXLib/Utils.cpp
+++ b/NWNXLib/Utils.cpp
@@ -409,6 +409,8 @@ int PushScriptContext(API::Types::ObjectID oid, bool valid)
     {
         vm->m_cRunTimeStack.InitializeStack();
         vm->m_cRunTimeStack.m_pVMachine = vm;
+        vm->m_nInstructPtrLevel = 0;
+        vm->m_nInstructionsExecuted = 0;
     }
 
     vm->m_oidObjectRunScript[vm->m_nRecursionLevel]    = oid;


### PR DESCRIPTION
Crash was due to unitinialized function index. Missing prints due to uninintialized TMI counter having a huge value, so it'd TMI immediately.