### PR TITLE
Weapon: fix a nullptr reference crash in GetEpicWeaponDevastatingCritical()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ N/A
 
 ### Fixed
 - Core: fixed NWNX ResourceDirectory init crashing on failed module load
-
+- Weapon: fixed a nullptr reference crash in GetEpicWeaponDevastatingCritical()
 
 ## 8193.13
 https://github.com/nwnxee/unified/compare/build8193.12...build8193.13

--- a/Plugins/Weapon/README.md
+++ b/Plugins/Weapon/README.md
@@ -49,6 +49,8 @@ The NWNX_Weapon_SetOption() function can be used to define the attack and damage
 
 This script just prints some info to the log and then bypasses the devastating critical 50% of the time. You have to set your script with NWNX_Weapon_SetDevastatingCriticalEventScript() (in the OnModuleLoad script for example)
 
+Note: `oWeapon` in `NWNX_Weapon_DevastatingCriticalEvent_Data` will be `OBJECT_INVALID` for Gloves/Unarmed Strike Devastating Critical Events. 
+
 ```cpp
 #include "nwnx_weapon"
 
@@ -70,4 +72,5 @@ void main()
       NWNX_Weapon_BypassDevastatingCritical();
       WriteTimestampedLogEntry("Devastating Critical Bypassed");
    }
-}```
+}
+```

--- a/Plugins/Weapon/Weapon.cpp
+++ b/Plugins/Weapon/Weapon.cpp
@@ -633,7 +633,7 @@ int32_t Weapon::GetEpicWeaponDevastatingCritical(CNWSCreatureStats* pStats, CNWS
         CNWSCombatRound      *pCombatRound = pCreature->m_pcCombatRound;
         CNWSCombatAttackData *pAttackData  = pCombatRound->GetAttack(pCombatRound->m_nCurrentAttack);
 
-        plugin.m_DCData.oidWeapon = pWeapon->m_idSelf;
+        plugin.m_DCData.oidWeapon = pWeapon ? pWeapon->m_idSelf : Constants::OBJECT_INVALID;
         plugin.m_DCData.oidTarget = pCreature->m_oidAttackTarget;
         plugin.m_DCData.nDamage   = pAttackData->GetTotalDamage(1);
         plugin.m_DCData.bBypass   = false;


### PR DESCRIPTION
Untested, but this should resolve #941 and resolve #893