### PR TITLE
scripts: Leave off the folders in the generated NWScript.zip and other stuff

### DIFF
--- a/Scripts/packageNWScript.sh
+++ b/Scripts/packageNWScript.sh
@@ -1,34 +1,4 @@
 #!/bin/bash
 
-for i in `find . -name NWScript`; do
-    scriptdir=`dirname $i`
-    folder=Binaries/NWScript/`basename $scriptdir`
-
-    if [ "$scriptdir" == "./Plugins/DotNET/NWN" ]; then
-      continue
-    fi
-
-    mkdir -p $folder
-    for n in $i/*.nss; do
-        if [[ ! `basename $n` =~ (_t+[0-9]{0,1}.nss) ]]; then
-            cp $n $folder/`basename $n`
-        fi
-    done
-done
-
-pushd Binaries
-
 echo "Zipping NWScripts..."
-zip -r NWScript.zip NWScript > /dev/null
-
-pushd NWScript
-for i in `find . -name *.nss`; do
-    rm $i
-done
-for d in *; do
-    rmdir -p $d
-done
-popd
-rmdir -p NWScript
-
-popd
+zip -j Binaries/NWScript.zip `find . -name "*.nss" -not -path "./build-nwnx/*" | grep -Pv '_t+[0-9]{0,1}.nss'` > /dev/null


### PR DESCRIPTION
My thoughts:

* If there are name collisions among scripts that's a problem that needs to be immediately addressed.  
* I don't personally see anyone enjoying picking through N folders in a zip to update their nwnx headers, they could easily get missed and adding them all does no real harm.
* If the test scripts are in there, which had been purposefully excluded, i think some people might want those.