### PR TITLE
WebHook: Fix a crash that happens when sending a webHook message just before shutting down the server

### DIFF
--- a/Plugins/WebHook/WebHook.cpp
+++ b/Plugins/WebHook/WebHook.cpp
@@ -116,6 +116,9 @@ ArgumentStack WebHook::SendWebHookHTTPS(ArgumentStack&& args)
             auto res = cli->second->post(path.c_str(), message, "application/json");
             g_plugin->GetServices()->m_tasks->QueueOnMainThread([message, host, path, origPath, res]()
             {
+                if (Core::g_CoreShuttingDown)
+                    return;
+
                 auto messaging = g_plugin->GetServices()->m_messaging.get();
                 auto moduleOid = NWNXLib::Utils::ObjectIDToString(Utils::GetModule()->m_idSelf);
 


### PR DESCRIPTION
Fixes #862