### PR TITLE
Core: provide a better error message when trying to call a nwnx function with outdated nwnx_*.nss scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ N/A
 - Area: GetMusicIsPlaying()
 
 ### Changed
-N/A
+- Core: NWNX will now provide you with better error messages when you try to call a NWScript NWNX function and you haven't updated your nwnx_*.nss files or the plugin is not loaded.
 
 ### Deprecated
 N/A

--- a/Core/NWNXCore.hpp
+++ b/Core/NWNXCore.hpp
@@ -29,6 +29,8 @@ public:
     static int32_t TagItemPropertyHandler(CNWVirtualMachineCommands*, int32_t, int32_t);
     static int32_t PlaySoundHandler(CNWVirtualMachineCommands*, int32_t, int32_t);
 
+    std::unique_ptr<NWNXLib::Services::ServiceList> m_services;
+
 private: // Structures
     using PluginProxyServiceMap = std::map<
         NWNXLib::Services::Plugins::RegistrationToken,
@@ -39,7 +41,6 @@ private: // Structures
 
 private:
     std::unique_ptr<NWNXLib::Hooking::FunctionHook> m_createServerHook;
-    std::unique_ptr<NWNXLib::Services::ServiceList> m_services;
     std::unique_ptr<NWNXLib::Services::ProxyServiceList> m_coreServices;
     PluginProxyServiceMap m_pluginProxyServiceMap;
 

--- a/NWNXLib/Services/Events/Events.cpp
+++ b/NWNXLib/Services/Events/Events.cpp
@@ -2,15 +2,18 @@
 #include "API/CExoString.hpp"
 #include "API/CGameEffect.hpp"
 #include "Utils.hpp"
+#include "../../../Core/NWNXCore.hpp"
 
 #include <algorithm>
 #include <array>
 #include <cstring>
 #include <sstream>
 
-namespace NWNXLib {
+namespace Core {
+extern NWNXCore* g_core;
+}
 
-namespace Services {
+namespace NWNXLib::Services {
 
 Events::Events()
 {
@@ -49,7 +52,18 @@ void Events::Call(const std::string& pluginName, const std::string& eventName)
     }
     else
     {
-        LOG_ERROR("Plugin '%s' does not have an event '%s' registered", pluginName, eventName);
+        std::string pluginNameWithoutPrefix = pluginName.substr(5, pluginName.length() - 5);
+
+        if (!Core::g_core->m_services->m_plugins->FindPluginByName(pluginNameWithoutPrefix))
+        {
+            LOG_ERROR("Plugin '%s' is not loaded but NWScript '%s' tried to call function '%s'.",
+                    pluginName, Utils::GetCurrentScript(), eventName);
+        }
+        else
+        {
+            LOG_ERROR("Plugin '%s' does not have an event '%s' registered. (NWScript: '%s', are your nwnx_*.nss files up to date?)",
+                    pluginName, eventName, Utils::GetCurrentScript());
+        }
     }
 }
 
@@ -160,8 +174,6 @@ std::string Events::Argument::toString() const
     if (m_effect) return *m_effect ? std::string("EffectID:") + std::to_string((*m_effect)->m_nID) : std::string("nullptr effect");
 
     return std::string("");
-}
-
 }
 
 }


### PR DESCRIPTION
Resolves #684

Will also give an error message when you try to call a nwnx function but the plugin is not loaded.