### PR TITLE
skillranks: Couple minor things

### DIFF
--- a/Plugins/SkillRanks/SkillRanks.cpp
+++ b/Plugins/SkillRanks/SkillRanks.cpp
@@ -694,7 +694,11 @@ char SkillRanks::GetSkillRankHook(
     if (pArea)
     {
         auto *pPOS = g_plugin->GetServices()->m_perObjectStorage.get();
-        retVal += *pPOS->Get<int>(pArea->m_idSelf, areaModPOSKey + std::to_string(nSkill));
+        if(auto areaMod = pPOS->Get<int>(pArea->m_idSelf, areaModPOSKey + std::to_string(nSkill))) 
+        {
+            retVal += *areaMod;
+        }
+
     }
 
     if (!bHasOverrideKeyAbilityFeat)

--- a/Plugins/SkillRanks/SkillRanks.cpp
+++ b/Plugins/SkillRanks/SkillRanks.cpp
@@ -77,7 +77,7 @@ SkillRanks::SkillRanks(const Plugin::CreateParams& params)
 
     GetServices()->m_hooks->RequestSharedHook<Functions::_ZN8CNWRules15LoadRulesetInfoEv, void, CNWRules*>(&LoadRulesetInfoHook);
     GetServices()->m_hooks->RequestExclusiveHook<Functions::_ZN17CNWSCreatureStats12GetSkillRankEhP10CNWSObjecti,
-        int32_t, CNWSCreatureStats*, uint8_t, CNWSObject*, int32_t>(&GetSkillRankHook);
+        char, CNWSCreatureStats*, uint8_t, CNWSObject*, int32_t>(&GetSkillRankHook);
 }
 
 SkillRanks::~SkillRanks()
@@ -559,7 +559,7 @@ void SkillRanks::LoadRulesetInfoHook(bool before, CNWRules* pRules)
     }
 }
 
-int32_t SkillRanks::GetSkillRankHook(
+char SkillRanks::GetSkillRankHook(
         CNWSCreatureStats* thisPtr,
         uint8_t nSkill,
         CNWSObject* pVersus,

--- a/Plugins/SkillRanks/SkillRanks.hpp
+++ b/Plugins/SkillRanks/SkillRanks.hpp
@@ -28,7 +28,7 @@ private:
     ArgumentStack SetAreaModifier             (ArgumentStack&& args);
 
     static void LoadRulesetInfoHook(bool, CNWRules*);
-    static int32_t GetSkillRankHook(CNWSCreatureStats*, uint8_t, CNWSObject*, int32_t);
+    static char GetSkillRankHook(CNWSCreatureStats*, uint8_t, CNWSObject*, int32_t);
 
     uint8_t m_blindnessMod;
 


### PR DESCRIPTION
In my testing this:

https://github.com/nwnxee/unified/blob/353368431564a0f1f03c4534c4af1b96c3711d72/Plugins/SkillRanks/SkillRanks.cpp#L694-L698

was causing problems.  I'm thinking maybe the old Maybe maybe default-initialized its vaules even when it technically did not have a value and so something like this might have worked fine.  I'm definitely getting uninitialized values in GCC 9.3 tho.

There are some issues with the tests in general as well, they're not addressed here, but fyi.