### PR TITLE
Fix to prevent unlimited uses of potions/scrolls

### DIFF
--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -17,4 +17,5 @@ add_plugin(Tweaks
     "Tweaks/ItemChargesCost.cpp"
     "Tweaks/FixDispelEffectLevels.cpp"
     "Tweaks/AddPrestigeclassCasterLevels.cpp"
+    "Tweaks/FixUnlimitedPotionsBug.cpp"
 )

--- a/Plugins/Tweaks/README.md
+++ b/Plugins/Tweaks/README.md
@@ -24,6 +24,7 @@ Tweaks stuff. See below.
 * `NWNX_TWEAKS_ITEM_CHARGES_COST_MODE`: Between 1 and 3
 * `NWNX_TWEAKS_FIX_DISPEL_EFFECT_LEVELS`: true or false
 * `NWNX_TWEAKS_ADD_PRESTIGECLASS_CASTER_LEVELS`: true or false
+* `NWNX_TWEAKS_FIX_UNLIMITED_POTIONS_BUG`: true or false
 
 ## Environment variable values
 

--- a/Plugins/Tweaks/Tweaks.cpp
+++ b/Plugins/Tweaks/Tweaks.cpp
@@ -16,6 +16,7 @@
 #include "Tweaks/ItemChargesCost.hpp"
 #include "Tweaks/FixDispelEffectLevels.hpp"
 #include "Tweaks/AddPrestigeclassCasterLevels.hpp"
+#include "Tweaks/FixUnlimitedPotionsBug.hpp"
 
 #include "Services/Config/Config.hpp"
 
@@ -151,6 +152,12 @@ Tweaks::Tweaks(const Plugin::CreateParams& params)
     {
         LOG_INFO("Automatically adding prestige class caster levels using (Div|Arc)SpellLvlMod colums in classes.2da");
         m_AddPrestigeclassCasterLevels = std::make_unique<AddPrestigeclassCasterLevels>(GetServices()->m_hooks.get());
+    }
+
+    if (GetServices()->m_config->Get<bool>("FIX_UNLIMITED_POTIONS_BUG", false))
+    {
+        LOG_INFO("Fixing unlimited potion/scroll uses bug");
+        m_FixUnlimitedPotionsBug = std::make_unique<FixUnlimitedPotionsBug>(GetServices()->m_hooks.get());
     }
 }
 

--- a/Plugins/Tweaks/Tweaks.hpp
+++ b/Plugins/Tweaks/Tweaks.hpp
@@ -22,6 +22,7 @@ class FixGreaterSanctuaryBug;
 class ItemChargesCost;
 class FixDispelEffectLevels;
 class AddPrestigeclassCasterLevels;
+class FixUnlimitedPotionsBug;
 
 class Tweaks : public NWNXLib::Plugin
 {
@@ -47,6 +48,7 @@ private:
     std::unique_ptr<ItemChargesCost> m_ItemChargesCost;
     std::unique_ptr<FixDispelEffectLevels> m_FixDispelEffectLevels;
     std::unique_ptr<AddPrestigeclassCasterLevels> m_AddPrestigeclassCasterLevels;
+    std::unique_ptr<FixUnlimitedPotionsBug> m_FixUnlimitedPotionsBug;
 };
 
 }

--- a/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.cpp
+++ b/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.cpp
@@ -1,0 +1,52 @@
+#include "Tweaks/FixUnlimitedPotionsBug.hpp"
+
+#include "Services/Hooks/Hooks.hpp"
+#include "Utils.hpp"
+
+#include "API/C2DA.hpp"
+#include "API/CAppManager.hpp"
+#include "API/CExoString.hpp"
+#include "API/CNWSCombatRound.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/CNWSCreatureAppearanceInfo.hpp"
+#include "API/CNWSCreatureStats.hpp"
+#include "API/CNWSItem.hpp"
+#include "API/CNWItemProperty.hpp"
+#include "API/CNWSObjectActionNode.hpp"
+#include "API/CNWSpellArray.hpp"
+#include "API/CNWSRules.hpp"
+#include "API/CServerExoApp.hpp"
+#include "API/CTwoDimArrays.hpp"
+#include "API/CWorldTimer.hpp"
+#include "API/Vector.hpp"
+#include "API/Functions.hpp"
+
+namespace Tweaks {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+bool s_bUsableItemRemoval = false;
+NWNXLib::Hooking::FunctionHook* s_AddEventDeltaTimeHook = nullptr;
+
+FixUnlimitedPotionsBug::FixUnlimitedPotionsBug(Services::HooksProxy* hooker)
+{
+    hooker->RequestSharedHook<Functions::_ZN12CNWSCreature21AIActionItemCastSpellEP20CNWSObjectActionNode, uint32_t>(&CNWSCreature__AIActionItemCastSpell_hook);
+    hooker->RequestExclusiveHook<Functions::_ZN15CServerAIMaster17AddEventDeltaTimeEjjjjjPv>(&CServerAIMaster__AddEventDeltaTime);
+    s_AddEventDeltaTimeHook = hooker->FindHookByAddress(Functions::_ZN15CServerAIMaster17AddEventDeltaTimeEjjjjjPv);
+}
+
+BOOL FixUnlimitedPotionsBug::CServerAIMaster__AddEventDeltaTime(CServerAIMaster* thisPtr, uint32_t nDaysFromNow, uint32_t nTimeFromNow, OBJECT_ID nCallerObjectId, OBJECT_ID nObjectId, uint32_t nEventId, void* pScript)
+{
+    if (s_bUsableItemRemoval && nEventId == Constants::Event::DestroyObject)
+        nTimeFromNow = 0;
+
+    return s_AddEventDeltaTimeHook->CallOriginal<BOOL>(thisPtr, nDaysFromNow, nTimeFromNow, nCallerObjectId, nObjectId, nEventId, pScript);
+}
+
+void FixUnlimitedPotionsBug::CNWSCreature__AIActionItemCastSpell_hook(bool before, CNWSCreature*, CNWSObjectActionNode*)
+{
+    s_bUsableItemRemoval = before;
+}
+
+}

--- a/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.cpp
+++ b/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.cpp
@@ -11,7 +11,7 @@ using namespace NWNXLib;
 using namespace NWNXLib::API;
 
 static bool s_bUsableItemRemoval = false;
-NWNXLib::Hooking::FunctionHook* s_AddEventDeltaTimeHook = nullptr;
+static NWNXLib::Hooking::FunctionHook* s_AddEventDeltaTimeHook = nullptr;
 
 FixUnlimitedPotionsBug::FixUnlimitedPotionsBug(Services::HooksProxy* hooker)
 {

--- a/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.cpp
+++ b/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.cpp
@@ -10,7 +10,7 @@ namespace Tweaks {
 using namespace NWNXLib;
 using namespace NWNXLib::API;
 
-bool s_bUsableItemRemoval = false;
+static bool s_bUsableItemRemoval = false;
 NWNXLib::Hooking::FunctionHook* s_AddEventDeltaTimeHook = nullptr;
 
 FixUnlimitedPotionsBug::FixUnlimitedPotionsBug(Services::HooksProxy* hooker)

--- a/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.cpp
+++ b/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.cpp
@@ -3,22 +3,6 @@
 #include "Services/Hooks/Hooks.hpp"
 #include "Utils.hpp"
 
-#include "API/C2DA.hpp"
-#include "API/CAppManager.hpp"
-#include "API/CExoString.hpp"
-#include "API/CNWSCombatRound.hpp"
-#include "API/CNWSCreature.hpp"
-#include "API/CNWSCreatureAppearanceInfo.hpp"
-#include "API/CNWSCreatureStats.hpp"
-#include "API/CNWSItem.hpp"
-#include "API/CNWItemProperty.hpp"
-#include "API/CNWSObjectActionNode.hpp"
-#include "API/CNWSpellArray.hpp"
-#include "API/CNWSRules.hpp"
-#include "API/CServerExoApp.hpp"
-#include "API/CTwoDimArrays.hpp"
-#include "API/CWorldTimer.hpp"
-#include "API/Vector.hpp"
 #include "API/Functions.hpp"
 
 namespace Tweaks {

--- a/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.hpp
+++ b/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "API/Types.hpp"
+#include "Common.hpp"
+#include "Services/Hooks/Hooks.hpp"
+
+class CNWSObjectActionNode;
+
+namespace Tweaks {
+
+class FixUnlimitedPotionsBug
+{
+public:
+    FixUnlimitedPotionsBug(NWNXLib::Services::HooksProxy* hooker);
+
+private:
+    static void CNWSCreature__AIActionItemCastSpell_hook(bool before, CNWSCreature* thisPtr, CNWSObjectActionNode* pNode);
+    static BOOL CServerAIMaster__AddEventDeltaTime(CServerAIMaster* thisPtr, uint32_t nDaysFromNow, uint32_t nTimeFromNow, OBJECT_ID nCallerObjectId, OBJECT_ID nObjectId, uint32_t nEventId, void* pScript);
+};
+
+}


### PR DESCRIPTION
Disclaimer: Use at your own risk.

Demo: https://www.youtube.com/watch?v=NeDrCFpZ090

Tested in 8193.12, it should work in newer versions.

It removes the item instantly right before the effect is applied, preventing users from triggering the bug by un/stacking items. I don't think it should cause any issues because when the item is removed the info needed by the spell script is stored already and the item/oid isn't used anywhere as far as I can tell, other than to signal the source of the spell.

I thought about moving the item somewhere so the player can't interact with it and destroying it after the spell is cast, but I don't think it's needed. If the fix causes any issues this alternative approach might work.