### PR TITLE
Scroll learning freeze fix attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ N/A
 ### Changed
 - ELC: Updated for custom spellcaster changes
 - Events: exposed TARGET and TYPE event data for DMActionEvent DumpLocals
+- Tweaks: added temporary fix for server freeze when learning a spell from a scroll (NWNX_TWEAKS_FIX_SCROLL_LEARNING_BUG)
 
 ### Deprecated
 - Creature: {Get|Set}{ClericDomain|WizardSpecialization}()

--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -14,4 +14,5 @@ add_plugin(Tweaks
     "Tweaks/DeadCreatureFiresOnAreaExit.cpp"
     "Tweaks/PreserveActionsOnDMPossess.cpp"
     "Tweaks/FixGreaterSanctuaryBug.cpp"
+    "Tweaks/FixScrollLearningBug.cpp"
 )

--- a/Plugins/Tweaks/Tweaks.cpp
+++ b/Plugins/Tweaks/Tweaks.cpp
@@ -13,6 +13,7 @@
 #include "Tweaks/DeadCreatureFiresOnAreaExit.hpp"
 #include "Tweaks/PreserveActionsOnDMPossess.hpp"
 #include "Tweaks/FixGreaterSanctuaryBug.hpp"
+#include "Tweaks/FixScrollLearningBug.hpp"
 
 #include "Services/Config/Config.hpp"
 
@@ -129,6 +130,12 @@ Tweaks::Tweaks(const Plugin::CreateParams& params)
     {
         LOG_INFO("Greater sanctuary bug fixed.");
         m_FixGreaterSanctuaryBug = std::make_unique<FixGreaterSanctuaryBug>(GetServices()->m_hooks.get());
+    }
+
+    if (GetServices()->m_config->Get<bool>("FIX_SCROLL_LEARNING_BUG", false))
+    {
+        LOG_INFO("Scroll learning freeze bug fixed.");
+        m_FixScrollLearningBug = std::make_unique<FixScrollLearningBug>(GetServices()->m_hooks.get());
     }
 }
 

--- a/Plugins/Tweaks/Tweaks.hpp
+++ b/Plugins/Tweaks/Tweaks.hpp
@@ -19,6 +19,7 @@ class StringToIntBaseToAuto;
 class DeadCreatureFiresOnAreaExit;
 class PreserveActionsOnDMPossess;
 class FixGreaterSanctuaryBug;
+class FixScrollLearningBug;
 
 class Tweaks : public NWNXLib::Plugin
 {
@@ -41,6 +42,7 @@ private:
     std::unique_ptr<DeadCreatureFiresOnAreaExit> m_DeadCreatureFiresOnAreaExit;
     std::unique_ptr<PreserveActionsOnDMPossess> m_PreserveActionsOnDMPossess;
     std::unique_ptr<FixGreaterSanctuaryBug> m_FixGreaterSanctuaryBug;
+    std::unique_ptr<FixScrollLearningBug> m_FixScrollLearningBug;
 };
 
 }

--- a/Plugins/Tweaks/Tweaks/FixScrollLearningBug.cpp
+++ b/Plugins/Tweaks/Tweaks/FixScrollLearningBug.cpp
@@ -66,11 +66,11 @@ BOOL FixScrollLearningBug::CNWSCreature__LearnScroll_hook(CNWSCreature *pThis, O
     }
 
     if (!pItemRepository) //Not present in decompiled code
-        return 0;
+        return false;
     
     if (!pItemRepository->GetItemInRepository(pItem, 0)) {
         pThis->SendFeedbackMessage(0xdc, nullptr, nullptr);
-        return 0;
+        return false;
     }
 
     int nFeedback = 0;

--- a/Plugins/Tweaks/Tweaks/FixScrollLearningBug.cpp
+++ b/Plugins/Tweaks/Tweaks/FixScrollLearningBug.cpp
@@ -1,0 +1,146 @@
+#include "Tweaks/FixScrollLearningBug.hpp"
+
+#include "Services/Hooks/Hooks.hpp"
+#include "Utils.hpp"
+
+#include "API/CItemRepository.hpp"
+#include "API/CNWClass.hpp"
+#include "API/CNWCCMessageData.hpp"
+#include "API/CNWRules.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/CNWSCreatureStats.hpp"
+#include "API/CNWSItem.hpp"
+#include "API/CNWSpellArray.hpp"
+#include "API/CNWSPlayer.hpp"
+#include "API/Constants.hpp"
+#include "API/Functions.hpp"
+#include "API/Globals.hpp"
+#include "API/CAppManager.hpp"
+#include "API/CServerExoApp.hpp"
+#include "API/CTwoDimArrays.hpp"
+#include "API/C2DA.hpp"
+
+namespace Tweaks {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+FixScrollLearningBug::FixScrollLearningBug(Services::HooksProxy* hooker)
+{
+    hooker->RequestExclusiveHook<Functions::_ZN12CNWSCreature11LearnScrollEj>
+                                    (&CNWSCreature__LearnScroll_hook);
+}
+
+BOOL FixScrollLearningBug::CNWSCreature__LearnScroll_hook(CNWSCreature *pThis, OBJECT_ID oidScrollToLearn)
+{
+
+    auto pServerExoApp = Globals::AppManager()->m_pServerExoApp;
+
+    auto pItem = pServerExoApp->GetItemByGameObjectID(oidScrollToLearn);
+    if (!pItem || pItem->m_nBaseItem != Constants::BaseItem::SpellScroll) {
+        pThis->SendFeedbackMessage(0x4e, nullptr, nullptr);
+        return false;
+    }
+
+    auto pActiveProperty = pItem->GetActiveProperty(0);
+    if (!pActiveProperty)
+        return false;
+
+    int nSpellIndex;
+    Globals::Rules()->m_p2DArrays->m_pIPRPSpells->GetINTEntry(pActiveProperty->m_nSubType, CExoString("SpellIndex"), &nSpellIndex);
+    
+    auto pSpell = Globals::Rules()->m_pSpellArray->GetSpell(nSpellIndex);
+    if (!pSpell)
+        return false;
+
+    auto pPlayer = pServerExoApp->GetClientObjectByObjectId(pThis->m_idSelf);
+    if (pPlayer && !pPlayer->HasExpansionPack(Globals::Rules()->GetSpellExpansionLevel(nSpellIndex), 1))
+        return false;
+
+    CItemRepository* pItemRepository = nullptr;
+    auto pPossessor = pServerExoApp->GetGameObject(pItem->m_oidPossessor);
+    if (pPossessor) {
+        if (pPossessor->m_nObjectType == Constants::ObjectType::Creature) {
+            pItemRepository = pPossessor->AsNWSCreature()->m_pcItemRepository;
+        } else if (pPossessor->m_nObjectType == Constants::ObjectType::Item) {
+            pItemRepository = pPossessor->AsNWSItem()->m_pItemRepository;
+        }
+    }
+
+    if (!pItemRepository) //Not present in decompiled code
+        return 0;
+    
+    if (!pItemRepository->GetItemInRepository(pItem, 0)) {
+        pThis->SendFeedbackMessage(0xdc, nullptr, nullptr);
+        return 0;
+    }
+
+    /*if (pThis->m_pStats->m_nNumMultiClasses == 0) {
+        pThis->SendFeedbackMessage(0x4f, nullptr, nullptr);
+        return 0;
+    }*/
+
+    int nFeedback = 0;
+    bool bLearned = false;
+    for (int nMultiClass = 0; nMultiClass < pThis->m_pStats->m_nNumMultiClasses; nMultiClass++) {
+        auto nClass = pThis->m_pStats->GetClass(nMultiClass);
+        if (Globals::Rules()->m_lstClasses[nClass].m_bCanLearnFromScrolls) {
+            auto nSpellLevel = pSpell->GetSpellLevel(nClass);
+            if (nSpellLevel == (uint8_t) -1) {
+                nFeedback = 0xe0;
+                continue;
+            }
+            auto nSpellGain = pThis->m_pStats->GetSpellGainWithBonus(nMultiClass, nSpellLevel);
+            if (nSpellGain == 0) {
+                nFeedback = 0x50;
+                continue;
+            }
+            if (!pThis->m_pStats->GetSpellMinAbilityMet(nMultiClass, nSpellLevel)) {
+                nFeedback = 0x51;
+                continue;
+            }
+            auto nSchool = pThis->m_pStats->GetSchool(nMultiClass);
+            if (nSchool) {
+                int nOppositeSchool = 0;
+                auto pSchoolTable = Globals::Rules()->m_p2DArrays->m_pSpellSchoolTable;
+                auto bFound = pSchoolTable->GetINTEntry(nSchool, "Opposition", &nOppositeSchool);
+                if (bFound && pSpell->m_nSchool == nOppositeSchool) {
+                    nFeedback = 0xdb;
+                    continue;
+                }
+            }
+
+            auto nKnownSpells = pThis->m_pStats->GetNumberKnownSpells(nMultiClass, nSpellLevel);
+            bool bKnownSpell = false;
+            for (int i = 0; i < nKnownSpells && !bKnownSpell; i++) {
+                if (pThis->m_pStats->GetKnownSpell(nMultiClass, nSpellLevel, i) == nSpellIndex) {
+                    nFeedback = 0xdd;
+                    bKnownSpell = true;
+                }
+            }
+
+            if (bKnownSpell)
+                continue;
+
+            pThis->m_pStats->AddKnownSpell(nMultiClass, nSpellIndex);
+            bLearned = true;
+        }
+    }
+
+    if (!bLearned) {
+        pThis->SendFeedbackMessage(nFeedback ? nFeedback : 0x4f, nullptr, nullptr);
+        return 0;
+    }
+
+    if (pItem->m_nStackSize < 2)
+        pThis->RemoveItem(pItem, 1, 1, 0, 1);
+    else
+        pItem->m_nStackSize -= 1;
+
+    CNWCCMessageData* pMessageData = new CNWCCMessageData();
+    pMessageData->SetInteger(0, nSpellIndex);
+    pThis->SendFeedbackMessage(0xde, pMessageData, nullptr);
+    return 1;
+}
+
+}

--- a/Plugins/Tweaks/Tweaks/FixScrollLearningBug.hpp
+++ b/Plugins/Tweaks/Tweaks/FixScrollLearningBug.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "Common.hpp"
+#include "Services/Hooks/Hooks.hpp"
+
+namespace Tweaks {
+
+class FixScrollLearningBug
+{
+public:
+    FixScrollLearningBug(NWNXLib::Services::HooksProxy* hooker);
+
+private:
+    static BOOL CNWSCreature__LearnScroll_hook(CNWSCreature *, OBJECT_ID);
+};
+
+}


### PR DESCRIPTION
This is an attempt at fixing the server freeze when trying to learn a spell from a scroll.
So far I tested it by trying to learn an already known spell:
![image](https://user-images.githubusercontent.com/1606943/73039178-5ce6e700-3e55-11ea-983b-812b746fc17f.png)

Learning a spell from an opposite school:
![image](https://user-images.githubusercontent.com/1606943/73039208-75570180-3e55-11ea-8c8c-dc1bfd873d53.png)

Learning a spell when all requirements are met:
![image](https://user-images.githubusercontent.com/1606943/73039300-bc44f700-3e55-11ea-87c5-dc30512cebec.png)

What I haven't been able to test yet: Learning a spell when the minimum characteristic isn't met and learning a spell from a higher level than you can cast.
I haven't set up any custom caster classes so I can't test that either. Also, client prevents using the learn action if the class can't learn from scrolls so that should never happen and can't be tested.