### PR TITLE
Add spawn point encounter functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ N/A
 - Player: SetCustomToken()
 - Player: SetCreatureNameOverride()
 - Util: CreateDoor()
+- Encounters: GetNumberOfSpawnPoints(), GetSpawnPointByIndex()
+- Encounters: GetMinNumSpawned(), GetMaxNumSpawned(), GetCurrentNumSpawned()
 
 ### Changed
 - Object: SetPosition() now has a toggle(default true) to update subareas if oObject is a creature, this means any traps/triggers at the new position will fire their events.

--- a/Plugins/Encounter/Encounter.cpp
+++ b/Plugins/Encounter/Encounter.cpp
@@ -3,6 +3,7 @@
 #include "API/CAppManager.hpp"
 #include "API/CServerExoApp.hpp"
 #include "API/CNWSEncounter.hpp"
+#include "API/CEncounterSpawnPoint.hpp"
 #include "API/CEncounterListEntry.hpp"
 #include "API/Constants.hpp"
 #include "API/Globals.hpp"
@@ -39,6 +40,11 @@ Encounter::Encounter(Services::ProxyServiceList* services)
     REGISTER(SetPlayerTriggeredOnly);
     REGISTER(GetResetTime);
     REGISTER(SetResetTime);
+    REGISTER(GetNumberOfSpawnPoints);
+    REGISTER(GetSpawnPointByIndex);
+    REGISTER(GetMinNumSpawned);
+    REGISTER(GetMaxNumSpawned);
+    REGISTER(GetCurrentNumSpawned);
 
 #undef REGISTER
 }
@@ -88,6 +94,7 @@ ArgumentStack Encounter::GetEncounterCreatureByIndex(ArgumentStack&& args)
     if (auto *pEncounter = encounter(args))
     {
         const auto index = Services::Events::ExtractArgument<int32_t>(args);
+        ASSERT_OR_THROW(index >= 0.0);
 
         if (index < pEncounter->m_nNumEncounterListEntries)
         {
@@ -107,7 +114,7 @@ ArgumentStack Encounter::SetEncounterCreatureByIndex(ArgumentStack&& args)
         const auto index = Services::Events::ExtractArgument<int32_t>(args);
         const auto resRef = Services::Events::ExtractArgument<std::string>(args);
         auto cr = Services::Events::ExtractArgument<float>(args);
-          ASSERT_OR_THROW(cr >= 0.0);
+        ASSERT_OR_THROW(cr >= 0.0);
         auto unique = Services::Events::ExtractArgument<int32_t>(args);
         unique = !!unique;
 
@@ -192,12 +199,78 @@ ArgumentStack Encounter::SetResetTime(ArgumentStack&& args)
     if (auto *pEncounter = encounter(args))
     {
         auto resetTime = Services::Events::ExtractArgument<int32_t>(args);
-          ASSERT_OR_THROW(resetTime >= 0);
+        ASSERT_OR_THROW(resetTime >= 0);
 
         pEncounter->m_nResetTime = resetTime;
     }
 
     return Services::Events::Arguments();
+}
+
+ArgumentStack Encounter::GetNumberOfSpawnPoints(ArgumentStack&& args)
+{
+    int32_t retVal = 0;
+
+    if (auto *pEncounter = encounter(args))
+    {
+        retVal = pEncounter->m_nNumSpawnPoints;
+    }
+
+    return Services::Events::Arguments(retVal);
+}
+
+ArgumentStack Encounter::GetSpawnPointByIndex(ArgumentStack&& args)
+{
+    float x = 0.0, y = 0.0, z = 0.0, o = 0.0;
+
+    if (auto *pEncounter = encounter(args))
+    {
+        const auto index = Services::Events::ExtractArgument<int32_t>(args);
+        ASSERT_OR_THROW(index >= 0);
+
+        if (index < pEncounter->m_nNumSpawnPoints)
+        {
+            x = pEncounter->m_pSpawnPointList[index].m_vPosition.x;
+            y = pEncounter->m_pSpawnPointList[index].m_vPosition.y;
+            z = pEncounter->m_pSpawnPointList[index].m_vPosition.z;
+            o = pEncounter->m_pSpawnPointList[index].m_fOrientation;
+        }
+    }
+
+    return Services::Events::Arguments(x, y, z, o);
+}
+
+ArgumentStack Encounter::GetMinNumSpawned(ArgumentStack&& args)
+{
+    int32_t retVal = 0;
+    if (auto *pEncounter = encounter(args))
+    {
+        retVal = pEncounter->m_nMinNumSpawnedCreatures;
+    }
+
+    return Services::Events::Arguments(retVal);
+}
+
+ArgumentStack Encounter::GetMaxNumSpawned(ArgumentStack&& args)
+{
+    int32_t retVal = 0;
+    if (auto *pEncounter = encounter(args))
+    {
+        retVal = pEncounter->m_nMaxSpawnedCreatures;
+    }
+
+    return Services::Events::Arguments(retVal);
+}
+
+ArgumentStack Encounter::GetCurrentNumSpawned(ArgumentStack&& args)
+{
+    int32_t retVal = 0;
+    if (auto *pEncounter = encounter(args))
+    {
+        retVal = pEncounter->m_nNumSpawnedCreatures;
+    }
+
+    return Services::Events::Arguments(retVal);
 }
 
 }

--- a/Plugins/Encounter/Encounter.hpp
+++ b/Plugins/Encounter/Encounter.hpp
@@ -24,6 +24,11 @@ private:
     ArgumentStack SetPlayerTriggeredOnly                    (ArgumentStack&& args);
     ArgumentStack GetResetTime                              (ArgumentStack&& args);
     ArgumentStack SetResetTime                              (ArgumentStack&& args);
+    ArgumentStack GetNumberOfSpawnPoints                    (ArgumentStack&& args);
+    ArgumentStack GetSpawnPointByIndex                      (ArgumentStack&& args);
+    ArgumentStack GetMinNumSpawned                          (ArgumentStack&& args);
+    ArgumentStack GetMaxNumSpawned                          (ArgumentStack&& args);
+    ArgumentStack GetCurrentNumSpawned                      (ArgumentStack&& args);
 
     CNWSEncounter *encounter(ArgumentStack& args);
 

--- a/Plugins/Encounter/NWScript/nwnx_encounter.nss
+++ b/Plugins/Encounter/NWScript/nwnx_encounter.nss
@@ -14,6 +14,7 @@ struct NWNX_Encounter_CreatureListEntry
     int unique; ///< Creature will be unique to the encounter.
 };
 
+
 /// @brief Get the number of creatures in the encounter list
 /// @param encounter The encounter object.
 /// @return The number of creatures in the encounter list.
@@ -43,7 +44,7 @@ void NWNX_Encounter_SetFactionId(object encounter, int factionId);
 
 /// @brief Get if encounter is player triggered only.
 /// @param encounter The encounter object.
-/// @return TRUE is encounter is player triggered only.
+/// @return TRUE if encounter is player triggered only.
 int NWNX_Encounter_GetPlayerTriggeredOnly(object encounter);
 
 /// @brief Set if encounter is player triggered only.
@@ -60,6 +61,32 @@ int NWNX_Encounter_GetResetTime(object encounter);
 /// @param encounter The encounter object.
 /// @param resetTime The seconds the encounter will reset.
 void NWNX_Encounter_SetResetTime(object encounter, int resetTime);
+
+/// @brief Get the number of spawn points of encounter.
+/// @param encounter The encounter object.
+/// @return The count of the spawn points for the encounter.
+int NWNX_Encounter_GetNumberOfSpawnPoints(object encounter);
+
+/// @brief Gets the spawn point list entry at the specified index
+/// @param encounter The encounter object.
+/// @param index The index of the spawn point in the encounter list.
+/// @return Location of spawn point.
+location NWNX_Encounter_GetSpawnPointByIndex(object encounter, int index);
+
+/// @brief Get the minimum amount of creatures that encounter will spawn.
+/// @param encounter The encounter object.
+/// @return the minimal amount.
+int NWNX_Encounter_GetMinNumSpawned(object encounter);
+
+/// @brief Get the maximum amount of creatures that encounter will spawn.
+/// @param encounter The encounter object.
+/// @return the maximal amount.
+int NWNX_Encounter_GetMaxNumSpawned(object encounter);
+
+/// @brief Get the current number of creatures that are spawned and alive
+/// @param encounter The encounter object.
+/// @return amount of creatures
+int NWNX_Encounter_GetCurrentNumSpawned(object encounter);
 
 /// @}
 
@@ -161,4 +188,60 @@ void NWNX_Encounter_SetResetTime(object encounter, int resetTime)
     NWNX_PushArgumentObject(NWNX_Encounter, sFunc, encounter);
 
     NWNX_CallFunction(NWNX_Encounter, sFunc);
+}
+
+int NWNX_Encounter_GetNumberOfSpawnPoints(object encounter)
+{
+    string sFunc = "GetNumberOfSpawnPoints";
+  
+    NWNX_PushArgumentObject(NWNX_Encounter, sFunc, encounter);
+    NWNX_CallFunction(NWNX_Encounter, sFunc);
+  
+    return NWNX_GetReturnValueInt(NWNX_Encounter, sFunc);
+}
+
+location NWNX_Encounter_GetSpawnPointByIndex(object encounter, int index)
+{
+    string sFunc = "GetSpawnPointByIndex";
+  
+    NWNX_PushArgumentInt(NWNX_Encounter, sFunc, index);
+    NWNX_PushArgumentObject(NWNX_Encounter, sFunc, encounter);
+    NWNX_CallFunction(NWNX_Encounter, sFunc);
+  
+    float o = NWNX_GetReturnValueFloat(NWNX_Encounter, sFunc);
+    float z = NWNX_GetReturnValueFloat(NWNX_Encounter, sFunc);
+    float y = NWNX_GetReturnValueFloat(NWNX_Encounter, sFunc);
+    float x = NWNX_GetReturnValueFloat(NWNX_Encounter, sFunc);
+  
+    return Location(GetArea(encounter), Vector(x, y, z), o);
+}
+
+int NWNX_Encounter_GetMinNumSpawned(object encounter)
+{
+    string sFunc = "GetMinNumSpawned";
+  
+    NWNX_PushArgumentObject(NWNX_Encounter, sFunc, encounter);
+    NWNX_CallFunction(NWNX_Encounter, sFunc);
+  
+    return NWNX_GetReturnValueInt(NWNX_Encounter, sFunc);
+}
+
+int NWNX_Encounter_GetMaxNumSpawned(object encounter)
+{
+    string sFunc = "GetMaxNumSpawned";
+  
+    NWNX_PushArgumentObject(NWNX_Encounter, sFunc, encounter);
+    NWNX_CallFunction(NWNX_Encounter, sFunc);
+  
+    return NWNX_GetReturnValueInt(NWNX_Encounter, sFunc);
+}
+
+int NWNX_Encounter_GetCurrentNumSpawned(object encounter)
+{
+    string sFunc = "GetCurrentNumSpawned";
+  
+    NWNX_PushArgumentObject(NWNX_Encounter, sFunc, encounter);
+    NWNX_CallFunction(NWNX_Encounter, sFunc);
+  
+    return NWNX_GetReturnValueInt(NWNX_Encounter, sFunc);
 }


### PR DESCRIPTION
I had a toolset crash everytime I wanted to do this:

```
/// @brief A spawn point list entry for an encounter.
struct NWNX_Encounter_SpawnPoint
{
    vector vec; ///< The vector.
    float orientation; ///< The orientation.
};
```

So I didn't take the high road and used x,y,z directly.