### PR TITLE
Optimizations::ObjectTagLookup: fix empty string not returning OBJECT_INVALID

### DIFF
--- a/Plugins/Optimizations/Optimizations/ObjectTagLookup.cpp
+++ b/Plugins/Optimizations/Optimizations/ObjectTagLookup.cpp
@@ -53,6 +53,9 @@ int32_t  ObjectTagLookup::RemoveObjectFromLookupTable(void*, CExoString sTag, ui
 
 uint32_t ObjectTagLookup::FindObjectByTagOrdinal(void*, CExoString & sTag, uint32_t nNth)
 {
+    if (sTag.IsEmpty())
+        return Constants::OBJECT_INVALID;
+
     try {
         return m_TagLookupMap.at(sTag.Left(64).CStr()).at(nNth);
     } catch (const std::out_of_range& oor) {}


### PR DESCRIPTION
Resolves #799