### PR TITLE
tweaks: Static member variables already zero initialized

### DIFF
--- a/Plugins/Tweaks/Tweaks/AddPrestigeclassCasterLevels.cpp
+++ b/Plugins/Tweaks/Tweaks/AddPrestigeclassCasterLevels.cpp
@@ -31,13 +31,6 @@ AddPrestigeclassCasterLevels::AddPrestigeclassCasterLevels(Services::HooksProxy*
     hooker->RequestSharedHook<Functions::_ZN25CNWVirtualMachineCommands25ExecuteCommandResistSpellEii, int32_t>(&CNWVirtualMachineCommands__ExecuteCommandResistSpell);
     hooker->RequestSharedHook<Functions::_ZN11CGameEffect10SetCreatorEj, void>(&CGameEffect__SetCreator);
     hooker->RequestSharedHook<Functions::_ZN8CNWRules13LoadClassInfoEv, void>(&CNWRules__LoadClassInfo);
-
-    for (int i = 0; i < sizeof(s_classCasterType) / sizeof(s_classCasterType[0]); i++)
-    {
-        s_classCasterType[i] = CasterType::None;
-        s_arcModClasses[i] = 0;
-        s_divModClasses[i] = 0;
-    }
 }
 
 void AddPrestigeclassCasterLevels::LoadCasterLevelModifiers(CNWRules* pRules)


### PR DESCRIPTION
From standard: “Variables with static storage duration (3.7.1) or thread storage duration (3.7.2) shall be zero-initialized (8.5) before any other initialization takes place”