### PR TITLE
ServerLogRedirector: hook PrintString() instead

### DIFF
--- a/Plugins/ServerLogRedirector/ServerLogRedirector.cpp
+++ b/Plugins/ServerLogRedirector/ServerLogRedirector.cpp
@@ -32,7 +32,7 @@ using namespace NWNXLib;
 using namespace NWNXLib::API;
 using namespace NWNXLib::Services;
 
-static bool writeTimestampedLogEntry;
+static bool printString;
 
 ServerLogRedirector::ServerLogRedirector(const Plugin::CreateParams& params)
     : Plugin(params)
@@ -44,8 +44,8 @@ ServerLogRedirector::ServerLogRedirector(const Plugin::CreateParams& params)
     GetServices()->m_hooks->RequestSharedHook<Functions::_ZN17CExoDebugInternal16WriteToErrorFileERK10CExoString,
         void, CExoDebugInternal*, CExoString*>(&WriteToErrorFileHook);
 
-    GetServices()->m_hooks->RequestSharedHook<Functions::_ZN25CNWVirtualMachineCommands27ExecuteCommandPrintLogEntryEii,
-        int32_t>(+[](bool before, CNWVirtualMachineCommands*, int32_t, int32_t){ writeTimestampedLogEntry = before; });
+    GetServices()->m_hooks->RequestSharedHook<Functions::_ZN25CNWVirtualMachineCommands25ExecuteCommandPrintStringEii,
+        int32_t>(+[](bool before, CNWVirtualMachineCommands*, int32_t, int32_t){ printString = before; });
 }
 
 ServerLogRedirector::~ServerLogRedirector()
@@ -56,7 +56,7 @@ inline std::string TrimMessage(CExoString* message)
 {
     std::string s = std::string(message->CStr());
 
-    if (writeTimestampedLogEntry)
+    if (!printString)
     {
         // Eat the auto-added timestamp.
         auto idxOfBracket = s.find_first_of(']');


### PR DESCRIPTION
Otherwise timestamps from other stuff doesn't get stripped:

`I [22:37:27] [NWNX_ServerLogRedirector] (Server) [Sun Jan 26 22:37:27] XXXXXXX (YYYYYY) Joined as Player 1`