### PR TITLE
[WIP] services/events: Add ExtractArguments

### DIFF
--- a/NWNXLib/Services/Events/Events.hpp
+++ b/NWNXLib/Services/Events/Events.hpp
@@ -77,6 +77,9 @@ public:
     template <typename T>
     static T ExtractArgument(ArgumentStack& arguments);
 
+    template <typename... Ts>
+    static std::tuple<Ts...> ExtractArguments(ArgumentStack& arguments);
+
 private: // Structures
     struct EventDataInternal
     {

--- a/NWNXLib/Services/Events/Events.inl
+++ b/NWNXLib/Services/Events/Events.inl
@@ -98,3 +98,9 @@ T Events::ExtractArgument(ArgumentStack& arguments)
 
     return real;
 }
+
+template <typename... Ts>
+std::tuple<Ts...> Events::ExtractArguments(ArgumentStack& arguments) 
+{
+    return {ExtractArgument<Ts>(arguments)...};
+}


### PR DESCRIPTION
Labeling this as WIP because I haven't done any real testing and not sure it adds much value beyond aesthetics, reduced verbosity.

Add helper function to be used in conjunction with c++17 structured binding (https://en.cppreference.com/w/cpp/language/structured_binding)

```c++
        const auto index = Services::Events::ExtractArgument<int32_t>(args);
        const auto level = Services::Events::ExtractArgument<int32_t>(args);
```
->
```c++
        const auto [index, level] = Services::Events::ExtractArguments<int32_t, int32_t>(args);
```