### PR TITLE
Removed double comment closer

### DIFF
--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1152,7 +1152,6 @@ _______________________________________
 
 _______________________________________
 */
-*/
 /*
 const int NWNX_EVENTS_OBJECT_TYPE_CREATURE          = 5;
 const int NWNX_EVENTS_OBJECT_TYPE_ITEM              = 6;


### PR DESCRIPTION
There was a double comment closer in nwnx_events.nss that made it into master, this fixes it.