### PR TITLE
Adding suggested improvement from GoLot - to handle exit event firing…

### DIFF
--- a/Plugins/Events/Events/StealthEvents.cpp
+++ b/Plugins/Events/Events/StealthEvents.cpp
@@ -49,7 +49,7 @@ void StealthEvents::SetStealthModeHook(CNWSCreature* thisPtr, uint8_t nStealthMo
 
         Events::SignalEvent("NWNX_ON_ENTER_STEALTH_AFTER", thisPtr->m_idSelf);
     }
-    else
+    else if(currentlyStealthed && !willBeStealthed)
     {
         if (Events::SignalEvent("NWNX_ON_EXIT_STEALTH_BEFORE", thisPtr->m_idSelf))
         {

--- a/Plugins/Factions/CMakeLists.txt
+++ b/Plugins/Factions/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_plugin(Factions
+    "Factions.cpp")

--- a/Plugins/Factions/Factions.cpp
+++ b/Plugins/Factions/Factions.cpp
@@ -62,7 +62,7 @@ Factions::~Factions()
 ArgumentStack Factions::GetFactionId(ArgumentStack&& args)
 {
 	int32_t retVal = -1;
-	    if (auto *pCreature = creature(args))
+	    if (auto *pCreature = Creature(args))
 	    {
 	        auto *faction = pCreature->GetFaction();
 			retVal = faction->m_nFactionId;
@@ -74,7 +74,7 @@ ArgumentStack Factions::SetFaction(ArgumentStack&& args)
 {
     int32_t retVal = -1;
 
-    if (auto *pObject = object(args))
+    if (auto *pObject = Object(args))
     {
         
 		  

--- a/Plugins/Factions/Factions.cpp
+++ b/Plugins/Factions/Factions.cpp
@@ -83,7 +83,7 @@ ArgumentStack Factions::SetFaction(ArgumentStack&& args)
 	    }else if (auto *pGameObject = Globals::AppManager()->m_pServerExoApp->GetGameObject(objectId))
         {
   		  const auto nFacId = Services::Events::ExtractArgument<int32_t>(args);
-  		  auto* pFactionManager= Globals::AppManager()->m_pServerExoApp->m_pcExoAppInternal->m_pFactionManager->GetFaction(nFacId);
+  		  auto* pFaction= Globals::AppManager()->m_pServerExoApp->m_pcExoAppInternal->m_pFactionManager->GetFaction(nFacId);
   		  if (pFaction){
   		      pFaction->AddMember(objectId);
   			  retVal = 1;

--- a/Plugins/Factions/Factions.cpp
+++ b/Plugins/Factions/Factions.cpp
@@ -79,8 +79,8 @@ ArgumentStack Factions::SetFaction(ArgumentStack&& args)
         
 		  
 		  const auto nFacId = Services::Events::ExtractArgument<int32_t>(args);
-		  
-		  auto* pFaction = Globals::AppManager()->m_pServerExoApp->m_pcExoAppInternal->m_pFactionManager->GetFaction(nFacId);
+		  auto* pFactionManager= lobals::AppManager()->m_pServerExoApp->m_pcExoAppInternal->m_pFactionManager;
+		  auto* pFaction = pFactionManager->GetFaction(nFacId);
 		  if (pFaction){
 		      pFaction->AddMember(pObject);
 			  retVal = 1;

--- a/Plugins/Factions/Factions.cpp
+++ b/Plugins/Factions/Factions.cpp
@@ -7,6 +7,8 @@
 #include "API/Functions.hpp"
 #include "API/CNWSFaction.hpp"
 #include "API/CNWSCreature.hpp"
+#include "API/CServerExoAppInternal.hpp"
+#include "API/CFactionManager.hpp"
 #include "Services/Events/Events.hpp"
 #include "Services/PerObjectStorage/PerObjectStorage.hpp"
 

--- a/Plugins/Factions/Factions.cpp
+++ b/Plugins/Factions/Factions.cpp
@@ -1,0 +1,95 @@
+#include "Appearance.hpp"
+
+#include "API/CAppManager.hpp"
+#include "API/CServerExoApp.hpp"
+#include "API/Constants.hpp"
+#include "API/Globals.hpp"
+#include "API/Functions.hpp"
+#include "API/CNWSFaction.hpp"
+#include "API/CNWSCreature.hpp"
+#include "Services/Events/Events.hpp"
+#include "Services/PerObjectStorage/PerObjectStorage.hpp"
+
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+static Appearance::Appearance* g_plugin;
+
+NWNX_PLUGIN_ENTRY Plugin::Info* PluginInfo()
+{
+    return new Plugin::Info
+    {
+        "Factions",
+        "Allows retrieval of faction id as well as changing faction by id",
+        "Baaleos",
+        "Baaleos@azmodan.net",
+        1,
+        true
+    };
+}
+
+NWNX_PLUGIN_ENTRY Plugin* PluginLoad(Plugin::CreateParams params)
+{
+    g_plugin = new Factions::Factions(params);
+    return g_plugin;
+}
+
+
+namespace Factions {
+
+Factions::Factions(const Plugin::CreateParams& params)
+    : Plugin(params)
+{
+#define REGISTER(func) \
+    GetServices()->m_events->RegisterEvent(#func, \
+        [this](ArgumentStack&& args){ return func(std::move(args)); })
+
+    REGISTER(GetFactionId);
+    REGISTER(SetFaction);
+
+#undef REGISTER
+
+    
+}
+
+Factions::~Factions()
+{
+}
+
+
+
+ArgumentStack Factions::GetFactionId(ArgumentStack&& args)
+{
+	int32_t retVal = -1;
+	    if (auto *pCreature = creature(args))
+	    {
+	        auto *faction = pCreature->GetFaction();
+			retVal = faction->m_nFactionId;
+	    }
+    return Services::Events::Arguments(retVal);
+}
+
+ArgumentStack Factions::SetFaction(ArgumentStack&& args)
+{
+    int32_t retVal = -1;
+
+    if (auto *pObject = object(args))
+    {
+        
+		  
+		  const auto nFacId = Services::Events::ExtractArgument<int32_t>(args);
+		  
+		  auto* pFaction = Globals::AppManager()->m_pServerExoApp->m_pcExoAppInternal->m_pFactionManager->GetFaction(nFacId);
+		  if (pFaction){
+		      pFaction->AddMember(pObject);
+			  retVal = 1;
+		  }
+
+        
+    }
+
+    return Services::Events::Arguments(retVal);
+}
+
+}

--- a/Plugins/Factions/Factions.cpp
+++ b/Plugins/Factions/Factions.cpp
@@ -76,21 +76,20 @@ ArgumentStack Factions::SetFaction(ArgumentStack&& args)
 {
     int32_t retVal = -1;
 
-    if (auto *pObject = Object(args))
-    {
-        
-		  
-		  const auto nFacId = Services::Events::ExtractArgument<int32_t>(args);
-		  auto* pFactionManager= Globals::AppManager()->m_pServerExoApp->m_pcExoAppInternal->m_pFactionManager;
-		  auto* pFaction = pFactionManager->GetFaction(nFacId);
-		  if (pFaction){
-		      pFaction->AddMember(pObject);
-			  retVal = 1;
-		  }
-
-        
-    }
-
+	const auto objectId = Services::Events::ExtractArgument<Types::ObjectID>(args);
+	if (objectId == Constants::OBJECT_INVALID)
+	    {
+	        LOG_NOTICE("NWNX_Faction SetFaction called on OBJECT_INVALID");
+	    }else if (auto *pGameObject = Globals::AppManager()->m_pServerExoApp->GetGameObject(objectId))
+        {
+  		  const auto nFacId = Services::Events::ExtractArgument<int32_t>(args);
+  		  auto* pFactionManager= Globals::AppManager()->m_pServerExoApp->m_pcExoAppInternal->m_pFactionManager->GetFaction(nFacId);
+  		  if (pFaction){
+  		      pFaction->AddMember(pObject);
+  			  retVal = 1;
+  		  }
+			
+        }
     return Services::Events::Arguments(retVal);
 }
 

--- a/Plugins/Factions/Factions.cpp
+++ b/Plugins/Factions/Factions.cpp
@@ -1,4 +1,4 @@
-#include "Appearance.hpp"
+#include "Factions.hpp"
 
 #include "API/CAppManager.hpp"
 #include "API/CServerExoApp.hpp"

--- a/Plugins/Factions/Factions.cpp
+++ b/Plugins/Factions/Factions.cpp
@@ -14,7 +14,7 @@
 using namespace NWNXLib;
 using namespace NWNXLib::API;
 
-static Appearance::Appearance* g_plugin;
+static Factions::Factions* g_plugin;
 
 NWNX_PLUGIN_ENTRY Plugin::Info* PluginInfo()
 {

--- a/Plugins/Factions/Factions.cpp
+++ b/Plugins/Factions/Factions.cpp
@@ -79,7 +79,7 @@ ArgumentStack Factions::SetFaction(ArgumentStack&& args)
         
 		  
 		  const auto nFacId = Services::Events::ExtractArgument<int32_t>(args);
-		  auto* pFactionManager= lobals::AppManager()->m_pServerExoApp->m_pcExoAppInternal->m_pFactionManager;
+		  auto* pFactionManager= Globals::AppManager()->m_pServerExoApp->m_pcExoAppInternal->m_pFactionManager;
 		  auto* pFaction = pFactionManager->GetFaction(nFacId);
 		  if (pFaction){
 		      pFaction->AddMember(pObject);

--- a/Plugins/Factions/Factions.cpp
+++ b/Plugins/Factions/Factions.cpp
@@ -85,7 +85,7 @@ ArgumentStack Factions::SetFaction(ArgumentStack&& args)
   		  const auto nFacId = Services::Events::ExtractArgument<int32_t>(args);
   		  auto* pFactionManager= Globals::AppManager()->m_pServerExoApp->m_pcExoAppInternal->m_pFactionManager->GetFaction(nFacId);
   		  if (pFaction){
-  		      pFaction->AddMember(pObject);
+  		      pFaction->AddMember(objectId);
   			  retVal = 1;
   		  }
 			

--- a/Plugins/Factions/Factions.hpp
+++ b/Plugins/Factions/Factions.hpp
@@ -16,7 +16,8 @@ public:
     virtual ~Factions();
 
 private:
-    
+    static CNWSCreature *Creature(ArgumentStack& args);
+	static CNWSObject *Object(ArgumentStack& args);
     ArgumentStack GetFactionId (ArgumentStack&& args);
     ArgumentStack SetFaction (ArgumentStack&& args);
 };

--- a/Plugins/Factions/Factions.hpp
+++ b/Plugins/Factions/Factions.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Services/Events/Events.hpp"
 #include "Plugin.hpp"
 #include <map>
 #include <bitset>
@@ -16,11 +17,6 @@ public:
 
 private:
     
-
-    
-
-    
-
     ArgumentStack GetFactionId (ArgumentStack&& args);
     ArgumentStack SetFaction (ArgumentStack&& args);
 };

--- a/Plugins/Factions/Factions.hpp
+++ b/Plugins/Factions/Factions.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Plugin.hpp"
+#include <map>
+#include <bitset>
+
+using ArgumentStack = NWNXLib::Services::Events::ArgumentStack;
+
+namespace Factions {
+
+class Factions : public NWNXLib::Plugin
+{
+public:
+    Factions(const Plugin::CreateParams& params);
+    virtual ~Factions();
+
+private:
+    
+
+    
+
+    
+
+    ArgumentStack GetFactionId (ArgumentStack&& args);
+    ArgumentStack SetFaction (ArgumentStack&& args);
+};
+
+}

--- a/Plugins/Factions/Factions.hpp
+++ b/Plugins/Factions/Factions.hpp
@@ -17,7 +17,7 @@ public:
 
 private:
     static CNWSCreature *Creature(ArgumentStack& args);
-	static CNWSObject *Object(ArgumentStack& args);
+	static OBJECT_ID *Object(ArgumentStack& args);
     ArgumentStack GetFactionId (ArgumentStack&& args);
     ArgumentStack SetFaction (ArgumentStack&& args);
 };

--- a/Plugins/Factions/NWScript/nwnx_factions.nss
+++ b/Plugins/Factions/NWScript/nwnx_factions.nss
@@ -1,0 +1,73 @@
+/// @addtogroup appearance Appearance
+/// @brief Allows the appearance and some other things of creatures to be overridden per player.
+/// @{
+/// @file nwnx_appearance.nss
+#include "nwnx"
+
+const string NWNX_Appearance = "NWNX_Appearance"; ///< @private
+
+/// @name Appearance Types
+/// @anchor appearance_types
+///
+/// The various types of changes that can be made to how a PC is perceived.
+/// @{
+const int NWNX_APPEARANCE_TYPE_APPEARANCE       = 0; ///< APPEARANCE_TYPE_* or -1 to remove
+const int NWNX_APPEARANCE_TYPE_GENDER           = 1; ///< GENDER_* or -1 to remove
+
+/// @brief 0-GetMaxHitPoints(oCreature) or -1 to remove
+/// @note This is visual only. Does not change the Examine Window health status.
+const int NWNX_APPEARANCE_TYPE_HITPOINTS        = 2;
+const int NWNX_APPEARANCE_TYPE_HAIR_COLOR       = 3; ///< 0-175 or -1 to remove
+const int NWNX_APPEARANCE_TYPE_SKIN_COLOR       = 4; ///< 0-175 or -1 to remove
+const int NWNX_APPEARANCE_TYPE_PHENOTYPE        = 5; ///< PHENOTYPE_* or -1 to remove
+const int NWNX_APPEARANCE_TYPE_HEAD_TYPE        = 6; ///< 0-? or -1 to remove
+const int NWNX_APPEARANCE_TYPE_SOUNDSET         = 7; ///< See soundset.2da or -1 to remove
+const int NWNX_APPEARANCE_TYPE_TAIL_TYPE        = 8; ///< CREATURE_TAIL_TYPE_* or see tailmodel.2da, -1 to remove
+const int NWNX_APPEARANCE_TYPE_WING_TYPE        = 9; ///< CREATURE_WING_TYPE_* or see wingmodel.2da, -1 to remove
+const int NWNX_APPEARANCE_TYPE_FOOTSTEP_SOUND   = 10; ///< 0-17 or see footstepsounds.2da, -1 to remove
+
+/// @brief See portraits.2da, -1 to remove
+/// @note Does not change the Examine Window portrait.
+const int NWNX_APPEARANCE_TYPE_PORTRAIT         = 11;
+///@}
+
+/// @brief Override a creature's appearance type for a player.
+/// @param oPlayer The player who will see/hear things differently.
+/// @param oCreature The target creature whose appearance type to alter for oPlayer. Can be a PC.
+/// @param nType The @ref appearance_types "Appearance Type" to set or -1 to fully remove override.
+/// @param nValue The new value for the appearance type.
+void NWNX_Appearance_SetOverride(object oPlayer, object oCreature, int nType, int nValue);
+
+/// @brief Get a creature's appearance type for a player.
+/// @param oPlayer The player who see/hear things differently.
+/// @param oCreature The target creature whose appearance type is altered for oPlayer. Can be a PC.
+/// @param nType The @ref appearance_types "Appearance Type" to get.
+/// @return The value for the appearance type or -1 when not set.
+int NWNX_Appearance_GetOverride(object oPlayer, object oCreature, int nType);
+
+/// @}
+
+void NWNX_Appearance_SetOverride(object oPlayer, object oCreature, int nType, int nValue)
+{
+    string sFunc = "SetOverride";
+
+    NWNX_PushArgumentInt(NWNX_Appearance, sFunc, nValue);
+    NWNX_PushArgumentInt(NWNX_Appearance, sFunc, nType);
+    NWNX_PushArgumentObject(NWNX_Appearance, sFunc, oCreature);
+    NWNX_PushArgumentObject(NWNX_Appearance, sFunc, oPlayer);
+
+    NWNX_CallFunction(NWNX_Appearance, sFunc);
+}
+
+int NWNX_Appearance_GetOverride(object oPlayer, object oCreature, int nType)
+{
+    string sFunc = "GetOverride";
+
+    NWNX_PushArgumentInt(NWNX_Appearance, sFunc, nType);
+    NWNX_PushArgumentObject(NWNX_Appearance, sFunc, oCreature);
+    NWNX_PushArgumentObject(NWNX_Appearance, sFunc, oPlayer);
+
+    NWNX_CallFunction(NWNX_Appearance, sFunc);
+
+    return NWNX_GetReturnValueInt(NWNX_Appearance, sFunc);
+}

--- a/Plugins/Factions/NWScript/nwnx_factions.nss
+++ b/Plugins/Factions/NWScript/nwnx_factions.nss
@@ -4,70 +4,35 @@
 /// @file nwnx_appearance.nss
 #include "nwnx"
 
-const string NWNX_Appearance = "NWNX_Appearance"; ///< @private
+const string NWNX_Factions = "NWNX_Factions"; ///< @private
 
-/// @name Appearance Types
-/// @anchor appearance_types
-///
-/// The various types of changes that can be made to how a PC is perceived.
-/// @{
-const int NWNX_APPEARANCE_TYPE_APPEARANCE       = 0; ///< APPEARANCE_TYPE_* or -1 to remove
-const int NWNX_APPEARANCE_TYPE_GENDER           = 1; ///< GENDER_* or -1 to remove
 
-/// @brief 0-GetMaxHitPoints(oCreature) or -1 to remove
-/// @note This is visual only. Does not change the Examine Window health status.
-const int NWNX_APPEARANCE_TYPE_HITPOINTS        = 2;
-const int NWNX_APPEARANCE_TYPE_HAIR_COLOR       = 3; ///< 0-175 or -1 to remove
-const int NWNX_APPEARANCE_TYPE_SKIN_COLOR       = 4; ///< 0-175 or -1 to remove
-const int NWNX_APPEARANCE_TYPE_PHENOTYPE        = 5; ///< PHENOTYPE_* or -1 to remove
-const int NWNX_APPEARANCE_TYPE_HEAD_TYPE        = 6; ///< 0-? or -1 to remove
-const int NWNX_APPEARANCE_TYPE_SOUNDSET         = 7; ///< See soundset.2da or -1 to remove
-const int NWNX_APPEARANCE_TYPE_TAIL_TYPE        = 8; ///< CREATURE_TAIL_TYPE_* or see tailmodel.2da, -1 to remove
-const int NWNX_APPEARANCE_TYPE_WING_TYPE        = 9; ///< CREATURE_WING_TYPE_* or see wingmodel.2da, -1 to remove
-const int NWNX_APPEARANCE_TYPE_FOOTSTEP_SOUND   = 10; ///< 0-17 or see footstepsounds.2da, -1 to remove
 
-/// @brief See portraits.2da, -1 to remove
-/// @note Does not change the Examine Window portrait.
-const int NWNX_APPEARANCE_TYPE_PORTRAIT         = 11;
-///@}
+/// @brief returns an integer representing the faction id used for a creatures faction affiliation.
+/// @param oCreature The creature who's faction id we wish to get - note currently only works for creatures.
+void NWNX_Factions_GetFactionId(object oCreature);
 
-/// @brief Override a creature's appearance type for a player.
-/// @param oPlayer The player who will see/hear things differently.
-/// @param oCreature The target creature whose appearance type to alter for oPlayer. Can be a PC.
-/// @param nType The @ref appearance_types "Appearance Type" to set or -1 to fully remove override.
-/// @param nValue The new value for the appearance type.
-void NWNX_Appearance_SetOverride(object oPlayer, object oCreature, int nType, int nValue);
-
-/// @brief Get a creature's appearance type for a player.
-/// @param oPlayer The player who see/hear things differently.
-/// @param oCreature The target creature whose appearance type is altered for oPlayer. Can be a PC.
-/// @param nType The @ref appearance_types "Appearance Type" to get.
-/// @return The value for the appearance type or -1 when not set.
-int NWNX_Appearance_GetOverride(object oPlayer, object oCreature, int nType);
+/// @brief Sets the faction id of a target object to nFaction
+/// @param oObject - should work with any object type
+/// @param nFaction - this should be an integer retrieved from the GetFactionId method
+/// @return -1 = Unsuccessful, 1 = Successful : In the event of Unsuccessful, check that the target object and faction id are valid.
+int NWNX_Factions_SetFactionId(object oObject, int nFaction);
 
 /// @}
 
-void NWNX_Appearance_SetOverride(object oPlayer, object oCreature, int nType, int nValue)
+void NWNX_Factions_GetFactionId(object oCreature)
 {
-    string sFunc = "SetOverride";
-
-    NWNX_PushArgumentInt(NWNX_Appearance, sFunc, nValue);
-    NWNX_PushArgumentInt(NWNX_Appearance, sFunc, nType);
-    NWNX_PushArgumentObject(NWNX_Appearance, sFunc, oCreature);
-    NWNX_PushArgumentObject(NWNX_Appearance, sFunc, oPlayer);
-
-    NWNX_CallFunction(NWNX_Appearance, sFunc);
+    string sFunc = "GetFactionId";
+    NWNX_PushArgumentObject(NWNX_Factions, sFunc, oObject);
+    NWNX_CallFunction(NWNX_Factions, sFunc);
 }
 
-int NWNX_Appearance_GetOverride(object oPlayer, object oCreature, int nType)
+int NWNX_Factions_SetFactionId(object oObject, int nFaction))
 {
-    string sFunc = "GetOverride";
+    string sFunc = "SetFactionId";
 
-    NWNX_PushArgumentInt(NWNX_Appearance, sFunc, nType);
-    NWNX_PushArgumentObject(NWNX_Appearance, sFunc, oCreature);
-    NWNX_PushArgumentObject(NWNX_Appearance, sFunc, oPlayer);
-
-    NWNX_CallFunction(NWNX_Appearance, sFunc);
-
-    return NWNX_GetReturnValueInt(NWNX_Appearance, sFunc);
+    NWNX_PushArgumentInt(NWNX_Factions, sFunc, nFaction);
+    NWNX_PushArgumentObject(NWNX_Factions, sFunc, oObject);
+    NWNX_CallFunction(NWNX_Factions, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Factions, sFunc);
 }

--- a/Plugins/Factions/README.md
+++ b/Plugins/Factions/README.md
@@ -1,0 +1,4 @@
+@page appearance Readme
+@ingroup appearance
+
+Allows the appearance and some other things of creatures to be overridden per player.


### PR DESCRIPTION
… when skip is called when not desired.
Discussed in detail here:
https://github.com/nwnxee/unified/issues/776

Essentially - skipping the onEnter event, was calling the onExit event - when not necessarily desired.
This could cause recursive loops if both events skipped.