### PR TITLE
PlayerDM Login/Logout Events and ToggleDM function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 https://github.com/nwnxee/unified/compare/build8193.14...HEAD
 
 ### Added
-N/A
+- Events: added skippable PlayerDM Login/Logout events to DMActionEvents
 
 ##### New Plugins
 N/A
 
 ##### New NWScript Functions
-N/A
+- Player: ToggleDM()
 
 ### Changed
 N/A
@@ -37,7 +37,6 @@ https://github.com/nwnxee/unified/compare/build8193.13...build8193.14
 - Events: added TogglePause to InputEvents
 - Tweaks: added `NWNX_TWEAKS_FIX_UNLIMITED_POTIONS_BUG` to prevent the unlimited potions/scrolls bug.
 - Tweaks: added `NWNX_TWEAKS_UNHARDCODE_SHIELDS` to change shield AC and create new shield-like items using the BaseAC column in baseitems.2da.
-- Utils: added SetItemActivator to set the value returned by GetItemActivator
 
 ##### New NWScript Functions
 - Creature: {Get|Set}CriticalMultiplier{Modifier|Override}() and {Get|Set}CriticalRange{Modifier|Override}()
@@ -54,6 +53,7 @@ https://github.com/nwnxee/unified/compare/build8193.13...build8193.14
 - Player: SetCreatureNameOverride()
 - Player: FloatingTextStringOnCreature();
 - Util: CreateDoor()
+- Util: SetItemActivator()
 
 ### Changed
 - Object: SetPosition() now has a toggle(default true) to update subareas if oObject is a creature, this means any traps/triggers at the new position will fire their events.

--- a/NWNXLib/API/Constants/Messages.hpp
+++ b/NWNXLib/API/Constants/Messages.hpp
@@ -1199,6 +1199,9 @@ namespace MessageDungeonMasterMinor
         Difficulty                       = 0x11,
         ViewInventory                    = 0x12,
         SpawnTrapOnObject                = 0x13,
+        Login                            = 0x14,
+        Logout                           = 0x15,
+        LoginState                       = 0x16,
         Heal                             = 0x20,
         Kill                             = 0x21,
         Goto                             = 0x22,
@@ -1267,6 +1270,9 @@ namespace MessageDungeonMasterMinor
             case Difficulty:             return "Difficulty";
             case ViewInventory:          return "ViewInventory";
             case SpawnTrapOnObject:      return "SpawnTrapOnObject";
+            case Login:                  return "Login";
+            case Logout:                 return "Logout";
+            case LoginState:             return "LoginState";
             case Heal:                   return "Heal";
             case Kill:                   return "Kill";
             case Goto:                   return "Goto";

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -19,7 +19,7 @@ __________________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    ASSOCIATE_OBJECT_ID   | object | Convert to object with NWNX_Object_StringToObject()
+    ASSOCIATE_OBJECT_ID   | object | Convert to object with StringToObject()
 
 _______________________________________
     ## Stealth Events
@@ -39,7 +39,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    EXAMINEE_OBJECT_ID    | object | Convert to object with NWNX_Object_StringToObject()
+    EXAMINEE_OBJECT_ID    | object | Convert to object with StringToObject()
     TRAP_EXAMINE_SUCCESS  | int    | For trap examine only, whether the examine succeeded
 
 _______________________________________
@@ -51,7 +51,7 @@ _______________________________________
 
     Event Data Tag          | Type   | Notes |
     ------------------------|--------|-------|
-    ITEM_OBJECT_ID          | object | Convert to object with NWNX_Object_StringToObject()|
+    ITEM_OBJECT_ID          | object | Convert to object with StringToObject()|
     BEFORE_RESULT           | int    | TRUE/FALSE, only in _AFTER events|
 
     @note Setting the result to "0" will cause the item to appear unusable (red) in the inventory.
@@ -67,8 +67,8 @@ _______________________________________
 
     Event Data Tag          | Type   | Notes |
     ------------------------|--------|-------|
-    ITEM_OBJECT_ID          | object | Convert to object with NWNX_Object_StringToObject()|
-    TARGET_OBJECT_ID        | object | Convert to object with NWNX_Object_StringToObject()|
+    ITEM_OBJECT_ID          | object | Convert to object with StringToObject()|
+    TARGET_OBJECT_ID        | object | Convert to object with StringToObject()|
     ITEM_PROPERTY_INDEX     | int    | |
     ITEM_SUB_PROPERTY_INDEX | int    | |
     TARGET_POSITION_X       | float  | |
@@ -90,7 +90,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    OWNER                 | object |Convert to object with NWNX_Object_StringToObject()
+    OWNER                 | object |Convert to object with StringToObject()
 
 _______________________________________
     ## Ammunition Reload Events
@@ -114,7 +114,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    SCROLL                | object | Convert to object with NWNX_Object_StringToObject()
+    SCROLL                | object | Convert to object with StringToObject()
 
 _______________________________________
     ## Validate Item Equip Events
@@ -125,7 +125,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes |
     ----------------------|--------|-------|
-    ITEM_OBJECT_ID        | object | Convert to object with NWNX_Object_StringToObject()|
+    ITEM_OBJECT_ID        | object | Convert to object with StringToObject()|
     SLOT                  | int    | INVENTORY_SLOT_* Constant|
     BEFORE_RESULT         | int    | TRUE/FALSE, only in _AFTER events|
 
@@ -142,7 +142,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes |
     ----------------------|--------|-------|
-    ITEM                  | object | Convert to object with NWNX_Object_StringToObject()|
+    ITEM                  | object | Convert to object with StringToObject()|
     SLOT                  | int    | |
 
 _______________________________________
@@ -154,7 +154,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    ITEM                  | object | Convert to object with NWNX_Object_StringToObject()
+    ITEM                  | object | Convert to object with StringToObject()
 
     @note These events do not trigger when equipment is replaced by equipping another item.
 _______________________________________
@@ -177,7 +177,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    ITEM                  | object |Convert to object with NWNX_Object_StringToObject()
+    ITEM                  | object |Convert to object with StringToObject()
 
 _______________________________________
     ## Item Pay To Identify Events
@@ -188,8 +188,8 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    ITEM                  | object | Convert to object with NWNX_Object_StringToObject()
-    STORE                 | object | Convert to object with NWNX_Object_StringToObject()
+    ITEM                  | object | Convert to object with StringToObject()
+    STORE                 | object | Convert to object with StringToObject()
 
 _______________________________________
     ## Item Split Events
@@ -200,7 +200,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes|
     ----------------------|--------|-------|
-    ITEM                  | object | Convert to object with NWNX_Object_StringToObject()|
+    ITEM                  | object | Convert to object with StringToObject()|
     NUMBER_SPLIT_OFF      | int    | |
 
 _______________________________________
@@ -214,8 +214,8 @@ _______________________________________
     ----------------------|--------|-------|
     FEAT_ID               | int    | |
     SUBFEAT_ID            | int    | |
-    TARGET_OBJECT_ID      | object | Convert to object with NWNX_Object_StringToObject() |
-    AREA_OBJECT_ID        | object | Convert to object with NWNX_Object_StringToObject() |
+    TARGET_OBJECT_ID      | object | Convert to object with StringToObject() |
+    AREA_OBJECT_ID        | object | Convert to object with StringToObject() |
     TARGET_POSITION_X     | float  | |
     TARGET_POSITION_Y     | float  | |
     TARGET_POSITION_Z     | float  | |
@@ -236,7 +236,7 @@ _______________________________________
     Event Data Tag        | Type   | Notes |
     ----------------------|--------|-------|
     AMOUNT                | int    | |
-    OBJECT                | object | Convert to object with NWNX_Object_StringToObject() |
+    OBJECT                | object | Convert to object with StringToObject() |
     ALIGNMENT_TYPE        | int    | Only valid for `NWNX_ON_DM_GIVE_ALIGNMENT_*` |
 
 _______________________________________
@@ -248,7 +248,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes |
     ----------------------|--------|-------|
-    AREA                  | object | Convert to object with NWNX_Object_StringToObject() |
+    AREA                  | object | Convert to object with StringToObject() |
     OBJECT                | object | Only returns a valid object in *_AFTER |
     OBJECT_TYPE           | int    | Returns `NWNX_EVENTS_OBJECT_TYPE_*` |
     POS_X                 | float  | |
@@ -264,7 +264,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    TARGET                | object | Convert to object with NWNX_Object_StringToObject()
+    TARGET                | object | Convert to object with StringToObject()
     ITEM                  | object | Only returns a valid object in *_AFTER
 
 _______________________________________
@@ -308,7 +308,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    TARGET                | object | Convert to object with NWNX_Object_StringToObject()
+    TARGET                | object | Convert to object with StringToObject()
 
     @note If `TARGET` is `OBJECT_INVALID` for `NWNX_ON_DM_POSSESS_*`, the DM is unpossessing.
 
@@ -325,7 +325,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes |
     ----------------------|--------|-------|
-    TARGET_AREA           | object | Convert to object with NWNX_Object_StringToObject() |
+    TARGET_AREA           | object | Convert to object with StringToObject() |
     POS_X                 | float  | |
     POS_Y                 | float  | |
     POS_Z                 | float  | |
@@ -353,7 +353,7 @@ _______________________________________
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
     OPEN_INVENTORY        | int    | TRUE if opening an inventory, FALSE if closing
-    TARGET                | object | Convert to object with NWNX_Object_StringToObject()
+    TARGET                | object | Convert to object with StringToObject()
 
 _______________________________________
     ## DM Spawn Trap Events
@@ -364,8 +364,8 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    AREA                  | object | Convert to object with NWNX_Object_StringToObject()
-    TARGET                | object | Convert to object with NWNX_Object_StringToObject()
+    AREA                  | object | Convert to object with StringToObject()
+    TARGET                | object | Convert to object with StringToObject()
 
 _______________________________________
     ## DM Dump Locals Events
@@ -377,9 +377,22 @@ _______________________________________
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
     TYPE                  | int    | 0 = dm_dumplocals, 1 = dm_dumparealocals, 3 = dm_dumpmodulelocals
-    TARGET                | object | Convert to object with NWNX_Object_StringToObject()
+    TARGET                | object | Convert to object with StringToObject()
 
     Note: For TYPE 1/2, use GetArea(TARGET) or GetModule()
+
+_______________________________________
+    ## DM PlayerDM Login/Logout Events
+    - NWNX_ON_DM_PLAYERDM_LOGIN_BEFORE
+    - NWNX_ON_DM_PLAYERDM_LOGIN_AFTER
+    - NWNX_ON_DM_PLAYERDM_LOGOUT_BEFORE
+    - NWNX_ON_DM_PLAYERDM_LOGOUT_AFTER
+
+    `OBJECT_SELF` = The DM
+
+    Event Data Tag        | Type   | Notes
+    ----------------------|--------|-------
+    PASSWORD              | string | The password the DM provided, only valid for NWNX_ON_DM_PLAYERDM_LOGIN_*
 
 _______________________________________
     ## DM Other Events
@@ -444,7 +457,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    TARGET_OBJECT_ID      | object | Convert to object with NWNX_Object_StringToObject()
+    TARGET_OBJECT_ID      | object | Convert to object with StringToObject()
 
 _______________________________________
     ## Cast Spell Events
@@ -459,8 +472,8 @@ _______________________________________
     TARGET_POSITION_X     | float  | |
     TARGET_POSITION_Y     | float  | |
     TARGET_POSITION_Z     | float  | |
-    TARGET_OBJECT_ID      | object | Convert to object with NWNX_Object_StringToObject() |
-    ITEM_OBJECT_ID        | object | Convert to object with NWNX_Object_StringToObject() |
+    TARGET_OBJECT_ID      | object | Convert to object with StringToObject() |
+    ITEM_OBJECT_ID        | object | Convert to object with StringToObject() |
     MULTI_CLASS           | int    | |
     SPELL_COUNTERED       | int    | Returns TRUE if spell was countered else FALSE |
     COUNTERING_SPELL      | int    | Returns TRUE if cast as counter else FALSE |
@@ -509,8 +522,8 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes |
     ----------------------|--------|-------|
-    TARGET_OBJECT_ID      | object | Convert to object with NWNX_Object_StringToObject() |
-    ITEM_OBJECT_ID        | object | Convert to object with NWNX_Object_StringToObject() |
+    TARGET_OBJECT_ID      | object | Convert to object with StringToObject() |
+    ITEM_OBJECT_ID        | object | Convert to object with StringToObject() |
     ITEM_PROPERTY_INDEX   | int    | |
     MOVE_TO_TARGET        | int    | |
     ACTION_RESULT         | int    | |
@@ -526,14 +539,14 @@ _______________________________________
 
     Event           | Event Data Tag        | Type   | Notes |
     ----------------|-----------------------|--------|-------|
-    LEAVE | LEAVING | object | Convert to object with NWNX_Object_StringToObject() |
-    KICK  | KICKED  | object | Convert to object with NWNX_Object_StringToObject() |
-    TRANSFER_LEADERSHIP  | NEW_LEADER  | object | Convert to object with NWNX_Object_StringToObject() |
-    INVITE  | INVITED  | object | Convert to object with NWNX_Object_StringToObject() |
-    IGNORE_INVITATION  | INVITED_BY  | object | Convert to object with NWNX_Object_StringToObject() |
-    ACCEPT_INVITATION  | INVITED_BY  | object | Convert to object with NWNX_Object_StringToObject() |
-    REJECT_INVITATION  | INVITED_BY  | object | Convert to object with NWNX_Object_StringToObject() |
-    KICK_HENCHMAN  | INVITED_BY  | object | Convert to object with NWNX_Object_StringToObject() |
+    LEAVE | LEAVING | object | Convert to object with StringToObject() |
+    KICK  | KICKED  | object | Convert to object with StringToObject() |
+    TRANSFER_LEADERSHIP  | NEW_LEADER  | object | Convert to object with StringToObject() |
+    INVITE  | INVITED  | object | Convert to object with StringToObject() |
+    IGNORE_INVITATION  | INVITED_BY  | object | Convert to object with StringToObject() |
+    ACCEPT_INVITATION  | INVITED_BY  | object | Convert to object with StringToObject() |
+    REJECT_INVITATION  | INVITED_BY  | object | Convert to object with StringToObject() |
+    KICK_HENCHMAN  | INVITED_BY  | object | Convert to object with StringToObject() |
 
 _______________________________________
     ## Combat Mode Toggle Events
@@ -573,8 +586,8 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes |
     ----------------------|--------|-------|
-    USED_ITEM_OBJECT_ID   | object | Convert to object with NWNX_Object_StringToObject() |
-    TARGET_OBJECT_ID      | object | Convert to object with NWNX_Object_StringToObject() |
+    USED_ITEM_OBJECT_ID   | object | Convert to object with StringToObject() |
+    TARGET_OBJECT_ID      | object | Convert to object with StringToObject() |
     SKILL_ID              | int | |
     SUB_SKILL_ID          | int | |
     TARGET_POSITION_X     | float | |
@@ -614,7 +627,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    TARGET                | object | Convert to object with NWNX_Object_StringToObject()
+    TARGET                | object | Convert to object with StringToObject()
     TARGET_INVISIBLE      | int    | TRUE/FALSE
     BEFORE_RESULT         | int    | TRUE/FALSE, only in _AFTER events
 
@@ -649,7 +662,7 @@ _______________________________________
     Event Data Tag        | Type   | Notes |
     ----------------------|--------|-------|
     UNIQUE_ID             | int    | |
-    CREATOR               | object | Convert to object with NWNX_Object_StringToObject() |
+    CREATOR               | object | Convert to object with StringToObject() |
     TYPE                  | int    | The effect type, does not match NWScript constants See: https://github.com/nwnxee/unified/blob/master/NWNXLib/API/Constants/Effect.hpp#L8 |
     SUB_TYPE              | int    | SUBTYPE_* |
     DURATION_TYPE         | int    | DURATION_TYPE_* |
@@ -660,7 +673,7 @@ _______________________________________
     INT_PARAM_*           | int    | * = 1-8 |
     FLOAT_PARAM_*         | float  | * = 1-4 |
     STRING_PARAM_*        | string | * = 1-6 |
-    OBJECT_PARAM_*        | object | * = 1-4, Convert to object with NWNX_Object_StringToObject() |
+    OBJECT_PARAM_*        | object | * = 1-4, Convert to object with StringToObject() |
 
     @note Only fires for Temporary or Permanent effects, does not include VisualEffects or ItemProperty effects.
 
@@ -722,8 +735,8 @@ _______________________________________
     BARTER_COMPLETE               | int    | TRUE/FALSE - whether the barter completed successfully
     BARTER_INITIATOR_ITEM_COUNT   | int    | How many items the initiator traded away, only in _BEFORE events
     BARTER_TARGET_ITEM_COUNT      | int    | How many items the target traded away, only in _BEFORE events
-    BARTER_INITIATOR_ITEM_*       | object | Convert to object with NWNX_Object_StringToObject(), only in _BEFORE events
-    BARTER_TARGET_ITEM_*          | object | Convert to object with NWNX_Object_StringToObject(), only in _BEFORE events
+    BARTER_INITIATOR_ITEM_*       | object | Convert to object with StringToObject(), only in _BEFORE events
+    BARTER_TARGET_ITEM_*          | object | Convert to object with StringToObject(), only in _BEFORE events
 
 _______________________________________
     ## Trap Events
@@ -744,7 +757,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    TRAP_OBJECT_ID        | object | Convert to object with NWNX_Object_StringToObject()
+    TRAP_OBJECT_ID        | object | Convert to object with StringToObject()
     TRAP_FORCE_SET        | int    | TRUE/FALSE, only in ENTER events
     ACTION_RESULT         | int    | TRUE/FALSE, only in _AFTER events (not ENTER)
 
@@ -843,7 +856,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    ITEM                  | object | Convert to object with NWNX_Object_StringToObject()
+    ITEM                  | object | Convert to object with StringToObject()
 
 _______________________________________
     ## Gold Events
@@ -870,7 +883,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    TARGET_OBJECT_ID      | object | Convert to object with NWNX_Object_StringToObject()
+    TARGET_OBJECT_ID      | object | Convert to object with StringToObject()
     ATTITUDE              | int    | 0 = Dislike, 1 = Like
 
 _______________________________________
@@ -882,7 +895,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes |
     ----------------------|--------|-------|
-    AREA                  | object | Convert to object with NWNX_Object_StringToObject() |
+    AREA                  | object | Convert to object with StringToObject() |
     POS_X                 | float  | |
     POS_Y                 | float  | |
     POS_Z                 | float  | |
@@ -911,7 +924,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    TARGET                | object | Convert to object with NWNX_Object_StringToObject()
+    TARGET                | object | Convert to object with StringToObject()
     PASSIVE               | int    | TRUE / FALSE
     CLEAR_ALL_ACTIONS     | int    | TRUE / FALSE
     ADD_TO_FRONT          | int    | TRUE / FALSE
@@ -925,7 +938,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    TARGET                | object | Convert to object with NWNX_Object_StringToObject()
+    TARGET                | object | Convert to object with StringToObject()
 
  _______________________________________
     ## Input Cast Spell Events
@@ -936,7 +949,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    TARGET                | object | Convert to object with NWNX_Object_StringToObject()
+    TARGET                | object | Convert to object with StringToObject()
     SPELL_ID              | int    |
     MULTICLASS            | int    |
     DOMAIN_LEVEL          | int    |
@@ -995,7 +1008,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    DOOR                  | object | Convert to object with NWNX_Object_StringToObject()
+    DOOR                  | object | Convert to object with StringToObject()
 
 _______________________________________
     ## Object Unlock Events
@@ -1006,8 +1019,8 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    DOOR                  | object | Convert to object with NWNX_Object_StringToObject()
-    THIEVES_TOOL          | object | Convert to object with NWNX_Object_StringToObject()
+    DOOR                  | object | Convert to object with StringToObject()
+    THIEVES_TOOL          | object | Convert to object with StringToObject()
     ACTIVE_PROPERTY_INDEX | int    |
 
 _______________________________________

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -309,6 +309,12 @@ void NWNX_Player_SetCreatureNameOverride(object oPlayer, object oCreature, strin
 /// @param sText The text to display.
 void NWNX_Player_FloatingTextStringOnCreature(object oPlayer, object oCreature, string sText);
 
+/// @brief Toggle oPlayer's PlayerDM status.
+/// @note This function does nothing for actual DMClient DMs.
+/// @param oPlayer The player.
+/// @param bIsDM TRUE to toggle dm mode on, FALSE for off.
+void NWNX_Player_ToggleDM(object oPlayer, int bIsDM);
+
 /// @}
 
 void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable)
@@ -766,6 +772,16 @@ void NWNX_Player_FloatingTextStringOnCreature(object oPlayer, object oCreature, 
 
     NWNX_PushArgumentString(NWNX_Player, sFunc, sText);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, oCreature);
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, oPlayer);
+
+    NWNX_CallFunction(NWNX_Player, sFunc);
+}
+
+void NWNX_Player_ToggleDM(object oPlayer, int bIsDM)
+{
+    string sFunc = "ToggleDM";
+
+    NWNX_PushArgumentInt(NWNX_Player, sFunc, bIsDM);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, oPlayer);
 
     NWNX_CallFunction(NWNX_Player, sFunc);

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -93,6 +93,7 @@ Player::Player(Services::ProxyServiceList* services)
     REGISTER(SetCustomToken);
     REGISTER(SetCreatureNameOverride);
     REGISTER(FloatingTextStringOnCreature);
+    REGISTER(ToggleDM);
 
 #undef REGISTER
 
@@ -126,14 +127,9 @@ ArgumentStack Player::ForcePlaceableExamineWindow(ArgumentStack&& args)
     {
         const auto placeableId = Services::Events::ExtractArgument<ObjectID>(args);
 
-        auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
-        if (pMessage)
+        if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
         {
             pMessage->SendServerToPlayerExamineGui_PlaceableData(pPlayer, placeableId);
-        }
-        else
-        {
-            LOG_ERROR("Unable to get CNWSMessage");
         }
     }
 
@@ -195,14 +191,9 @@ ArgumentStack Player::StartGuiTimingBar(ArgumentStack&& args)
           ASSERT_OR_THROW(type > 0);
           ASSERT_OR_THROW(type <= 10);
 
-        auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
-        if (pMessage)
+        if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
         {
             pMessage->SendServerToPlayerGuiTimingEvent(pPlayer, true, type, milliseconds);
-        }
-        else
-        {
-            LOG_ERROR("Unable to get CNWSMessage");
         }
     }
 
@@ -213,14 +204,9 @@ ArgumentStack Player::StopGuiTimingBar(ArgumentStack&& args)
 {
     if (auto *pPlayer = player(args))
     {
-        auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
-        if (pMessage)
+        if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
         {
             pMessage->SendServerToPlayerGuiTimingEvent(pPlayer, false, 10, 0);
-        }
-        else
-        {
-            LOG_ERROR("Unable to get CNWSMessage");
         }
     }
 
@@ -293,11 +279,13 @@ ArgumentStack Player::GetQuickBarSlot(ArgumentStack&& args)
         auto slot = Services::Events::ExtractArgument<int32_t>(args);
           ASSERT_OR_THROW(slot < 36);
 
-        CNWSCreature *pCreature = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(pPlayer->m_oidNWSObject);
-        if (!pCreature->m_pQuickbarButton)
-            pCreature->InitializeQuickbar();
+        if (auto *pCreature = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(pPlayer->m_oidNWSObject))
+        {
+            if (!pCreature->m_pQuickbarButton)
+                pCreature->InitializeQuickbar();
 
-        qbs = pCreature->m_pQuickbarButton[slot];
+            qbs = pCreature->m_pQuickbarButton[slot];
+        }
     }
 
     return Services::Events::Arguments
@@ -344,7 +332,7 @@ ArgumentStack Player::SetQuickBarSlot(ArgumentStack&& args)
         pCreature->m_pQuickbarButton[slot].m_oidSecondaryItem = Services::Events::ExtractArgument<ObjectID>(args);
         pCreature->m_pQuickbarButton[slot].m_oidItem          = Services::Events::ExtractArgument<ObjectID>(args);
 
-        auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
+        auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage();
         pMessage->SendServerToPlayerGuiQuickbar_SetButton(pPlayer, slot, 0);
     }
     return Services::Events::Arguments();
@@ -372,8 +360,7 @@ ArgumentStack Player::ShowVisualEffect(ArgumentStack&& args)
         pos.y = Services::Events::ExtractArgument<float>(args);
         pos.x = Services::Events::ExtractArgument<float>(args);
 
-        auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
-        if (pMessage)
+        if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
         {
             ObjectVisualTransformData ovtd;
             pMessage->SendServerToPlayerArea_VisualEffect(pPlayer, effectId, pos, ovtd);
@@ -393,8 +380,7 @@ ArgumentStack Player::ChangeBackgroundMusic(ArgumentStack&& args)
           ASSERT_OR_THROW(track >= 0);
           ASSERT_OR_THROW(track <= 0xFFFF);
 
-        auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
-        if (pMessage)
+        if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
         {
             pMessage->SendServerToPlayerAmbientMusicChangeTrack(oidPlayer, day, track);
         }
@@ -410,8 +396,7 @@ ArgumentStack Player::PlayBackgroundMusic(ArgumentStack&& args)
 
         auto play = Services::Events::ExtractArgument<int32_t>(args);
 
-        auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
-        if (pMessage)
+        if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
         {
             pMessage->SendServerToPlayerAmbientMusicPlay(oidPlayer, play);
         }
@@ -429,8 +414,7 @@ ArgumentStack Player::ChangeBattleMusic(ArgumentStack&& args)
           ASSERT_OR_THROW(track >= 0);
           ASSERT_OR_THROW(track <= 0xFFFF);
 
-        auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
-        if (pMessage)
+        if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
         {
             pMessage->SendServerToPlayerAmbientBattleMusicChange(oidPlayer, track);
         }
@@ -446,8 +430,7 @@ ArgumentStack Player::PlayBattleMusic(ArgumentStack&& args)
 
         auto play = Services::Events::ExtractArgument<int32_t>(args);
 
-        auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
-        if (pMessage)
+        if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
         {
             pMessage->SendServerToPlayerAmbientBattleMusicPlay(oidPlayer, play);
         }
@@ -470,8 +453,7 @@ ArgumentStack Player::PlaySound(ArgumentStack&& args)
             oidTarget = pPlayer->m_oidNWSObject;
         }
 
-        auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
-        if (pMessage)
+        if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
         {
             pMessage->SendServerToPlayerAIActionPlaySound(playerID, oidTarget, sound.c_str());
         }
@@ -486,8 +468,7 @@ ArgumentStack Player::SetPlaceableUsable(ArgumentStack&& args)
         const auto oidPlaceable = Services::Events::ExtractArgument<ObjectID>(args);
         const auto bUsable = Services::Events::ExtractArgument<int32_t>(args);
 
-        auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
-        if (pMessage)
+        if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
         {
             pMessage->CreateWriteMessage(sizeof(bUsable) + sizeof(oidPlaceable), pPlayer->m_nPlayerID, 1);
 
@@ -570,8 +551,7 @@ ArgumentStack Player::ApplyInstantVisualEffectToObject(ArgumentStack&& args)
         vTargetPosition.y = 0.0f;
         vTargetPosition.z = 0.0f;
 
-        auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
-        if (pMessage)
+        if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
         {
             pMessage->SendServerToPlayerGameObjUpdateVisEffect(
                     pPlayer,
@@ -595,8 +575,7 @@ ArgumentStack Player::UpdateCharacterSheet(ArgumentStack&& args)
         uint32_t msg = charSheet->ComputeCharacterSheetUpdateRequired(pPlayer);
         if (msg)
         {
-            auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
-            if (pMessage)
+            if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
                 pMessage->WriteGameObjUpdate_CharacterSheet(pPlayer, msg);
         }
     }
@@ -614,7 +593,7 @@ ArgumentStack Player::OpenInventory(ArgumentStack&& args)
         CNWSPlayerInventoryGUI *pInventory = pPlayer->m_oidNWSObject == oidTarget ? pPlayer->m_pInventoryGUI :
                                                                                     pPlayer->m_pOtherInventoryGUI;
 
-        auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
+        auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage();
         if (pMessage && pInventory)
         {
             pMessage->SendPlayerToServerGuiInventory_Status(pPlayer, open, oidTarget);
@@ -632,7 +611,7 @@ ArgumentStack Player::OpenInventory(ArgumentStack&& args)
 
 ArgumentStack Player::GetAreaExplorationState(ArgumentStack&& args)
 {
-    std::string encString = "";
+    std::string encString;
 
     if (auto *pPlayer = player(args))
     {
@@ -1138,7 +1117,7 @@ ArgumentStack Player::UpdateItemName(ArgumentStack&& args)
           ASSERT_OR_THROW(oidItem != Constants::OBJECT_INVALID);
 
         auto *pItem = Utils::AsNWSItem(Utils::GetGameObject(oidItem));
-        auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
+        auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage();
 
         if (pItem && pMessage)
         {
@@ -1329,14 +1308,9 @@ ArgumentStack Player::SetResManOverride(ArgumentStack&& args)
         const auto newResName = Services::Events::ExtractArgument<std::string>(args);
           ASSERT_OR_THROW(newResName.size() <= 16);
 
-        auto *pMessage = static_cast<CNWSMessage *>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
-        if (pMessage)
+        if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
         {
             pMessage->SendServerToPlayerResmanOverride(pPlayer->m_nPlayerID, resType, oldResName.c_str(), newResName.c_str());
-        }
-        else
-        {
-            LOG_ERROR("Unable to get CNWSMessage");
         }
     }
 
@@ -1350,14 +1324,9 @@ ArgumentStack Player::SetCustomToken(ArgumentStack&& args)
         const auto tokenNumber = Services::Events::ExtractArgument<int32_t>(args);
         const auto tokenText = Services::Events::ExtractArgument<std::string>(args);
 
-        auto *pMessage = static_cast<CNWSMessage *>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
-        if (pMessage)
+        if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
         {
             pMessage->SendServerToPlayerSetCustomToken(pPlayer->m_nPlayerID, tokenNumber, tokenText.c_str());
-        }
-        else
-        {
-            LOG_ERROR("Unable to get CNWSMessage");
         }
     }
 
@@ -1450,6 +1419,44 @@ ArgumentStack Player::FloatingTextStringOnCreature(ArgumentStack&& args)
                 messageData.SetString(0, text);
 
                 pMessage->SendServerToPlayerCCMessage(pPlayer->m_nPlayerID, Constants::MessageClientSideMsgMinor::Feedback, &messageData, nullptr);
+            }
+        }
+    }
+
+    return Services::Events::Arguments();
+}
+
+ArgumentStack Player::ToggleDM(ArgumentStack&& args)
+{
+    if (auto *pPlayer = player(args))
+    {
+        auto isDM = !!Services::Events::ExtractArgument<int32_t>(args);
+        auto *pNetLayer = Globals::AppManager()->m_pServerExoApp->GetNetLayer();
+
+        if (auto *pPlayerInfo = pNetLayer->GetPlayerInfo(pPlayer->m_nPlayerID))
+        {
+            if (pPlayerInfo->m_bGameMasterPrivileges && !pPlayerInfo->m_bGameMasterIsPlayerLogin)
+            {
+                LOG_WARNING("ToggleDM: Called on a DMClient DM");
+                return Services::Events::Arguments();
+            }
+
+            if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
+            {
+                bool currentlyPlayerDM = pPlayerInfo->m_bGameMasterPrivileges && pPlayerInfo->m_bGameMasterIsPlayerLogin;
+
+                if (isDM && !currentlyPlayerDM)
+                {
+                    pMessage->SendServerToPlayerDungeonMasterLoginState(pPlayer, true, true);
+                    pPlayerInfo->m_bGameMasterPrivileges = true;
+                    pPlayerInfo->m_bGameMasterIsPlayerLogin = true;
+                }
+                else if (!isDM && currentlyPlayerDM)
+                {
+                    pMessage->SendServerToPlayerDungeonMasterLoginState(pPlayer, false, true);
+                    pPlayerInfo->m_bGameMasterPrivileges = false;
+                    pPlayerInfo->m_bGameMasterIsPlayerLogin = false;
+                }
             }
         }
     }

--- a/Plugins/Player/Player.hpp
+++ b/Plugins/Player/Player.hpp
@@ -53,6 +53,7 @@ private:
     ArgumentStack SetCustomToken                    (ArgumentStack&& args);
     ArgumentStack SetCreatureNameOverride           (ArgumentStack&& args);
     ArgumentStack FloatingTextStringOnCreature      (ArgumentStack&& args);
+    ArgumentStack ToggleDM                          (ArgumentStack&& args);
 
     CNWSPlayer *player(ArgumentStack& args);
 


### PR DESCRIPTION
Adds the following skippable events to DMActionEvents:

```
NWNX_ON_DM_PLAYERDM_LOGIN_BEFORE
NWNX_ON_DM_PLAYERDM_LOGIN_AFTER
NWNX_ON_DM_PLAYERDM_LOGOUT_BEFORE
NWNX_ON_DM_PLAYERDM_LOGOUT_AFTER
```

Also adds ToggleDM() to NWNX_Player
