### PR TITLE
Add GetFeatGrantLevel, GetInternalObjectType, PluginExists, GetUserDirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ N/A
 
 ##### New NWScript Functions
 - Creature: GetFeatGrantLevel()
+- Util: GetUserDirectory()
+- Util: PluginExists()
 
 ### Changed
 N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ N/A
 N/A
 
 ##### New NWScript Functions
-N/A
+- Creature: GetFeatGrantLevel()
 
 ### Changed
 N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ N/A
 
 ##### New NWScript Functions
 - Creature: GetFeatGrantLevel()
+- Object: GetInternalObjectType()
 - Util: GetUserDirectory()
 - Util: PluginExists()
 

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -62,6 +62,7 @@ Creature::Creature(const Plugin::CreateParams& params)
     REGISTER(GetKnowsFeat);
     REGISTER(GetFeatCountByLevel);
     REGISTER(GetFeatByLevel);
+    REGISTER(GetFeatGrantLevel);
     REGISTER(GetFeatCount);
     REGISTER(GetFeatByIndex);
     REGISTER(GetMeetsFeatRequirements);
@@ -264,6 +265,34 @@ ArgumentStack Creature::GetFeatByLevel(ArgumentStack&& args)
         }
     }
     return Services::Events::Arguments(retVal);
+}
+
+ArgumentStack Creature::GetFeatGrantLevel(ArgumentStack&& args)
+{
+    ArgumentStack stack;
+    if (auto* pCreature = creature(args))
+    {
+        const auto feat = Services::Events::ExtractArgument<int32_t>(args);
+        ASSERT_OR_THROW(feat >= Constants::Feat::MIN);
+        ASSERT_OR_THROW(feat <= Constants::Feat::MAX);
+        const auto uFeat = static_cast<uint16_t>(feat);
+
+        for (int32_t i = 0; i < pCreature->m_pStats->GetLevel(); i++)
+        {
+            auto* pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[i];
+            ASSERT_OR_THROW(pLevelStats);
+
+            for (int32_t j = 0; j < pLevelStats->m_lstFeats.num; j++)
+            {
+                if (pLevelStats->m_lstFeats.element[j] == uFeat)
+                {
+                    return Services::Events::Arguments(i + 1);
+                }
+            }
+        }
+    }
+
+    return Services::Events::Arguments(0);
 }
 
 ArgumentStack Creature::GetFeatCount(ArgumentStack&& args)

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -22,6 +22,7 @@ private:
     ArgumentStack GetKnowsFeat                  (ArgumentStack&& args);
     ArgumentStack GetFeatCountByLevel           (ArgumentStack&& args);
     ArgumentStack GetFeatByLevel                (ArgumentStack&& args);
+    ArgumentStack GetFeatGrantLevel             (ArgumentStack&& args);
     ArgumentStack GetFeatCount                  (ArgumentStack&& args);
     ArgumentStack GetFeatByIndex                (ArgumentStack&& args);
     ArgumentStack GetMeetsFeatRequirements      (ArgumentStack&& args);

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -130,6 +130,12 @@ int NWNX_Creature_GetFeatCountByLevel(object creature, int level);
 /// @return The feat id at the index.
 int NWNX_Creature_GetFeatByLevel(object creature, int level, int index);
 
+/// @brief Returns the creature level where the specified feat was learned.
+/// @param creature The creature object.
+/// @param feat The feat id.
+/// @return The character level that the specified feat was granted, otherwise 0 if the creature does not have this feat.
+int NWNX_Creature_GetFeatGrantLevel(object creature, int feat);
+
 /// @brief Get the total number of feats known by creature.
 /// @param creature The creature object.
 /// @return The total feat count for the creature.
@@ -733,6 +739,15 @@ int NWNX_Creature_GetFeatCount(object creature)
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 
     NWNX_CallFunction(NWNX_Creature, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
+}
+
+int NWNX_Creature_GetFeatGrantLevel(object creature, int feat)
+{
+    string sFunc = "GetFeatGrantLevel";
+
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, feat);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
     return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
 }
 

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -44,6 +44,7 @@ void main()
     NWNX_Tests_Report("NWNX_Creature", "GetFeatByIndex", NWNX_Creature_GetFeatByIndex(oCreature, nFeatCountTotal) == FEAT_PLAYER_TOOL_01);
 
     NWNX_Tests_Report("NWNX_Creature", "GetFeatByLevel", NWNX_Creature_GetFeatByLevel(oCreature, 1, nFeatCountLvl1) == FEAT_PLAYER_TOOL_01);
+    NWNX_Tests_Report("NWNX_Creature", "GetFeatGrantLevel", NWNX_Creature_GetFeatGrantLevel(oCreature, FEAT_PLAYER_TOOL_01) == 1);
 
     NWNX_Creature_AddFeat(oCreature, FEAT_BARBARIAN_RAGE);
     NWNX_Tests_Report("NWNX_Creature", "GetHighestLevelOfFeat", NWNX_Creature_GetHighestLevelOfFeat(oCreature, FEAT_BARBARIAN_RAGE) == FEAT_BARBARIAN_RAGE);

--- a/Plugins/Object/NWScript/nwnx_object.nss
+++ b/Plugins/Object/NWScript/nwnx_object.nss
@@ -16,6 +16,28 @@ const int NWNX_OBJECT_LOCALVAR_TYPE_OBJECT   = 4;
 const int NWNX_OBJECT_LOCALVAR_TYPE_LOCATION = 5;
 /// @}
 
+/// @anchor object_internal_types
+/// @name Internal Object Types
+/// @{
+const int NWNX_OBJECT_TYPE_INTERNAL_INVALID = -1;
+const int NWNX_OBJECT_TYPE_INTERNAL_GUI = 1;
+const int NWNX_OBJECT_TYPE_INTERNAL_TILE = 2;
+const int NWNX_OBJECT_TYPE_INTERNAL_MODULE = 3;
+const int NWNX_OBJECT_TYPE_INTERNAL_AREA = 4;
+const int NWNX_OBJECT_TYPE_INTERNAL_CREATURE = 5;
+const int NWNX_OBJECT_TYPE_INTERNAL_ITEM = 6;
+const int NWNX_OBJECT_TYPE_INTERNAL_TRIGGER = 7;
+const int NWNX_OBJECT_TYPE_INTERNAL_PROJECTILE = 8;
+const int NWNX_OBJECT_TYPE_INTERNAL_PLACEABLE = 9;
+const int NWNX_OBJECT_TYPE_INTERNAL_DOOR = 10;
+const int NWNX_OBJECT_TYPE_INTERNAL_AREAOFEFFECT = 11;
+const int NWNX_OBJECT_TYPE_INTERNAL_WAYPOINT = 12;
+const int NWNX_OBJECT_TYPE_INTERNAL_ENCOUNTER = 13;
+const int NWNX_OBJECT_TYPE_INTERNAL_STORE = 14;
+const int NWNX_OBJECT_TYPE_INTERNAL_PORTAL = 15;
+const int NWNX_OBJECT_TYPE_INTERNAL_SOUND = 16;
+/// @}
+
 /// A local variable structure.
 struct NWNX_Object_LocalVariable
 {
@@ -298,6 +320,11 @@ void NWNX_Object_DeleteVarRegex(object oObject, string sRegex);
 /// @param vPosition The position.
 /// @return TRUE if vPosition is inside oTrigger's geometry.
 int NWNX_Object_GetPositionIsInTrigger(object oTrigger, vector vPosition);
+
+/// @brief Gets the given object's internal type (NWNX_OBJECT_TYPE_INTERNAL_*)
+/// @param oObject The object.
+/// @return The object's type (NWNX_OBJECT_TYPE_INTERNAL_*)
+int NWNX_Object_GetInternalObjectType(object oObject);
 
 /// @}
 
@@ -734,6 +761,16 @@ int NWNX_Object_GetPositionIsInTrigger(object oTrigger, vector vPosition)
     NWNX_PushArgumentFloat(NWNX_Object, sFunc, vPosition.y);
     NWNX_PushArgumentFloat(NWNX_Object, sFunc, vPosition.x);
     NWNX_PushArgumentObject(NWNX_Object, sFunc, oTrigger);
+    NWNX_CallFunction(NWNX_Object, sFunc);
+
+    return NWNX_GetReturnValueInt(NWNX_Object, sFunc);
+}
+
+int NWNX_Object_GetInternalObjectType(object oObject)
+{
+    string sFunc = "GetInternalObjectType";
+
+    NWNX_PushArgumentObject(NWNX_Object, sFunc, oObject);
     NWNX_CallFunction(NWNX_Object, sFunc);
 
     return NWNX_GetReturnValueInt(NWNX_Object, sFunc);

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -101,6 +101,7 @@ Object::Object(const Plugin::CreateParams& params)
     REGISTER(DeleteFloat);
     REGISTER(DeleteVarRegex);
     REGISTER(GetPositionIsInTrigger);
+    REGISTER(GetInternalObjectType);
 
 #undef REGISTER
 }
@@ -837,6 +838,18 @@ ArgumentStack Object::GetPositionIsInTrigger(ArgumentStack&& args)
     }
 
     return Services::Events::Arguments(retVal);
+}
+
+ArgumentStack Object::GetInternalObjectType(ArgumentStack&& args)
+{
+    const auto objectId = Services::Events::ExtractArgument<Types::ObjectID>(args);
+
+    if (auto* go = Utils::GetGameObject(objectId))
+    {
+        return Services::Events::Arguments(go->m_nObjectType);
+    }
+
+    return Services::Events::Arguments(-1);
 }
 
 }

--- a/Plugins/Object/Object.hpp
+++ b/Plugins/Object/Object.hpp
@@ -52,6 +52,7 @@ private:
     ArgumentStack DeleteFloat               (ArgumentStack&& args);
     ArgumentStack DeleteVarRegex            (ArgumentStack&& args);
     ArgumentStack GetPositionIsInTrigger    (ArgumentStack&& args);
+    ArgumentStack GetInternalObjectType     (ArgumentStack&& args);
 
     CNWSObject *object(ArgumentStack& args);
 };

--- a/Plugins/Util/NWScript/nwnx_util.nss
+++ b/Plugins/Util/NWScript/nwnx_util.nss
@@ -163,6 +163,16 @@ int NWNX_Util_RegisterServerConsoleCommand(string sCommand, string sScriptChunk)
 /// @param sCommand The name of the command.
 void NWNX_Util_UnregisterServerConsoleCommand(string sCommand);
 
+/// @brief Determines if the given plugin exists and is enabled.
+/// @param sPlugin The name of the plugin to check. This is the case sensitive plugin name as used by NWNX_CallFunction, NWNX_PushArgumentX
+/// @note Example usage: NWNX_Util_PluginExists("NWNX_Creature");
+/// @return TRUE if the plugin exists and is enabled, otherwise FALSE.
+int NWNX_Util_PluginExists(string sPlugin);
+
+/// @brief Gets the server's current working user folder.
+/// @return The absolute path of the server's home directory (-userDirectory)
+string NWNX_Util_GetUserDirectory();
+
 /// @}
 
 string NWNX_Util_GetCurrentScriptName(int depth = 0)
@@ -380,4 +390,19 @@ void NWNX_Util_UnregisterServerConsoleCommand(string sCommand)
 
     NWNX_PushArgumentString(NWNX_Util, sFunc, sCommand);
     NWNX_CallFunction(NWNX_Util, sFunc);
+}
+
+int NWNX_Util_PluginExists(string sPlugin)
+{
+    string sFunc = "PluginExists";
+    NWNX_PushArgumentString(NWNX_Util, sFunc, sPlugin);
+    NWNX_CallFunction(NWNX_Util, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Util, sFunc);
+}
+
+string NWNX_Util_GetUserDirectory()
+{
+    string sFunc = "GetUserDirectory";
+    NWNX_CallFunction(NWNX_Util, sFunc);
+    return NWNX_GetReturnValueString(NWNX_Util, sFunc);
 }

--- a/Plugins/Util/Util.cpp
+++ b/Plugins/Util/Util.cpp
@@ -2,6 +2,7 @@
 
 #include "API/Constants.hpp"
 #include "API/Globals.hpp"
+#include "API/CExoBase.hpp"
 #include "API/C2DA.hpp"
 #include "API/CNWRules.hpp"
 #include "API/CTwoDimArrays.hpp"
@@ -20,6 +21,7 @@
 #include "API/Functions.hpp"
 #include "Utils.hpp"
 #include "Services/Config/Config.hpp"
+#include "Services/Plugins/Plugins.hpp"
 #include "Services/Commands/Commands.hpp"
 
 #include <string>
@@ -85,6 +87,8 @@ Util::Util(const Plugin::CreateParams& params)
     REGISTER(SetInstructionLimit);
     REGISTER(RegisterServerConsoleCommand);
     REGISTER(UnregisterServerConsoleCommand);
+    REGISTER(PluginExists);
+    REGISTER(GetUserDirectory);
 
 #undef REGISTER
 
@@ -546,6 +550,19 @@ ArgumentStack Util::UnregisterServerConsoleCommand(ArgumentStack&& args)
     }
 
     return Services::Events::Arguments();
+}
+
+ArgumentStack Util::PluginExists(ArgumentStack&& args)
+{
+    std::string pluginName = Services::Events::ExtractArgument<std::string>(args);
+    std::string pluginNameWithoutPrefix = pluginName.substr(5, pluginName.length() - 5);
+
+    return GetServices()->m_plugins->FindPluginByName(pluginNameWithoutPrefix) ? Services::Events::Arguments(1) : Services::Events::Arguments(0);
+}
+
+ArgumentStack Util::GetUserDirectory(ArgumentStack&&)
+{
+    return Services::Events::Arguments(Globals::ExoBase()->m_sUserDirectory.CStr());
 }
 
 }

--- a/Plugins/Util/Util.hpp
+++ b/Plugins/Util/Util.hpp
@@ -39,6 +39,8 @@ private:
     ArgumentStack SetInstructionLimit           (ArgumentStack&& args);
     ArgumentStack RegisterServerConsoleCommand  (ArgumentStack&& args);
     ArgumentStack UnregisterServerConsoleCommand(ArgumentStack&& args);
+    ArgumentStack PluginExists                  (ArgumentStack&& args);
+    ArgumentStack GetUserDirectory              (ArgumentStack&&);
 
     size_t m_resRefIndex;
     std::vector<std::string> m_listResRefs;


### PR DESCRIPTION
**Creature - GetFeatGrantLevel**
When a feat is removed from a creature, there is no easy API to determine which level this feat was removed from, if we need to restore it later using AddFeatByLevel.

**Object - GetInternalObjectType**
Modules, Areas and a few other object types do not have their own OBJECT_TYPE_* constant that is returned from GetObjectType. NWNX knows this exact type, and this would be super handy to have for type safety in a managed implementation (e.g. DotNet).

**Util - PluginExists**
Currently there is no way to check if a plugin exists (e.g. to check if a plugin is an optional dependency) without throwing an error. I'm not sure if this might make more sense as a core function.

**Util - GetUserDirectory**
When using other plugins for databases and persistent data (e.g. EF in DotNet), this can be useful for getting a location to store such data.