### PR TITLE
Events: allow any integer result in equip validation

### DIFF
--- a/Plugins/Events/Events/ItemEvents.cpp
+++ b/Plugins/Events/Events/ItemEvents.cpp
@@ -329,7 +329,7 @@ int32_t ItemEvents::CanEquipItemHook(CNWSCreature* thisPtr, CNWSItem* pItem, uin
     Events::PushEventData("BEFORE_RESULT", std::to_string(retVal));
     Events::SignalEvent("NWNX_ON_VALIDATE_ITEM_EQUIP_AFTER", thisPtr->m_idSelf, &sAfterEventResult);
 
-    retVal = sAfterEventResult.empty() ? retVal : sAfterEventResult == "1";
+    retVal = sAfterEventResult.empty() ? retVal : std::stoi(sAfterEventResult);
 
     return retVal;
 }


### PR DESCRIPTION
This fixes #958 by allowing the `NWNX_ON_VALIDATE_ITEM_EQUIP_AFTER` event to return any integer, rather than just `0` or `1`.

Ideally we could be a little smarter and automate the process, since it appears that a value of `2` means "replace the current item in the slot" and a value of `3` means "replace the current main and offhand weapon in the slot". More experimentation of whether this is the right interpretation is probably needed.

In my case, I manually check in NWScript whether the chest slot is occupied, and return `1` or `2` depending on that.

However, while this PR could be improved, this at least makes it possible to use the validate equip event on occupied slots, and may do as an interim solution.