### PR TITLE
Deprecate NWNX_Object_StringToObject, delete some other stuff.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,12 @@ N/A
 N/A
 
 ### Deprecated
-N/A
+- Object: StringToObject();
 
 ### Removed
-N/A
+- Creature: {Get|Set}{ClericDomain|WizardSpecialization}()
+- Creature: SetAbilityScore()
+- Object: {Get|Set|Delete}Persistent{Int|String|Float}()
 
 ### Fixed
 N/A

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -196,13 +196,6 @@ void NWNX_Creature_SetBaseAC(object creature, int ac);
 /// @return The base AC.
 int NWNX_Creature_GetBaseAC(object creature);
 
-/// @brief Sets the ability score of the creature to the value.
-/// @param creature The creature object.
-/// @param ability The ability constant.
-/// @param value The value to set.
-/// @deprecated Use NWNX_Creature_SetRawAbilityScore(). This will be removed in future NWNX releases.
-void NWNX_Creature_SetAbilityScore(object creature, int ability, int value);
-
 /// @brief Sets the ability score of the creature to the provided value.
 /// @note Does not apply racial bonuses/penalties.
 /// @param creature The creature object.
@@ -317,18 +310,6 @@ void NWNX_Creature_ClearMemorisedKnownSpells(object creature, int class, int spe
 /// @param index The index. Index bounds: 0 <= index < NWNX_Creature_GetMemorisedSpellCountByLevel().
 void NWNX_Creature_ClearMemorisedSpell(object creature, int class, int level, int index);
 
-/// @brief Gets whether or not creature has a specialist school of wizardry.
-/// @param creature The creature object.
-/// @return TRUE if the wizard specializes.
-/// @deprecated Use GetSpecialization(). This will be removed in future NWNX releases.
-int NWNX_Creature_GetWizardSpecialization(object creature);
-
-/// @brief Sets creature's wizard specialist school.
-/// @param creature The creature object.
-/// @param school The wizard school constant.
-/// @deprecated Use NWNX_Creature_SetSpecialization(). This will be removed in future NWNX releases.
-void NWNX_Creature_SetWizardSpecialization(object creature, int school);
-
 /// @brief Gets the maximum hit points for creature for level.
 /// @param creature The creature object.
 /// @param level The level.
@@ -385,19 +366,6 @@ void NWNX_Creature_SetAlignmentGoodEvil(object creature, int value);
 /// @param creature The creature object.
 /// @param value The value to set.
 void NWNX_Creature_SetAlignmentLawChaos(object creature, int value);
-
-/// @brief Gets one of creature's cleric domains.
-/// @param creature The creature object.
-/// @param index The first or second domain.
-/// @deprecated Use GetDomain(). This will be removed in future NWNX releases.
-int NWNX_Creature_GetClericDomain(object creature, int index);
-
-/// @brief Sets one of creature's cleric domains.
-/// @param creature The creature object.
-/// @param index The first or second domain.
-/// @param domain The domain constant to set.
-/// @deprecated Use NWNX_Creature_SetDomain(). This will be removed in future NWNX releases.
-void NWNX_Creature_SetClericDomain(object creature, int index, int domain);
 
 /// @brief Get the soundset index for creature.
 /// @param creature The creature object.
@@ -981,12 +949,6 @@ int NWNX_Creature_GetBaseAC(object creature)
     return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
 }
 
-void NWNX_Creature_SetAbilityScore(object creature, int ability, int value)
-{
-    WriteTimestampedLogEntry("NWNX_Creature: SetAbilityScore() is deprecated. Use native NWNX_Creature_SetRawAbilityScore() instead");
-    NWNX_Creature_SetRawAbilityScore(creature, ability, value);
-}
-
 void NWNX_Creature_SetRawAbilityScore(object creature, int ability, int value)
 {
     string sFunc = "SetRawAbilityScore";
@@ -1267,30 +1229,6 @@ void NWNX_Creature_SetAlignmentLawChaos(object creature, int value)
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, creature);
 
     NWNX_CallFunction(NWNX_Creature, sFunc);
-}
-
-int NWNX_Creature_GetClericDomain(object creature, int index)
-{
-    WriteTimestampedLogEntry("NWNX_Creature: GetClericDomain() is deprecated. Please use the basegame's GetDomain() instead");
-    return GetDomain(creature, index, CLASS_TYPE_CLERIC);
-}
-
-void NWNX_Creature_SetClericDomain(object creature, int index, int domain)
-{
-    WriteTimestampedLogEntry("NWNX_Creature: SetClericDomain() is deprecated. Please use NWNX_Creature_SetDomain() instead");
-    NWNX_Creature_SetDomain(creature, CLASS_TYPE_CLERIC, index, domain);
-}
-
-int NWNX_Creature_GetWizardSpecialization(object creature)
-{
-    WriteTimestampedLogEntry("NWNX_Creature: GetWizardSpecialization() is deprecated. Please use the basegame's GetSpecialization() instead");
-    return GetSpecialization(creature, CLASS_TYPE_WIZARD);
-}
-
-void NWNX_Creature_SetWizardSpecialization(object creature, int school)
-{
-    WriteTimestampedLogEntry("NWNX_Creature: SetWizardSpecialization() is deprecated. Please use NWNX_Creature_SetSpecialization() instead");
-    NWNX_Creature_SetSpecialization(creature, CLASS_TYPE_WIZARD, school);
 }
 
 int NWNX_Creature_GetSoundset(object creature)

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -93,8 +93,8 @@ void main()
 
     int nOldStr = GetAbilityScore(oCreature, ABILITY_STRENGTH, TRUE);
     NWNX_Creature_SetRawAbilityScore(oCreature, ABILITY_STRENGTH, 25);
-    NWNX_Tests_Report("NWNX_Creature", "SetAbilityScore", nOldStr != GetAbilityScore(oCreature, ABILITY_STRENGTH, TRUE));
-    NWNX_Tests_Report("NWNX_Creature", "SetAbilityScore", 25      == GetAbilityScore(oCreature, ABILITY_STRENGTH, TRUE));
+    NWNX_Tests_Report("NWNX_Creature", "SetRawAbilityScore", nOldStr != GetAbilityScore(oCreature, ABILITY_STRENGTH, TRUE));
+    NWNX_Tests_Report("NWNX_Creature", "SetRawAbilityScore", 25      == GetAbilityScore(oCreature, ABILITY_STRENGTH, TRUE));
 
     ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectPolymorph(POLYMORPH_TYPE_BADGER), oCreature);
     NWNX_Tests_Report("NWNX_Creature", "GetPrePolymorphAbilityScore", 25 == NWNX_Creature_GetPrePolymorphAbilityScore(oCreature, ABILITY_STRENGTH));
@@ -207,11 +207,6 @@ void main()
     NWNX_Creature_SetSpecialization(oCreature, CLASS_TYPE_WIZARD, (nSchool+1)%5);
     NWNX_Tests_Report("NWNX_Creature", "{S,G}etSpecialization", NWNX_Creature_GetSpecialization(oCreature, CLASS_TYPE_WIZARD) == (nSchool+1)%5);
 
-    //Test old functions for compatibility (deprecated)
-    nSchool = NWNX_Creature_GetWizardSpecialization(oCreature);
-    NWNX_Creature_SetWizardSpecialization(oCreature, (nSchool+1)%5);
-    NWNX_Tests_Report("NWNX_Creature", "{S,G}etWizardSpecialization", NWNX_Creature_GetWizardSpecialization(oCreature) == (nSchool+1)%5);
-
     //Test domain functions on a class that doesn't have domains
     int nDomain = NWNX_Creature_GetDomain(oCreature, CLASS_TYPE_WIZARD, 1);
     NWNX_Tests_Report("NWNX_Creature", "GetDomain", NWNX_Creature_GetDomain(oCreature, CLASS_TYPE_WIZARD, 1) == 0);
@@ -243,14 +238,6 @@ void main()
     nDomain2 = NWNX_Creature_GetDomain(oCreature, CLASS_TYPE_CLERIC, 2);
     NWNX_Creature_SetDomain(oCreature, CLASS_TYPE_CLERIC, 2, (nDomain2+1)%5);
     NWNX_Tests_Report("NWNX_Creature", "{S,G}etDomain", NWNX_Creature_GetDomain(oCreature, CLASS_TYPE_CLERIC, 2) == (nDomain2+1)%5);
-
-    //Test old functions for compatibility (deprecated)
-    nDomain = NWNX_Creature_GetClericDomain(oCreature, 1);
-    NWNX_Creature_SetClericDomain(oCreature, 1, (nDomain+1)%5);
-    NWNX_Tests_Report("NWNX_Creature", "{S,G}etClericDomain", NWNX_Creature_GetClericDomain(oCreature, 1) == (nDomain+1)%5);
-    nDomain2 = NWNX_Creature_GetClericDomain(oCreature, 2);
-    NWNX_Creature_SetClericDomain(oCreature, 2, (nDomain2+1)%5);
-    NWNX_Tests_Report("NWNX_Creature", "{S,G}etClericDomain", NWNX_Creature_GetClericDomain(oCreature, 2) == (nDomain2+1)%5);
 
     WriteTimestampedLogEntry("NWNX_Creature unit test end.");
 }

--- a/Plugins/Object/NWScript/nwnx_object.nss
+++ b/Plugins/Object/NWScript/nwnx_object.nss
@@ -70,6 +70,7 @@ struct NWNX_Object_LocalVariable NWNX_Object_GetLocalVariable(object obj, int in
 /// @param id The object id.
 /// @return An object from the provided object ID.
 /// @remark This is the counterpart to ObjectToString.
+/// @deprecated Use the basegame StringToObject() function. This will be removed in a future NWNX release.
 object NWNX_Object_StringToObject(string id);
 
 /// @brief Set oObject's position.
@@ -207,69 +208,6 @@ void NWNX_Object_RemoveIconEffect(object obj, int nIcon);
 /// @param oObject The object to export. Valid object types: Creature, Item, Placeable, Waypoint, Door, Store, Trigger
 void NWNX_Object_Export(string sFileName, object oObject);
 
-/// @brief Get oObject's persistent integer variable sVarName.
-/// @param oObject The object to set the variable on.
-/// @param sVarName The variable name.
-/// @return The value or 0 on error.
-/// @deprecated Please use NWNX_Object_GetInt()
-int NWNX_Object_GetPersistentInt(object oObject, string sVarName);
-
-/// @brief Set oObject's persistent integer variable sVarName to nValue.
-/// @note The value is persisted to GFF, this means that it'll be saved in the .bic file of a player's character or when an object is serialized.
-/// @param oObject The object to set the variable on.
-/// @param sVarName The variable name.
-/// @param nValue The integer value to to set
-/// @deprecated Please use NWNX_Object_SetInt()
-void NWNX_Object_SetPersistentInt(object oObject, string sVarName, int nValue);
-
-/// @brief Delete oObject's persistent integer variable sVarName.
-/// @param oObject The object to set the variable on.
-/// @param sVarName The variable name.
-/// @deprecated Please use NWNX_Object_DeleteInt()
-void NWNX_Object_DeletePersistentInt(object oObject, string sVarName);
-
-/// @brief Get oObject's persistent string variable sVarName.
-/// @param oObject The object to set the variable on.
-/// @param sVarName The variable name.
-/// @return The value or "" on error.
-/// @deprecated Please use NWNX_Object_GetString()
-string NWNX_Object_GetPersistentString(object oObject, string sVarName);
-
-/// @brief Set oObject's persistent string variable sVarName to sValue.
-/// @note The value is persisted to GFF, this means that it'll be saved in the .bic file of a player's character or when an object is serialized.
-/// @param oObject The object to set the variable on.
-/// @param sVarName The variable name.
-/// @param sValue The string value to to set
-/// @deprecated Please use NWNX_Object_SetString()
-void NWNX_Object_SetPersistentString(object oObject, string sVarName, string sValue);
-
-/// @brief Delete oObject's persistent string variable sVarName.
-/// @param oObject The object to set the variable on.
-/// @param sVarName The variable name.
-/// @deprecated Please use NWNX_Object_DeleteString()
-void NWNX_Object_DeletePersistentString(object oObject, string sVarName);
-
-/// @brief Get oObject's persistent float variable sVarName.
-/// @param oObject The object to set the variable on.
-/// @param sVarName The variable name.
-/// @return The value or 0.0f on error.
-/// @deprecated Please use NWNX_Object_GetFloat()
-float NWNX_Object_GetPersistentFloat(object oObject, string sVarName);
-
-/// @brief Set oObject's persistent float variable sVarName to fValue.
-/// @note The value is persisted to GFF, this means that it'll be saved in the .bic file of a player's character or when an object is serialized.
-/// @param oObject The object to set the variable on.
-/// @param sVarName The variable name.
-/// @param fValue The float value to to set
-/// @deprecated Please use NWNX_Object_SetFloat()
-void NWNX_Object_SetPersistentFloat(object oObject, string sVarName, float fValue);
-
-/// @brief Delete oObject's persistent float variable sVarName.
-/// @param oObject The object to set the variable on.
-/// @param sVarName The variable name.
-/// @deprecated Please use NWNX_Object_DeleteFloat()
-void NWNX_Object_DeletePersistentFloat(object oObject, string sVarName);
-
 /// @brief Get oObject's integer variable sVarName.
 /// @param oObject The object to get the variable from.
 /// @param sVarName The variable name.
@@ -404,11 +342,9 @@ struct NWNX_Object_LocalVariable NWNX_Object_GetLocalVariable(object obj, int in
 
 object NWNX_Object_StringToObject(string id)
 {
-    string sFunc = "StringToObject";
+    WriteTimestampedLogEntry("WARNING: NWNX_Object_StringToObject() is deprecated, please use the basegame's StringToObject()");
 
-    NWNX_PushArgumentString(NWNX_Object, sFunc, id);
-    NWNX_CallFunction(NWNX_Object, sFunc);
-    return NWNX_GetReturnValueObject(NWNX_Object, sFunc);
+    return StringToObject(id);
 }
 
 void NWNX_Object_SetPosition(object oObject, vector vPosition, int bUpdateSubareas = TRUE)
@@ -647,69 +583,6 @@ void NWNX_Object_Export(string sFileName, object oObject)
     NWNX_PushArgumentObject(NWNX_Object, sFunc, oObject);
     NWNX_PushArgumentString(NWNX_Object, sFunc, sFileName);
     NWNX_CallFunction(NWNX_Object, sFunc);
-}
-
-int NWNX_Object_GetPersistentInt(object oObject, string sVarName)
-{
-    WriteTimestampedLogEntry("WARNING: NWNX_Object_GetPersistentInt() is deprecated, please use NWNX_Object_GetInt()");
-
-    return NWNX_Object_GetInt(oObject, sVarName);
-}
-
-void NWNX_Object_SetPersistentInt(object oObject, string sVarName, int nValue)
-{
-    WriteTimestampedLogEntry("WARNING: NWNX_Object_SetPersistentInt() is deprecated, please use NWNX_Object_SetInt()");
-
-    NWNX_Object_SetInt(oObject, sVarName, nValue, TRUE);
-}
-
-void NWNX_Object_DeletePersistentInt(object oObject, string sVarName)
-{
-    WriteTimestampedLogEntry("WARNING: NWNX_Object_DeletePersistentInt() is deprecated, please use NWNX_Object_DeleteInt()");
-
-    NWNX_Object_DeleteInt(oObject, sVarName);
-}
-
-string NWNX_Object_GetPersistentString(object oObject, string sVarName)
-{
-    WriteTimestampedLogEntry("WARNING: NWNX_Object_GetPersistentString() is deprecated, please use NWNX_Object_GetString()");
-
-    return NWNX_Object_GetString(oObject, sVarName);
-}
-
-void NWNX_Object_SetPersistentString(object oObject, string sVarName, string sValue)
-{
-    WriteTimestampedLogEntry("WARNING: NWNX_Object_SetPersistentString() is deprecated, please use NWNX_Object_SetString()");
-
-    NWNX_Object_SetString(oObject, sVarName, sValue, TRUE);
-}
-
-void NWNX_Object_DeletePersistentString(object oObject, string sVarName)
-{
-    WriteTimestampedLogEntry("WARNING: NWNX_Object_DeletePersistentString() is deprecated, please use NWNX_Object_DeleteString()");
-
-    NWNX_Object_DeleteString(oObject, sVarName);
-}
-
-float NWNX_Object_GetPersistentFloat(object oObject, string sVarName)
-{
-    WriteTimestampedLogEntry("WARNING: NWNX_Object_GetPersistentFloat() is deprecated, please use NWNX_Object_GetFloat()");
-
-    return NWNX_Object_GetFloat(oObject, sVarName);
-}
-
-void NWNX_Object_SetPersistentFloat(object oObject, string sVarName, float fValue)
-{
-    WriteTimestampedLogEntry("WARNING: NWNX_Object_SetPersistentFloat() is deprecated, please use NWNX_Object_SetFloat()");
-
-    NWNX_Object_SetFloat(oObject, sVarName, fValue, TRUE);
-}
-
-void NWNX_Object_DeletePersistentFloat(object oObject, string sVarName)
-{
-    WriteTimestampedLogEntry("WARNING: NWNX_Object_DeletePersistentFloat() is deprecated, please use NWNX_Object_DeleteFloat()");
-
-    NWNX_Object_DeleteFloat(oObject, sVarName);
 }
 
 int NWNX_Object_GetInt(object oObject, string sVarName)

--- a/Plugins/Object/NWScript/nwnx_object_t.nss
+++ b/Plugins/Object/NWScript/nwnx_object_t.nss
@@ -20,10 +20,6 @@ void main()
     NWNX_Tests_Report("NWNX_Object", "GetLocalVariable", lv.key == "nwnx_object_test");
     NWNX_Tests_Report("NWNX_Object", "GetLocalVariable", lv.type == NWNX_OBJECT_LOCALVAR_TYPE_INT);
 
-    string sObj = ObjectToString(o);
-    NWNX_Tests_Report("NWNX_Object", "StringToObject", NWNX_Object_StringToObject(sObj) == o);
-    NWNX_Tests_Report("NWNX_Object", "Negative: StringToObject", NWNX_Object_StringToObject("!@#!@#!@#!") == OBJECT_INVALID);
-
     vector vPos = GetPosition(o);
     vPos.x += 1;
     NWNX_Object_SetPosition(o, vPos);

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -55,7 +55,6 @@ Object::Object(Services::ProxyServiceList* services)
 
     REGISTER(GetLocalVariableCount);
     REGISTER(GetLocalVariable);
-    REGISTER(StringToObject);
     REGISTER(SetPosition);
     REGISTER(GetCurrentHitPoints);
     REGISTER(SetCurrentHitPoints);
@@ -173,26 +172,6 @@ ArgumentStack Object::GetLocalVariable(ArgumentStack&& args)
     return Services::Events::Arguments(type, key);
 }
 
-// NOTE: StringToObject does not receive an object argument.
-ArgumentStack Object::StringToObject(ArgumentStack&& args)
-{
-    ObjectID retVal;
-
-    const auto id = Services::Events::ExtractArgument<std::string>(args);
-
-    if (id.empty())
-        retVal = Constants::OBJECT_INVALID;
-    else
-    {
-        retVal = static_cast<ObjectID>(stoul(id, nullptr, 16));
-
-        if (!Globals::AppManager()->m_pServerExoApp->GetGameObject(retVal))
-            retVal = Constants::OBJECT_INVALID;
-    }
-
-    return Services::Events::Arguments(retVal);
-}
-
 ArgumentStack Object::SetPosition(ArgumentStack&& args)
 {
     if (auto *pObject = object(args))
@@ -201,17 +180,7 @@ ArgumentStack Object::SetPosition(ArgumentStack&& args)
         pos.z = Services::Events::ExtractArgument<float>(args);
         pos.y = Services::Events::ExtractArgument<float>(args);
         pos.x = Services::Events::ExtractArgument<float>(args);
-        int32_t bUpdateSubareas;
-
-        // TODO: Remove this try/catch at some point
-        try
-        {
-            bUpdateSubareas = Services::Events::ExtractArgument<int32_t>(args);
-        }
-        catch (const std::runtime_error& e)
-        {
-            bUpdateSubareas = true;
-        }
+        auto bUpdateSubareas = !!Services::Events::ExtractArgument<int32_t>(args);
 
         pObject->SetPosition(pos, true /*bUpdateInAreaArray*/);
 

--- a/Plugins/Object/Object.hpp
+++ b/Plugins/Object/Object.hpp
@@ -17,7 +17,6 @@ public:
 private:
     ArgumentStack GetLocalVariableCount     (ArgumentStack&& args);
     ArgumentStack GetLocalVariable          (ArgumentStack&& args);
-    ArgumentStack StringToObject            (ArgumentStack&& args);
     ArgumentStack SetPosition               (ArgumentStack&& args);
     ArgumentStack GetCurrentHitPoints       (ArgumentStack&& args);
     ArgumentStack SetCurrentHitPoints       (ArgumentStack&& args);

--- a/Plugins/SQL/NWScript/nwnx_sql_t.nss
+++ b/Plugins/SQL/NWScript/nwnx_sql_t.nss
@@ -83,7 +83,7 @@ void main()
             NWNX_Tests_Report("NWNX_SQL", "ReadString", s == "FourtyTwooo");
 
             string sObjId = NWNX_SQL_ReadDataInActiveRow(3); // In base 10
-            object o2 = NWNX_Object_StringToObject(IntToHexString(StringToInt(sObjId)));
+            object o2 = StringToObject(IntToHexString(StringToInt(sObjId)));
             NWNX_Tests_Report("NWNX_SQL", "ReadObjectId", o == o2);
 
             object o3 = NWNX_SQL_ReadFullObjectInActiveRow(4, GetArea(o), v.x, v.y, v.z);


### PR DESCRIPTION
### Deprecated
- Object: StringToObject();

### Removed
- Creature: {Get|Set}{ClericDomain|WizardSpecialization}()
- Creature: SetAbilityScore()
- Object: {Get|Set|Delete}Persistent{Int|String|Float}()