### PR TITLE
Effect applied modified to catch instant effects

### DIFF
--- a/Plugins/Events/Events/EffectEvents.cpp
+++ b/Plugins/Events/Events/EffectEvents.cpp
@@ -27,7 +27,7 @@ void EffectEvents::HandleEffectHook(const std::string& event, bool before, CNWSO
 {
     int32_t effectDurationType = pEffect->m_nSubType & EffectDurationType::MASK;
 
-    if (effectDurationType != EffectDurationType::Temporary && effectDurationType != EffectDurationType::Permanent)
+    if (effectDurationType != EffectDurationType::Temporary && effectDurationType != EffectDurationType::Permanent && effectDurationType != EffectDurationType::Instant)
         return;
 
     switch (pEffect->m_nType)


### PR DESCRIPTION
Discussion on discord suggested that the limitation of catching instant effects via events plugin was artificially implemented and 'might' be safe to be removed.

I've removed the limitation in my branch and tested and it does function as expected.
If anyone has any intel on why instant effects should not be caught - please comment.
I can't imagine this change having any detrimental effect to temp or perm effects.

![Greenshot 2020-02-28 11 49 13](https://user-images.githubusercontent.com/6419940/75546564-af9d5b00-5a20-11ea-8982-351eae879256.png)


Hook code I am testing with:
```
public static int Before(uint oid)
        {
            string tag = NWScript.GetTag(NWScript.OBJECT_SELF);
            if (tag.ToLower().Trim() == "eff_unittest")
            {
                int type = Convert.ToInt32(NWNX.Events.GetEventData("TYPE"));
                NWScript.SetLocalInt(NWScript.OBJECT_SELF,"EFFECT_TYPE", type);
            }


            return 0;
        }
```

Unit test code:

```
public bool Test1()
        {
            string resref = "commale005";
            uint area = NWScript.GetFirstArea();
            bool result = false;
            if (NWScript.GetIsObjectValid(area) == 1)
            {


                Area ar = new Area(area);
                uint cre = NWScript.CreateObject(NWScript.OBJECT_TYPE_CREATURE, resref, ar.RandomLocationInArea(), 0, "");
                NWScript.SetTag(cre, "eff_unittest");
                Effect eHeal = NWScript.EffectHeal(10);
                NWScript.ApplyEffectToObject(NWScript.DURATION_TYPE_INSTANT, eHeal, cre);
                int type = NWScript.GetLocalInt(cre, "EFFECT_TYPE");
                if (type != 39) //Heal effect as per NWNX Effects
                {
                    this.Note += "The heal type was not picked up ";
                    result = false;
                }
                else
                {
                    result = true;
                }
                NWScript.DestroyObject(cre,0.25f);

            }
            return result;
        }
```