### PR TITLE
[nwnxlib/plugin, services/plugins] Add check for build revision

### DIFF
--- a/NWNXLib/Plugin.cpp
+++ b/NWNXLib/Plugin.cpp
@@ -15,18 +15,14 @@ Plugin::Info::Info(std::string name,
     std::string description,
     std::string author,
     std::string contact,
-    const Version version,
-    const bool hotswap,
-    const uint32_t flags,
-    const Version targetVersion)
+    const uint32_t version,
+    const bool hotswap)
     : m_name(std::move(name)),
       m_description(std::move(description)),
       m_author(std::move(author)),
       m_contact(std::move(contact)),
       m_version(version),
-      m_hotswap(hotswap),
-      m_flags(flags),
-      m_targetVersion(targetVersion)
+      m_hotswap(hotswap)
 {
 }
 

--- a/NWNXLib/Plugin.hpp
+++ b/NWNXLib/Plugin.hpp
@@ -17,27 +17,22 @@ class Plugin
 public: // Structures
     struct Info
     {
-    public: // Structures
-        using Version = uint32_t;
-
-    public:
         Info(std::string name,
             std::string description,
             std::string author,
             std::string contact,
-            const Version version,
-            const bool hotswap,
-            const uint32_t flags = 0,
-            const Version targetVersion = NWNX_TARGET_NWN_BUILD);
+            const uint32_t version,
+            const bool hotswap);
 
         std::string m_name; // The plugin's name.
         std::string m_description; // The plugin's description.
         std::string m_author; // The author's name.
         std::string m_contact; // The author's or plugin's contact information.
-        Version m_version; // The plugin's version..
+        uint32_t m_version; // The plugin's version..
         bool m_hotswap; // Whether this plugin should be monitored and reloaded if the plugin changes.
-        uint32_t m_flags; // Any additional flags.
-        Version m_targetVersion; // The targetted build version
+
+        static const uint32_t s_targetBuild = NWNX_TARGET_NWN_BUILD; // The targetted build version
+        static const uint32_t s_targetBuildRevision = NWNX_TARGET_NWN_BUILD_REVISION;
     };
 
     struct CreateParams

--- a/NWNXLib/Services/Plugins/Plugins.cpp
+++ b/NWNXLib/Services/Plugins/Plugins.cpp
@@ -56,7 +56,7 @@ Plugins::RegistrationToken Plugins::LoadPlugin(const std::string& path, Plugin::
     // We capture a unique_ptr right away to avoid leak if the exception occurs.
     auto info = std::unique_ptr<Plugin::Info>(pluginInfoFuncPtr());
 
-    if (info->m_targetVersion != NWNX_TARGET_NWN_BUILD)
+    if (info->s_targetBuild != NWNX_TARGET_NWN_BUILD || info->s_targetBuildRevision != NWNX_TARGET_NWN_BUILD_REVISION)
     {
         throw std::runtime_error("Plugin version mismatch -- has the server updated?");
     }

--- a/Plugins/MaxLevel/MaxLevel.cpp
+++ b/Plugins/MaxLevel/MaxLevel.cpp
@@ -39,8 +39,7 @@ NWNX_PLUGIN_ENTRY Plugin::Info* PluginInfo()
                     "orth",
                     "plenarius@gmail.com",
                     1,
-                    true,
-                    0
+                    true
             };
 }
 


### PR DESCRIPTION
* Change m_targetVersion to s_targetBuild, make it a static member (I can't see anyone wanting to pass in that value)
* Add s_targetBuildReisvion cause the addresses aren't stable among build revisions and if they don't match in a hook bad times will be had.
* Check when the plugin is loaded that both build and revision match.
* Get rid of m_flags, it's never used, not obvious how it would be used.  Easier to add it back if a need arose than having it and trying to figure out what it's supposed to be used for.
* Remove some pointless public access specifiers on a struct
* Remove the `Version` alias.  Maybe there was going to be a bigger idea here, but 90%+ of the plugins are still version 1 anyway.

I imagine all plugins are in tree or downstream in tree so these changes really wouldn't make a ton of difference.