### PR TITLE
POS: Fix persistence for PCs. This simplifies a lot of things.

### DIFF
--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -178,10 +178,8 @@ void NWNXCore::InitialSetupHooks()
     m_services->m_hooks->RequestSharedHook<API::Functions::_ZN8CNWSAreaD0Ev, void>(&Services::PerObjectStorage::CNWSArea__CNWSAreaDtor__0_hook);
     m_services->m_hooks->RequestSharedHook<API::Functions::_ZN10CNWSPlayer7EatTURDEP14CNWSPlayerTURD, void>(&Services::PerObjectStorage::CNWSPlayer__EatTURD_hook);
     m_services->m_hooks->RequestSharedHook<API::Functions::_ZN10CNWSPlayer8DropTURDEv, void>(&Services::PerObjectStorage::CNWSPlayer__DropTURD_hook);
-    m_services->m_hooks->RequestSharedHook<API::Functions::_ZN10CNWSObject15SaveObjectStateEP7CResGFFP10CResStruct, void>(&Services::PerObjectStorage::CNWSObject__SaveObjectState_hook);
-    m_services->m_hooks->RequestSharedHook<API::Functions::_ZN10CNWSObject15LoadObjectStateEP7CResGFFP10CResStruct, void>(&Services::PerObjectStorage::CNWSObject__LoadObjectState_hook);
-    m_services->m_hooks->RequestSharedHook<API::Functions::_ZN12CNWSCreature12SaveCreatureEP7CResGFFP10CResStructiiii, int32_t>(&Services::PerObjectStorage::CNWSCreature__SaveCreature_hook);
-    m_services->m_hooks->RequestSharedHook<API::Functions::_ZN12CNWSCreature12LoadCreatureEP7CResGFFP10CResStructiiii, int32_t>(&Services::PerObjectStorage::CNWSCreature__LoadCreature_hook);
+    m_services->m_hooks->RequestSharedHook<API::Functions::_ZN8CNWSUUID9SaveToGffEP7CResGFFP10CResStruct, void>(&Services::PerObjectStorage::CNWSUUID__SaveToGff_hook);
+    m_services->m_hooks->RequestSharedHook<API::Functions::_ZN8CNWSUUID11LoadFromGffEP7CResGFFP10CResStruct, void>(&Services::PerObjectStorage::CNWSUUID__LoadFromGff_hook);
 
     m_services->m_hooks->RequestSharedHook<API::Functions::_ZN10CNWSModule20LoadModuleInProgressEii, uint32_t>(
             +[](bool before, CNWSModule *pModule, int32_t nAreasLoaded, int32_t nAreasToLoad)

--- a/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
+++ b/NWNXLib/Services/PerObjectStorage/PerObjectStorage.cpp
@@ -5,7 +5,7 @@
 #include "API/CNWSPlayer.hpp"
 #include "API/CNWSPlayerTURD.hpp"
 #include "API/CNWSModule.hpp"
-#include "API/CNWSCreature.hpp"
+#include "API/CNWSUUID.hpp"
 #include "API/CExoLinkedListInternal.hpp"
 #include "API/CExoLinkedListNode.hpp"
 #include "API/Constants.hpp"
@@ -419,46 +419,23 @@ void PerObjectStorage::CNWSPlayer__DropTURD_hook(bool before, CNWSPlayer* thisPt
     }
 }
 
-void PerObjectStorage::CNWSObject__SaveObjectState_hook(bool before, CNWSObject* pThis, CResGFF* pRes, CResStruct* pStruct)
-{
-    if (!before)
-    {
-        if (Utils::AsNWSCreature(pThis))
-            return;
 
-        pRes->WriteFieldCExoString(pStruct, GetObjectStorage(pThis)->Serialize(), GffFieldName);
-    }
-}
-void PerObjectStorage::CNWSObject__LoadObjectState_hook(bool before, CNWSObject* pThis, CResGFF* pRes, CResStruct* pStruct)
+void PerObjectStorage::CNWSUUID__SaveToGff_hook(bool before, CNWSUUID* pThis, CResGFF* pRes, CResStruct* pStruct)
 {
     if (before)
     {
-        if (Utils::AsNWSCreature(pThis))
-            return;
-
-        int32_t success;
-        auto str = pRes->ReadFieldCExoString(pStruct, GffFieldName, success);
-        if (success)
-            GetObjectStorage(pThis)->Deserialize(str.CStr());
+        pRes->WriteFieldCExoString(pStruct, GetObjectStorage(pThis->m_parent)->Serialize(), GffFieldName);
     }
 }
-void PerObjectStorage::CNWSCreature__SaveCreature_hook(bool before, CNWSCreature *pThis, CResGFF * pRes, CResStruct * pStruct, BOOL, BOOL, BOOL, BOOL)
-{
-    if (!before)
-    {
-        pRes->WriteFieldCExoString(pStruct, GetObjectStorage(pThis)->Serialize(), GffFieldName);
-    }
-}
-void PerObjectStorage::CNWSCreature__LoadCreature_hook(bool before, CNWSCreature *pThis, CResGFF * pRes, CResStruct * pStruct, BOOL, BOOL, BOOL, BOOL)
+void PerObjectStorage::CNWSUUID__LoadFromGff_hook(bool before, CNWSUUID* pThis, CResGFF* pRes, CResStruct* pStruct)
 {
     if (before)
     {
         int32_t success;
         auto str = pRes->ReadFieldCExoString(pStruct, GffFieldName, success);
         if (success)
-            GetObjectStorage(pThis)->Deserialize(str.CStr());
+            GetObjectStorage(pThis->m_parent)->Deserialize(str.CStr());
     }
 }
-
 
 }

--- a/NWNXLib/Services/PerObjectStorage/PerObjectStorage.hpp
+++ b/NWNXLib/Services/PerObjectStorage/PerObjectStorage.hpp
@@ -40,10 +40,8 @@ public:
     static void CNWSArea__CNWSAreaDtor__0_hook(bool, CNWSArea* thisPtr);
     static void CNWSPlayer__EatTURD_hook(bool, CNWSPlayer* thisPtr, CNWSPlayerTURD* pTURD);
     static void CNWSPlayer__DropTURD_hook(bool, CNWSPlayer* thisPtr);
-    static void CNWSObject__SaveObjectState_hook(bool, CNWSObject* pThis, CResGFF* pRes, CResStruct* pStruct);
-    static void CNWSObject__LoadObjectState_hook(bool, CNWSObject* pThis, CResGFF* pRes, CResStruct* pStruct);
-    static void CNWSCreature__LoadCreature_hook(bool, CNWSCreature* pThis, CResGFF * pRes, CResStruct * cCreatureStruct, BOOL bIsSaveGame, BOOL bIsAssociate, BOOL bPreserveItemIds, BOOL bCopyObject);
-    static void CNWSCreature__SaveCreature_hook(bool, CNWSCreature* pThis, CResGFF * pRes, CResStruct * pStruct, BOOL bStoreAssociateList, BOOL bUseDesiredAreaInfo, BOOL bExportingChar, BOOL bSaveOIDs);
+    static void CNWSUUID__SaveToGff_hook(bool, CNWSUUID* pThis, CResGFF* pRes, CResStruct* pStruct);
+    static void CNWSUUID__LoadFromGff_hook(bool, CNWSUUID* pThis, CResGFF* pRes, CResStruct* pStruct);
 private:
     class ObjectStorage
     {


### PR DESCRIPTION
I'm still getting mixed results when the server goes down while the PCs are there, but the same mixed results also happen for other bic stuff (like the UUID that this is piggy-backing on) so just "don't do that".