### PR TITLE
Add an iRanged flag to NWNX_Damage_DealDamage()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ https://github.com/nwnxee/unified/compare/build8193.6...build8193.7
 - Events: exposed TARGET and TYPE event data for DMActionEvent DumpLocals
 - Tweaks: added temporary fix for server freeze when learning a spell from a scroll (NWNX_TWEAKS_FIX_SCROLL_LEARNING_BUG)
 - Events: OnStealthExit will no longer fire if OnStealthEnter was skipped
+- Damage: Added a Ranged flag to NWNX_Damage_DealDamage()
 
 ### Deprecated
 - Creature: {Get|Set}{ClericDomain|WizardSpecialization}()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ N/A
 
 ### Changed
 - Core: the console commands `eval` and `evalx` will now provide an error message if the script chunk fails to execute.
+- Damage: Added a Ranged flag to NWNX_Damage_DealDamage()
 
 ### Deprecated
 N/A
@@ -61,7 +62,6 @@ https://github.com/nwnxee/unified/compare/build8193.6...build8193.7
 - Events: exposed TARGET and TYPE event data for DMActionEvent DumpLocals
 - Tweaks: added temporary fix for server freeze when learning a spell from a scroll (NWNX_TWEAKS_FIX_SCROLL_LEARNING_BUG)
 - Events: OnStealthExit will no longer fire if OnStealthEnter was skipped
-- Damage: Added a Ranged flag to NWNX_Damage_DealDamage()
 
 ### Deprecated
 - Creature: {Get|Set}{ClericDomain|WizardSpecialization}()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ N/A
 - Events: UnsubscribeEvent()
 - Creature: Get|SetFaction()
 - Util: (Un)RegisterServerConsoleCommand()
+- Area: GetTileModuleResRef()
 
 ### Changed
 - Core: the console commands `eval` and `evalx` will now provide an error message if the script chunk fails to execute.

--- a/Plugins/Area/Area.cpp
+++ b/Plugins/Area/Area.cpp
@@ -674,7 +674,7 @@ ArgumentStack Area::GetTileModelResRef(ArgumentStack&& args)
 
         if (pTile)
         {
-            retVal = pTile->m_pTileData->GetModelResRef();
+            retVal = pTile->m_pTileData->GetModelResRef()->GetResRefStr();
         }
         else
         {
@@ -682,7 +682,7 @@ ArgumentStack Area::GetTileModelResRef(ArgumentStack&& args)
         }
     }
 
-    return Services::Events::Arguments(retVal.CStr());
+    return Services::Events::Arguments(retVal);
 }
 
 

--- a/Plugins/Area/Area.cpp
+++ b/Plugins/Area/Area.cpp
@@ -674,7 +674,7 @@ ArgumentStack Area::GetTileModelResRef(ArgumentStack&& args)
 
         if (pTile)
         {
-            retVal = pTile->m_pTileData->GetModelResRef()->GetResRefStr();
+            retVal = pTile->m_pTileData->GetModelResRef().GetResRefStr();
         }
         else
         {

--- a/Plugins/Area/Area.cpp
+++ b/Plugins/Area/Area.cpp
@@ -673,7 +673,7 @@ ArgumentStack Area::GetTileModelResRef(ArgumentStack&& args)
 
         if (pTile)
         {
-            retVal = pTile->m_pTileData->GetModelResRef();
+            retVal = pTile->GetTileData()->GetModelResRef();
         }
         else
         {

--- a/Plugins/Area/Area.cpp
+++ b/Plugins/Area/Area.cpp
@@ -73,6 +73,7 @@ Area::Area(const Plugin::CreateParams& params)
     REGISTER(CreateTransition);
     REGISTER(GetTileAnimationLoop);
     REGISTER(SetTileAnimationLoop);
+    REGISTER(GetTileModelResRef);
     REGISTER(TestDirectLine);
     REGISTER(GetMusicIsPlaying);
     REGISTER(CreateGenericTrigger);
@@ -657,6 +658,32 @@ ArgumentStack Area::SetTileAnimationLoop(ArgumentStack&& args)
 
     return Services::Events::Arguments();
 }
+
+ArgumentStack Area::GetTileModelResRef(ArgumentStack&& args)
+{
+    CExoString retVal = "";
+    if (auto* pArea = area(args))
+    {
+        const auto tileX = Services::Events::ExtractArgument<float>(args);
+        ASSERT_OR_THROW(tileX >= 0.0f);
+        const auto tileY = Services::Events::ExtractArgument<float>(args);
+        ASSERT_OR_THROW(tileY >= 0.0f);
+
+        CNWSTile* pTile = GetTile(pArea, tileX, tileY);
+
+        if (pTile)
+        {
+            retVal = pTile->m_pTileData->GetModelResRef();
+        }
+        else
+        {
+            LOG_ERROR("NWNX_Area_GetTileName: invalid tile specified");
+        }
+    }
+
+    return Services::Events::Arguments(retVal.CStr());
+}
+
 
 ArgumentStack Area::TestDirectLine(ArgumentStack&& args)
 {

--- a/Plugins/Area/Area.cpp
+++ b/Plugins/Area/Area.cpp
@@ -662,7 +662,7 @@ ArgumentStack Area::SetTileAnimationLoop(ArgumentStack&& args)
 
 ArgumentStack Area::GetTileModelResRef(ArgumentStack&& args)
 {
-    CExoString retVal = "";
+    std::string retVal = "";
     if (auto* pArea = area(args))
     {
         const auto tileX = Services::Events::ExtractArgument<float>(args);

--- a/Plugins/Area/Area.cpp
+++ b/Plugins/Area/Area.cpp
@@ -7,6 +7,7 @@
 #include "API/CNWSTransition.hpp"
 #include "API/CNWSTrigger.hpp"
 #include "API/CNWSTile.hpp"
+#include "API/CNWTileData.hpp"
 #include "API/CNWSAmbientSound.hpp"
 #include "API/Constants.hpp"
 #include "API/Globals.hpp"
@@ -673,7 +674,7 @@ ArgumentStack Area::GetTileModelResRef(ArgumentStack&& args)
 
         if (pTile)
         {
-            retVal = pTile->GetTileData()->GetModelResRef();
+            retVal = pTile->m_pTileData->GetModelResRef();
         }
         else
         {

--- a/Plugins/Area/Area.hpp
+++ b/Plugins/Area/Area.hpp
@@ -41,6 +41,7 @@ private:
     ArgumentStack CreateTransition          (ArgumentStack&& args);
     ArgumentStack GetTileAnimationLoop      (ArgumentStack&& args);
     ArgumentStack SetTileAnimationLoop      (ArgumentStack&& args);
+    ArgumentStack GetTileModelResRef        (ArgumentStack&& args);
     ArgumentStack TestDirectLine            (ArgumentStack&& args);
     ArgumentStack GetMusicIsPlaying         (ArgumentStack&& args);
     ArgumentStack CreateGenericTrigger      (ArgumentStack&& args);

--- a/Plugins/Area/NWScript/nwnx_area.nss
+++ b/Plugins/Area/NWScript/nwnx_area.nss
@@ -175,20 +175,25 @@ void NWNX_Area_SetSunMoonColors(object area, int type, int color);
 /// @sa NWNX_Object_SetTriggerGeometry() if you wish to draw the transition as something other than a square.
 object NWNX_Area_CreateTransition(object area, object target, float x, float y, float z, float size = 2.0f, string tag="");
 
-/// @brief Get the state of a tile animation loop
+/// @brief Get the state of a tile animation loop.
 /// @param oArea The area object.
 /// @param fTileX, fTileY The coordinates of the tile.
 /// @param nAnimLoop The loop to check. (1-3)
 /// @return TRUE if the loop is enabled.
 int NWNX_Area_GetTileAnimationLoop(object oArea, float fTileX, float fTileY, int nAnimLoop);
 
-/// @brief Set the state of a tile animation loop
+/// @brief Set the state of a tile animation loop.
 /// @param oArea The area object.
 /// @param fTileX, fTileY The coordinates of the tile.
 /// @param nAnimLoop The loop to set (1-3).
 /// @param bEnabled TRUE or FALSE.
 /// @note Requires clients to re-enter the area for it to take effect
 void NWNX_Area_SetTileAnimationLoop(object oArea, float fTileX, float fTileY, int nAnimLoop, int bEnabled);
+
+/// @brief Get the name of the tile model from any location.
+/// @param oArea The area name.
+/// @param fTileX, fTileY The coordinates of the tile.
+string NWNX_Area_GetTileModelName(object oArea, float fTileX, float fTileY);
 
 /// @brief Test to see if there's a direct, walkable line between two points in the area.
 /// @param oArea The area object.
@@ -488,6 +493,17 @@ void NWNX_Area_SetTileAnimationLoop(object oArea, float fTileX, float fTileY, in
     NWNX_CallFunction(NWNX_Area, sFunc);
 }
 
+string NWNX_Area_GetTileModelResRef(object oArea, float fTileX, float fTileY)
+{
+    string sFunc = "GetTileModelResRef";
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, fTileY);
+    NWNX_PushArgumentFloat(NWNX_Area, sFunc, fTileX);
+    NWNX_PushArgumentObject(NWNX_Area, sFunc, oArea);
+
+    NWNX_CallFunction(NWNX_Area, sFunc);
+
+    return NWNX_GetReturnValueString(NWNX_Area, sFunc);
+}
 
 int NWNX_Area_TestDirectLine(object oArea, float fStartX, float fStartY, float fEndX, float fEndY, float fPerSpace, float fHeight, int bIgnoreDoors=FALSE)
 {

--- a/Plugins/Area/NWScript/nwnx_area.nss
+++ b/Plugins/Area/NWScript/nwnx_area.nss
@@ -193,7 +193,7 @@ void NWNX_Area_SetTileAnimationLoop(object oArea, float fTileX, float fTileY, in
 /// @brief Get the name of the tile model from any location.
 /// @param oArea The area name.
 /// @param fTileX, fTileY The coordinates of the tile.
-string NWNX_Area_GetTileModelName(object oArea, float fTileX, float fTileY);
+string NWNX_Area_GetTileModelResRef(object oArea, float fTileX, float fTileY);
 
 /// @brief Test to see if there's a direct, walkable line between two points in the area.
 /// @param oArea The area object.

--- a/Plugins/Area/NWScript/nwnx_area_t.nss
+++ b/Plugins/Area/NWScript/nwnx_area_t.nss
@@ -57,6 +57,9 @@ void main()
         object oAT = NWNX_Area_CreateTransition(oArea, oWP, vLoc.x, vLoc.y, vLoc.z);
         NWNX_Tests_Report("NWNX_Area", "CreateTransition", oAT != OBJECT_INVALID);
 
+        string sResult = NWNX_Area_GetTileModelResRef(oArea, vLoc.x, vLoc.y);
+        NWNX_Tests_Report("NWNX_Area", "GetTileModelResRef", sResult != "");
+
         NWNX_Area_SetTileAnimationLoop(oArea, vLoc.x, vLoc.y, 1, FALSE);
         NWNX_Tests_Report("NWNX_Area", "{Set/Get}TileAnimationLoop", NWNX_Area_GetTileAnimationLoop(oArea, vLoc.x, vLoc.y, 1) == FALSE);
     }

--- a/Plugins/Damage/Damage.cpp
+++ b/Plugins/Damage/Damage.cpp
@@ -238,6 +238,7 @@ ArgumentStack Damage::DealDamage(ArgumentStack&& args)
         positive[k] = vDamage[k] > 0;
     }
     int damagePower = Services::Events::ExtractArgument<int32_t>(args);
+    int range = Services::Events::ExtractArgument<int>(args);
 
     CNWSCreature *pSource = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(oidSource);
     CNWSObject *pTarget = Utils::AsNWSObject(Globals::AppManager()->m_pServerExoApp->GetGameObject(oidTarget));
@@ -268,6 +269,10 @@ ArgumentStack Damage::DealDamage(ArgumentStack&& args)
         pEffect->SetInteger(k, positive[k] ? vDamage[k] : -1);
     pEffect->SetInteger(17, true); // combat damage
     // ... and apply it
+    
+    //Check if ranged (this sets bRangedAttack internally)
+    pEffect->SetInteger(18, !!range);
+
     pTarget->ApplyEffect(pEffect, false, true);
 
     return Services::Events::Arguments();

--- a/Plugins/Damage/Damage.cpp
+++ b/Plugins/Damage/Damage.cpp
@@ -238,7 +238,16 @@ ArgumentStack Damage::DealDamage(ArgumentStack&& args)
         positive[k] = vDamage[k] > 0;
     }
     int damagePower = Services::Events::ExtractArgument<int32_t>(args);
-    int range = Services::Events::ExtractArgument<int>(args);
+
+    int range = 0;
+    try 
+    {
+        range = Services::Events::ExtractArgument<int>(args);
+    }
+    catch(std::exception e) 
+    {
+        LOG_WARNING("NWNX_Damage_DealDamage() called from NWScript without final parameter. Please download the latest versions of NWNX scripts.");
+    }
 
     CNWSCreature *pSource = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(oidSource);
     CNWSObject *pTarget = Utils::AsNWSObject(Globals::AppManager()->m_pServerExoApp->GetGameObject(oidTarget));

--- a/Plugins/Damage/NWScript/nwnx_damage.nss
+++ b/Plugins/Damage/NWScript/nwnx_damage.nss
@@ -104,7 +104,8 @@ void NWNX_Damage_SetAttackEventData(struct NWNX_Damage_AttackEventData data);
 /// @param data A NWNX_Damage_DamageData struct.
 /// @param oTarget The target object on whom the damage is dealt.
 /// @param oSource The source of the damage.
-void NWNX_Damage_DealDamage(struct NWNX_Damage_DamageData data, object oTarget, object oSource=OBJECT_SELF);
+/// @param iRanged Whether the attack should be treated as ranged by the engine (for example when considering damage inflicted by Acid Sheath and other such effects)
+void NWNX_Damage_DealDamage(struct NWNX_Damage_DamageData data, object oTarget, object oSource=OBJECT_SELF, int iRanged = FALSE);
 
 /// @}
 
@@ -227,10 +228,11 @@ void NWNX_Damage_SetAttackEventData(struct NWNX_Damage_AttackEventData data)
     NWNX_CallFunction(NWNX_Damage, sFunc);
 }
 
-void NWNX_Damage_DealDamage(struct NWNX_Damage_DamageData data, object oTarget, object oSource)
+void NWNX_Damage_DealDamage(struct NWNX_Damage_DamageData data, object oTarget, object oSource, int iRanged = FALSE)
 {
     string sFunc = "DealDamage";
 
+    NWNX_PushArgumentInt(NWNX_Damage, sFunc, iRanged);
     NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iPower);
     NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iSonic);
     NWNX_PushArgumentInt(NWNX_Damage, sFunc, data.iPositive);


### PR DESCRIPTION
This change allows the scripter to specify that damage dealt is ranged only. Default value of FALSE in NWScript so shouldn’t break compatibility.