### PR TITLE
Player: restore associate type after possession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ N/A
 
 ### Fixed
 - Core: fixed NWNX ResourceDirectory init crashing on failed module load
+- Player: fixed possessed associates from losing their associate type on unpossess
 
 
 ## 8193.13

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -1249,10 +1249,20 @@ ArgumentStack Player::PossessCreature(ArgumentStack&& args)
                             pPossessor->RemoveAssociate(possessedOidPOS);
                             pPOS->Remove(pPossessor->m_idSelf, "possessedOid");
                             pPOS->Remove(possessedOidPOS, "possessorOid");
+
+                            auto possessedAssociateType = *pPOS->Get<int>(pPossessor->m_idSelf, "possessedAssociateType");
+                            if (possessedAssociateType)
+                            {
+                                pPossessor->AddAssociate(possessedOidPOS, possessedAssociateType);
+                                pPOS->Remove(pPossessor->m_idSelf, "possessedAssociateType");
+                            }
                         }
                     }
                 });
     }
+
+    // Save previous associate type so it can be set back after unpossess
+    pPOS->Set(possessorId, "possessedAssociateType", (int32_t)pPossessed->m_nAssociateType);
 
     // If they already have a familiar we temporarily remove it as an associate
     // then we add the possessed creature as a familiar. We then add the regular familiar back.

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -1250,10 +1250,10 @@ ArgumentStack Player::PossessCreature(ArgumentStack&& args)
                             pPOS->Remove(pPossessor->m_idSelf, "possessedOid");
                             pPOS->Remove(possessedOidPOS, "possessorOid");
 
-                            auto possessedAssociateType = *pPOS->Get<int>(pPossessor->m_idSelf, "possessedAssociateType");
-                            if (possessedAssociateType)
+                            auto possessedAssociateType = pPOS->Get<int>(pPossessor->m_idSelf, "possessedAssociateType");
+                            if (possessedAssociateType && *possessedAssociateType != 0)
                             {
-                                pPossessor->AddAssociate(possessedOidPOS, possessedAssociateType);
+                                pPossessor->AddAssociate(possessedOidPOS, *possessedAssociateType);
                                 pPOS->Remove(pPossessor->m_idSelf, "possessedAssociateType");
                             }
                         }


### PR DESCRIPTION
If a summon or other non-familiar associate is possessed, the associate type should be reset back to its previous value when unpossessed. This prevents the PC from losing their associate from their party.

This commit will store the possessed creature's associate type, and if it has a type (i.e. is not zero), it will re-add the creature as that associate type to the possessor.