### PR TITLE
Creature: add NWNX_Creature_SetMovementRateFactorCap

### DIFF
--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -1108,7 +1108,7 @@ ArgumentStack Creature::SetMovementRateFactorCap(ArgumentStack&& args)
                 }
             });
 
-        pSetMovementRateFactor_hook = GetServices()->m_hooks->FindHookByAddress(Functions::_ZN12CNWSCreature21GetMovementRateFactorEv);
+        pSetMovementRateFactor_hook = GetServices()->m_hooks->FindHookByAddress(Functions::_ZN12CNWSCreature21SetMovementRateFactorEf);
     }
 
     if (auto *pCreature = creature(args))

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -55,6 +55,7 @@ private:
     ArgumentStack SetMovementRate               (ArgumentStack&& args);
     ArgumentStack GetMovementRateFactor         (ArgumentStack&& args);
     ArgumentStack SetMovementRateFactor         (ArgumentStack&& args);
+    ArgumentStack SetMovementRateFactorCap      (ArgumentStack&& args);
     ArgumentStack SetAlignmentGoodEvil          (ArgumentStack&& args);
     ArgumentStack SetAlignmentLawChaos          (ArgumentStack&& args);
     ArgumentStack SetDomain                     (ArgumentStack&& args);

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -358,6 +358,12 @@ float NWNX_Creature_GetMovementRateFactor(object creature);
 /// @param rate The rate to set.
 void NWNX_Creature_SetMovementRateFactor(object creature, float rate);
 
+/// @brief Sets the creature's maximum movement rate cap.
+/// @note Default movement rate cap is 1.5.
+/// @param creature The creature object.
+/// @param cap The cap to set.
+void NWNX_Creature_SetMovementRateFactorCap(object creature, float cap);
+
 /// @brief Returns the creature's current movement type
 /// @param creature The creature object.
 /// @return An NWNX_CREATURE_MOVEMENT_TYPE_* constant.
@@ -1228,6 +1234,16 @@ void NWNX_Creature_SetMovementRateFactor(object creature, float factor)
     string sFunc = "SetMovementRateFactor";
 
     NWNX_PushArgumentFloat(NWNX_Creature, sFunc, factor);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_SetMovementRateFactorCap(object creature, float cap)
+{
+    string sFunc = "SetMovementRateFactorCap";
+
+    NWNX_PushArgumentFloat(NWNX_Creature, sFunc, cap);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 
     NWNX_CallFunction(NWNX_Creature, sFunc);


### PR DESCRIPTION
This PR adds functionality for upping the movement rate cap on creatures, which is usually capped at 1.5 base speed.

I've tested this in a sandbox environment, but I'm going to put it on my test server and see how it shakes out in order before I'm completely confident that there isn't any weirdness around it. To this end, I've added a WIP, though as far as I know the code is done.