### PR TITLE
[Docker/Admin Plugin] Make ShutdownServer graceful

### DIFF
--- a/Plugins/Administration/Administration.cpp
+++ b/Plugins/Administration/Administration.cpp
@@ -128,9 +128,9 @@ Events::ArgumentStack Administration::SetDMPassword(Events::ArgumentStack&& args
 Events::ArgumentStack Administration::ShutdownServer(Events::ArgumentStack&&)
 {
     LOG_NOTICE("Shutting down the server!");
-    if (kill(getpid(), SIGTERM) != 0)
+    if (kill(getpid(), SIGINT) != 0)
     {
-      LOG_ERROR("Shutdown failed: SIGTERM signal not sent successfully");
+      LOG_ERROR("Shutdown failed: SIGINT signal not sent successfully");
     }
     return Events::Arguments();
 }

--- a/Plugins/Administration/Administration.cpp
+++ b/Plugins/Administration/Administration.cpp
@@ -128,10 +128,7 @@ Events::ArgumentStack Administration::SetDMPassword(Events::ArgumentStack&& args
 Events::ArgumentStack Administration::ShutdownServer(Events::ArgumentStack&&)
 {
     LOG_NOTICE("Shutting down the server!");
-    if (kill(getpid(), SIGINT) != 0)
-    {
-      LOG_ERROR("Shutdown failed: SIGINT signal not sent successfully");
-    }
+    *Globals::ExitProgram() = true;
     return Events::Arguments();
 }
 


### PR DESCRIPTION
Currently, the server process seems to treat SIGTERM like SIGKILL, and can sometimes prevent plugins from flushing data to disk. I'm not sure if this might make sense as a nwn issue instead as [SIGTERM should allow for a graceful shutdown.](https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html).





