### PR TITLE
Core: fix NWNX ResourceDirectory init crashing on failed module load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ N/A
 N/A
 
 ### Fixed
-N/A
+- Core: fixed NWNX ResourceDirectory init crashing on failed module load
 
 
 ## 8193.13

--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -335,6 +335,9 @@ void NWNXCore::InitialSetupResourceDirectory()
     m_services->m_tasks->QueueOnMainThread(
         [path, cleanDirectory, priority]
         {
+            if (g_CoreShuttingDown)
+                return;
+
             CExoString sAlias = CExoString("NWNX:");
             CExoString sPath = CExoString(path);
 


### PR DESCRIPTION
Fixes #901