### PR TITLE
DotNET - Search pack folder for libnethost

### DIFF
--- a/Plugins/DotNET/DotNET.cpp
+++ b/Plugins/DotNET/DotNET.cpp
@@ -85,25 +85,35 @@ bool DotNET::InitThunks()
         if (dir != nullptr)
         {
             dirent* directoryEntry = readdir(dir);
+            std::vector<std::string> paths;
 
             while (directoryEntry != nullptr)
             {
                 if (directoryEntry->d_type == DT_DIR)
                 {
                     const auto path = (std::string(hostBaseDir) + directoryEntry->d_name + hostLibSuffix);
-
-                    nethost = dlopen(path.c_str(), RTLD_LAZY);
-                    if (nethost)
-                    {
-                        LOG_INFO("Loaded libnethost.so from: %s (autodetected)", path);
-                        break;
-                    }
+                    paths.push_back(path);
                 }
 
                 directoryEntry = readdir(dir);
             }
 
             closedir(dir);
+
+            if (!paths.empty())
+            {
+                std::sort(paths.begin(), paths.end(), std::greater<std::string>());
+                for (std::string path : paths)
+                {
+                    nethost = dlopen(path.c_str(), RTLD_LAZY);
+
+                    if (nethost)
+                    {
+                        LOG_INFO("Loaded libnethost.so from: %s (autodetected)", path);
+                        break;
+                    }
+                }
+            }
         }
     }
 

--- a/Plugins/DotNET/DotNET.cpp
+++ b/Plugins/DotNET/DotNET.cpp
@@ -13,6 +13,7 @@
 
 #include "sdk/coreclr_delegates.h"
 #include "sdk/hostfxr.h"
+#include <dirent.h>
 #include <dlfcn.h>
 #include <limits.h>
 
@@ -61,15 +62,7 @@ bool DotNET::InitThunks()
         const char *paths[] = {
             "libnethost.so",
             "./libnethost.so",
-            "lib/libnethost.so",
-            "/usr/share/dotnet/packs/Microsoft.NETCore.App.Host.linux-x64/3.1.4/runtimes/linux-x64/native/libnethost.so",
-            "/usr/share/dotnet/packs/Microsoft.NETCore.App.Host.linux-x64/3.1.3/runtimes/linux-x64/native/libnethost.so",
-            "/usr/share/dotnet/packs/Microsoft.NETCore.App.Host.linux-x64/3.1.2/runtimes/linux-x64/native/libnethost.so",
-            "/usr/share/dotnet/packs/Microsoft.NETCore.App.Host.linux-x64/3.1.1/runtimes/linux-x64/native/libnethost.so",
-            "/usr/share/dotnet/packs/Microsoft.NETCore.App.Host.linux-x64/3.1.0/runtimes/linux-x64/native/libnethost.so",
-            "/usr/share/dotnet/packs/Microsoft.NETCore.App.Host.linux-x64/3.0.2/runtimes/linux-x64/native/libnethost.so",
-            "/usr/share/dotnet/packs/Microsoft.NETCore.App.Host.linux-x64/3.0.1/runtimes/linux-x64/native/libnethost.so",
-            "/usr/share/dotnet/packs/Microsoft.NETCore.App.Host.linux-x64/3.0.0/runtimes/linux-x64/native/libnethost.so"
+            "lib/libnethost.so"
         };
         for (size_t i = 0; i < std::size(paths); i++)
         {
@@ -79,6 +72,38 @@ bool DotNET::InitThunks()
                 LOG_INFO("Loaded libnethost.so from: %s (autodetected)", paths[i]);
                 break;
             }
+        }
+    }
+
+    if (!nethost)
+    {
+        const auto hostBaseDir = "/usr/share/dotnet/packs/Microsoft.NETCore.App.Host.linux-x64/";
+        const auto hostLibSuffix = "/runtimes/linux-x64/native/libnethost.so";
+
+        DIR* dir = opendir(hostBaseDir);
+
+        if (dir != nullptr)
+        {
+            dirent* directoryEntry = readdir(dir);
+
+            while (directoryEntry != nullptr)
+            {
+                if (directoryEntry->d_type == DT_DIR)
+                {
+                    const auto path = (std::string(hostBaseDir) + directoryEntry->d_name + hostLibSuffix);
+
+                    nethost = dlopen(path.c_str(), RTLD_LAZY);
+                    if (nethost)
+                    {
+                        LOG_INFO("Loaded libnethost.so from: %s (autodetected)", path);
+                        break;
+                    }
+                }
+
+                directoryEntry = readdir(dir);
+            }
+
+            closedir(dir);
         }
     }
 


### PR DESCRIPTION
This should be a more permanent fix over adding each dotnet-sdk release to the paths lists (e.g. #905)