### PR TITLE
Optimizations: Fix a potential memory leak in GameObjectLookup

### DIFF
--- a/Plugins/Optimizations/Optimizations/GameObjectLookup.cpp
+++ b/Plugins/Optimizations/Optimizations/GameObjectLookup.cpp
@@ -23,7 +23,7 @@ GameObjectLookup::GameObjectLookup(Services::HooksProxy* hooker)
         {
             // Reading the config is currently.. complicated in NWNX, so just
             // let the CGOA constructor read it, and then undo the allocation.
-            delete pThis->m_pArray;
+            delete[] pThis->m_pArray;
             pThis->m_pArray = nullptr;
             pThis->m_nArraySize = 0;
             pThis->m_nGameObjectCache = 0;


### PR DESCRIPTION
Asan was complaining about this:
```==18698==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x7f48820b1800 in thread T0:
  object passed to delete has wrong type:
  size of the allocated type:   1048576 bytes;
  size of the deallocated type: 8 bytes.
    #0 0x7f489af99128 in operator delete(void*, unsigned long) (/lib/x86_64-linux-gnu/libasan.so.5+0xec128)
    #1 0x7f488780d0ec in operator() /home/nwn/nwnee/unified/Plugins/Optimizations/Optimizations/GameObjectLookup.cpp:26
    #2 0x7f488780d210 in _FUN /home/nwn/nwnee/unified/Plugins/Optimizations/Optimizations/GameObjectLookup.cpp:32
    #3 0x7f48878155ca in void NWNXLib::Services::HooksImpl::DispatchCallbacks<CGameObjectArray*>(bool, std::vector<unsigned long, std::allocator<unsigned long> > const*, CGameObjectArray*) /home/nwn/nwnee/unified/NWNXLib/./Services/Hooks/HooksImpl.inl:66
    #4 0x7f4887815221 in void NWNXLib::Services::HooksImpl::ScopedCallbackDispatcher<CGameObjectArray*>::UnpackAndDispatch<0>(bool, NWNXLib::Services::HooksImpl::Sequence<0>) /home/nwn/nwnee/unified/NWNXLib/./Services/Hooks/HooksImpl.inl:21
    #5 0x7f4887814d72 in NWNXLib::Services::HooksImpl::ScopedCallbackDispatcher<CGameObjectArray*>::~ScopedCallbackDispatcher() /home/nwn/nwnee/unified/NWNXLib/./Services/Hooks/HooksImpl.inl:14
    #6 0x7f48878145f6 in void NWNXLib::Services::HooksImpl::HookLandingHolderShared::HookLanding<8147856ul, void, CGameObjectArray*>(CGameObjectArray*) /home/nwn/nwnee/unified/NWNXLib/./Services/Hooks/HooksImpl.inl:41