### PR TITLE
scriptvariant: Fix char* going to UserDefined

### DIFF
--- a/NWNXLib/ScriptVariant.hpp
+++ b/NWNXLib/ScriptVariant.hpp
@@ -12,7 +12,6 @@ namespace NWNXLib
 {
 
 struct NullArgument {};
-using UserDefined = void*;
 
 namespace detail
 {
@@ -25,15 +24,14 @@ constexpr bool is_argument_type()
         || std::is_same_v<T, API::Types::ObjectID>
         || std::is_same_v<T, std::string>
         || std::is_same_v<T, CGameEffect*>
-        || std::is_same_v<T, NullArgument>
-        || std::is_same_v<T, UserDefined>);
+        || std::is_same_v<T, NullArgument>);
 }
 
 } // namespace detail
 
 struct ScriptVariant
 {
-    using Variant = std::variant<NullArgument, int32_t, float, API::Types::ObjectID, std::string, CGameEffect*, UserDefined>;
+    using Variant = std::variant<NullArgument, int32_t, float, API::Types::ObjectID, std::string, CGameEffect*>;
     Variant m_data;
 
     // Constructors


### PR DESCRIPTION
Sorry about that, I'm just going to remove that for now since it's not used anywhere yet.

The issue is (partly) because of here:
https://github.com/nwnxee/unified/blob/49148fd442b02563ea09fb67782fd3fa1e3e6c1c/NWNXLib/API/API/CExoString.hpp#L50

Not sure there's anything that can be done about that.