### PR TITLE
Object: add GetCurrentHitPoints()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ N/A
 - Creature: AddAssociate()
 - Object: GetDoorHasVisibleModel()
 - Object: GetIsDestroyable()
+- Object: GetCurrentHitPoints()
 - Player: SetCustomToken()
 
 ### Changed

--- a/Plugins/Object/NWScript/nwnx_object.nss
+++ b/Plugins/Object/NWScript/nwnx_object.nss
@@ -69,6 +69,12 @@ object NWNX_Object_StringToObject(string id);
 /// @param bUpdateSubareas If TRUE and oObject is a creature, any triggers/traps at vPosition will fire their events.
 void NWNX_Object_SetPosition(object oObject, vector vPosition, int bUpdateSubareas = TRUE);
 
+/// @brief Get an object's hit points.
+/// @note Unlike the native GetCurrentHitpoints function, this excludes temporary hitpoints.
+/// @param obj The object.
+/// @return The hit points.
+int NWNX_Object_GetCurrentHitPoints(object obj);
+
 /// @brief Set an object's hit points.
 /// @param obj The object.
 /// @param hp The hit points.
@@ -407,6 +413,16 @@ void NWNX_Object_SetPosition(object oObject, vector vPosition, int bUpdateSubare
     NWNX_PushArgumentObject(NWNX_Object, sFunc, oObject);
 
     NWNX_CallFunction(NWNX_Object, sFunc);
+}
+
+int NWNX_Object_GetCurrentHitPoints(object creature)
+{
+    string sFunc = "GetCurrentHitPoints";
+
+    NWNX_PushArgumentObject(NWNX_Object, sFunc, creature);
+    NWNX_CallFunction(NWNX_Object, sFunc);
+
+    return NWNX_GetReturnValueInt(NWNX_Object, sFunc);
 }
 
 void NWNX_Object_SetCurrentHitPoints(object creature, int hp)

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -71,6 +71,7 @@ Object::Object(const Plugin::CreateParams& params)
     REGISTER(GetLocalVariable);
     REGISTER(StringToObject);
     REGISTER(SetPosition);
+    REGISTER(GetCurrentHitPoints);
     REGISTER(SetCurrentHitPoints);
     REGISTER(SetMaxHitPoints);
     REGISTER(Serialize);
@@ -223,6 +224,16 @@ ArgumentStack Object::SetPosition(ArgumentStack&& args)
         }
     }
     return Services::Events::Arguments();
+}
+
+ArgumentStack Object::GetCurrentHitPoints(ArgumentStack&& args)
+{
+    int32_t retval = 0;
+    if (auto *pObject = object(args))
+    {
+        retval = pObject->m_nCurrentHitPoints;
+    }
+    return Services::Events::Arguments(retval);
 }
 
 ArgumentStack Object::SetCurrentHitPoints(ArgumentStack&& args)

--- a/Plugins/Object/Object.hpp
+++ b/Plugins/Object/Object.hpp
@@ -20,6 +20,7 @@ private:
     ArgumentStack GetLocalVariable          (ArgumentStack&& args);
     ArgumentStack StringToObject            (ArgumentStack&& args);
     ArgumentStack SetPosition               (ArgumentStack&& args);
+    ArgumentStack GetCurrentHitPoints       (ArgumentStack&& args);
     ArgumentStack SetCurrentHitPoints       (ArgumentStack&& args);
     ArgumentStack SetMaxHitPoints           (ArgumentStack&& args);
     ArgumentStack Serialize                 (ArgumentStack&& args);


### PR DESCRIPTION
Fixes #951. This PR adds a `NWNX_Object_GetCurrentHitPoints` function, which returns the object's current HP, *excluding* any temporary HP.