### PR TITLE
m_formats and m_lengths must be allocated or bad things will happen

### DIFF
--- a/Plugins/SQL/Targets/PostgreSQL.cpp
+++ b/Plugins/SQL/Targets/PostgreSQL.cpp
@@ -98,6 +98,8 @@ bool PostgreSQL::PrepareQuery(const Query& query)
     LOG_DEBUG("Detected %d parameters.", m_paramCount);
 
     m_params.resize(m_paramCount);
+    m_formats.resize(m_paramCount);
+    m_lengths.resize(m_paramCount);
 
     PGresult *res = PQprepare(m_conn,      // connection
                         "",                // statement name, blank in this case.


### PR DESCRIPTION
follow up to the "binary blob" changes.   m_formats and m_lengths were not allocated so this caused seg faults when using parameterized queries.