### PR TITLE
plugins/events: Change a few params to const&

### DIFF
--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -140,14 +140,14 @@ Events::~Events()
 {
 }
 
-void Events::PushEventData(const std::string tag, const std::string data)
+void Events::PushEventData(const std::string& tag, const std::string& data)
 {
     LOG_DEBUG("Pushing event data: '%s' -> '%s'.", tag, data);
     g_plugin->CreateNewEventDataIfNeeded();
-    g_plugin->m_eventData.top().m_EventDataMap[tag] = std::move(data);
+    g_plugin->m_eventData.top().m_EventDataMap[tag] = data;
 }
 
-std::string Events::GetEventData(const std::string tag)
+std::string Events::GetEventData(const std::string& tag)
 {
     std::string retVal;
     if (g_plugin->m_eventDepth == 0 || g_plugin->m_eventData.empty())

--- a/Plugins/Events/Events.hpp
+++ b/Plugins/Events/Events.hpp
@@ -66,10 +66,10 @@ public:
     virtual ~Events();
 
     // Pushes event data to the stack - won't do anything until SignalEvent is called.
-    static void PushEventData(const std::string tag, const std::string data);
+    static void PushEventData(const std::string& tag, const std::string& data);
 
     // Get event data
-    static std::string GetEventData(const std::string tag);
+    static std::string GetEventData(const std::string& tag);
 
     // Returns true if the event can proceed, or false if the event has been skipped.
     static bool SignalEvent(const std::string& eventName, const NWNXLib::API::Types::ObjectID target, std::string *result=nullptr);


### PR DESCRIPTION
I didn't see these in https://github.com/nwnxee/unified/pull/852

I guess `const std::string data` could be `std::string` that parameter is sunk, someone tried to move from it so maybe the intention was to make the copy explicit in the signature?