### PR TITLE
Events: add ResourceEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 https://github.com/nwnxee/unified/compare/build8193.7...HEAD
 
 ### Added
-N/A
+- Events: Added OnResource{Added|Removed|Modified} events to ResourceEvents, these events fire when a file gets added/removed/modified in the UserDirectory/nwnx folder
 
 ##### New Plugins
 N/A
@@ -54,7 +54,6 @@ https://github.com/nwnxee/unified/compare/build8193.6...build8193.7
 - Area: CreateGenericTrigger()
 - Object: GetPositionIsInTrigger()
 
-
 ### Changed
 - ELC: Updated for custom spellcaster changes
 - Events: exposed TARGET and TYPE event data for DMActionEvent DumpLocals
@@ -70,7 +69,6 @@ https://github.com/nwnxee/unified/compare/build8193.6...build8193.7
 - Core: POS is now saved for characters who were online when the server was shut down
 - Core: Fixed issue where POS would occasionally get corrupted and print errors to the log
 - ServerLogRedirector: Fixed dropped prefixes when using PrintString()
-
 
 ## 8193.6
 https://github.com/nwnxee/unified/compare/build8193.5...build8193.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 https://github.com/nwnxee/unified/compare/build8193.7...HEAD
 
 ### Added
-- Events: Added OnResource{Added|Removed|Modified} events to ResourceEvents, these events fire when a file gets added/removed/modified in the UserDirectory/nwnx folder
+- Events: Added OnResource{Added|Removed|Modified} events to ResourceEvents, these events fire when a file gets added/removed/modified in the /nwnx or /development folders
 
 ##### New Plugins
 N/A

--- a/Plugins/Events/CMakeLists.txt
+++ b/Plugins/Events/CMakeLists.txt
@@ -25,4 +25,5 @@ add_plugin(Events
     "Events/InputEvents.cpp"
     "Events/MaterialChangeEvents.cpp"
     "Events/ObjectEvents.cpp"
-    "Events/UUIDEvents.cpp")
+    "Events/UUIDEvents.cpp"
+    "Events/ResourceEvents.cpp")

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -29,6 +29,7 @@
 #include "Events/MaterialChangeEvents.hpp"
 #include "Events/ObjectEvents.hpp"
 #include "Events/UUIDEvents.hpp"
+#include "Events/ResourceEvents.hpp"
 #include "Services/Config/Config.hpp"
 #include "Services/Messaging/Messaging.hpp"
 
@@ -128,6 +129,7 @@ Events::Events(const Plugin::CreateParams& params)
     m_matChangeEvents   = std::make_unique<MaterialChangeEvents>(hooker);
     m_objectEvents      = std::make_unique<ObjectEvents>(hooker);
     m_uuidEvents        = std::make_unique<UUIDEvents>(hooker);
+    m_resourceEvents    = std::make_unique<ResourceEvents>(GetServices()->m_tasks.get());
 }
 
 Events::~Events()

--- a/Plugins/Events/Events.hpp
+++ b/Plugins/Events/Events.hpp
@@ -39,6 +39,7 @@ class InputEvents;
 class MaterialChangeEvents;
 class ObjectEvents;
 class UUIDEvents;
+class ResourceEvents;
 
 class Events : public NWNXLib::Plugin
 {
@@ -128,6 +129,7 @@ private:
     std::unique_ptr<MaterialChangeEvents> m_matChangeEvents;
     std::unique_ptr<ObjectEvents> m_objectEvents;
     std::unique_ptr<UUIDEvents> m_uuidEvents;
+    std::unique_ptr<ResourceEvents> m_resourceEvents;
 };
 
 }

--- a/Plugins/Events/Events/ResourceEvents.cpp
+++ b/Plugins/Events/Events/ResourceEvents.cpp
@@ -1,0 +1,161 @@
+#include "Events/ResourceEvents.hpp"
+#include "API/CExoBase.hpp"
+#include "API/CExoAliasList.hpp"
+#include "API/CNWSModule.hpp"
+#include "API/CExoResMan.hpp"
+#include "API/Functions.hpp"
+#include "API/Constants.hpp"
+#include "Events.hpp"
+#include "Utils.hpp"
+
+#include <sys/inotify.h>
+#include <unistd.h>
+#include <poll.h>
+#include <climits>
+#include <fcntl.h>
+
+namespace Core {
+    extern bool g_CoreShuttingDown;
+}
+
+namespace Events {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+using namespace NWNXLib::API::Constants;
+
+#define EVENT_SIZE          ( sizeof (struct inotify_event) )
+#define EVENT_BUF_LEN       ( 128 * ( EVENT_SIZE + NAME_MAX + 1) )
+
+static bool processEvents;
+static int selfPipeFds[2];
+std::unique_ptr<std::thread> ResourceEvents::m_pollThread;
+
+ResourceEvents::ResourceEvents(Services::TasksProxy* tasks)
+{
+    Events::InitOnFirstSubscribe("NWNX_ON_RESOURCE_.*", [tasks]()
+    {
+        int ret = pipe2(selfPipeFds, O_NONBLOCK);
+
+        if (ret == -1)
+        {
+            LOG_ERROR("Failed to initialize self-pipe with error: %s", std::strerror(errno));
+            return;
+        }
+
+        int pipeReadFd = selfPipeFds[0];
+        CExoString exoPath = Globals::ExoBase()->m_pcExoAliasList->GetAliasPath("NWNX");
+        std::string path = exoPath.CStr();
+
+        m_pollThread = std::make_unique<std::thread>([tasks, path, pipeReadFd]()
+        {
+            struct pollfd fds[2];
+            char buffer[EVENT_BUF_LEN];
+
+            fds[0].fd = pipeReadFd;
+            fds[0].events = POLLIN;
+
+            int fd = inotify_init1(IN_NONBLOCK), wd = 0;
+
+            if (fd != -1)
+            {
+                fds[1].fd = fd;
+                fds[1].events = POLLIN;
+
+                wd = inotify_add_watch(fd, path.c_str(), IN_CREATE | IN_DELETE | IN_MODIFY);
+
+                if (wd != -1)
+                {
+                    processEvents = true;
+                }
+            }
+
+            auto ProcessEvent = [tasks](const std::string &eventType, const std::string &file) -> void
+            {
+                tasks->QueueOnMainThread([eventType, file]()
+                {
+                    if (Core::g_CoreShuttingDown)
+                        return;
+
+                    LOG_DEBUG("EventType: %s, File: %s", eventType, file);
+
+                    uint16_t resType = Globals::ExoResMan()->GetResTypeFromFile(file);
+
+                    if (resType != 65535)
+                    {
+                        CResRef resRef;
+                        Globals::ExoResMan()->GetResRefFromFile(resRef, file);
+
+                        Events::PushEventData("RESREF", resRef.GetResRefStr());
+                        Events::PushEventData("TYPE", std::to_string(resType));
+                        Events::SignalEvent("NWNX_ON_RESOURCE_" + eventType, Utils::GetModule()->m_idSelf);
+                    }
+                });
+            };
+
+            while (processEvents)
+            {
+                int pollNum = poll(fds, 2, -1);
+
+                if (pollNum > 0)
+                {
+                    if (fds[1].revents & POLLIN)
+                    {
+                        size_t length = read(fd, buffer, EVENT_BUF_LEN);
+
+                        if (length > 0)
+                        {
+                            for (size_t i = 0; i < length;)
+                            {
+                                auto *event = reinterpret_cast<inotify_event *>(&buffer[i]);
+
+                                if (event->len)
+                                {
+                                    if (event->mask & IN_MODIFY)
+                                    {
+                                        ProcessEvent("MODIFIED", event->name);
+                                    }
+                                    else
+                                    if (event->mask & IN_CREATE)
+                                    {
+                                        ProcessEvent("ADDED", event->name);
+                                    }
+                                    else
+                                    if (event->mask & IN_DELETE)
+                                    {
+                                        ProcessEvent("REMOVED", event->name);
+                                    }
+                                }
+
+                                i += (EVENT_SIZE + event->len);
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (wd != -1)
+                inotify_rm_watch(fd, wd);
+            if (fd != -1)
+                close(fd);
+        });
+    });
+}
+
+ResourceEvents::~ResourceEvents()
+{
+    processEvents = false;
+
+    if (m_pollThread)
+    {
+        int ret = write(selfPipeFds[1], "a", 1);
+        (void)ret;
+
+        m_pollThread->join();
+
+        close(selfPipeFds[0]);
+        close(selfPipeFds[1]);
+    }
+}
+
+}

--- a/Plugins/Events/Events/ResourceEvents.hpp
+++ b/Plugins/Events/Events/ResourceEvents.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "API/Vector.hpp"
+#include "Common.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include "Services/Tasks/Tasks.hpp"
+
+#include <thread>
+
+namespace Events {
+
+class ResourceEvents
+{
+public:
+    ResourceEvents(NWNXLib::Services::TasksProxy* tasks);
+    virtual ~ResourceEvents();
+
+private:
+    static std::unique_ptr<std::thread> m_pollThread;
+};
+
+}

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -917,10 +917,11 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
+    ALIAS                 | string | NWNX for /nwnx, DEVELOPMENT for /development
     RESREF                | string | The ResRef of the file
     TYPE                  | int    | The type of the file, see NWNX_UTIL_RESREF_TYPE_*
 
-    Note: These events fire when a file gets added/removed/modified in the UserDirectory/nwnx folder
+    Note: These events fire when a file gets added/removed/modified in the /nwnx or /development folder
 
 _______________________________________
 */

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -908,6 +908,21 @@ _______________________________________
           object is added to the world which means many functions (for example `GetArea(OBJECT_SELF)`) will not work.
 
 _______________________________________
+    ## Resource Events
+    - NWNX_ON_RESOURCE_ADDED
+    - NWNX_ON_RESOURCE_REMOVED
+    - NWNX_ON_RESOURCE_MODIFIED
+
+    `OBJECT_SELF` = The module
+
+    Event Data Tag        | Type   | Notes
+    ----------------------|--------|-------
+    RESREF                | string | The ResRef of the file
+    TYPE                  | int    | The type of the file, see NWNX_UTIL_RESREF_TYPE_*
+
+    Note: These events fire when a file gets added/removed/modified in the UserDirectory/nwnx folder
+
+_______________________________________
 */
 /*
 const int NWNX_EVENTS_OBJECT_TYPE_CREATURE          = 5;


### PR DESCRIPTION
Seems to work okay. I don't know if there's a better place to hook than the main loop, I have it poll every second but if there's a better place to hook that runs semi frequently I'm open to suggestions.
```
D [11:11:48] File modified: es_s_travel.nss
D [11:11:48] Pushing event data: 'RESREF' -> 'es_s_travel'.
D [11:11:48] Pushing event data: 'TYPE' -> '2009'.
D [11:11:48] Dispatching notification for event 'NWNX_ON_RESOURCE_MODIFIED' to script 'es_s_subsysman'.
D [11:11:48] Getting event data: 'RESREF' -> 'es_s_travel'.
D [11:11:48] Getting event data: 'TYPE' -> '2009'.
I [11:11:48] (Server) ResRef: 'es_s_travel' -> 2009
```