### PR TITLE
Add healing events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ N/A
 ### Changed
 - Effect: (Un)PackEffect now supports vector params
 - Events: added a `RESULT` event data tag to LearnScroll in ItemEvents 
-- Events: Renamed HealerKitEvents to HealingEvents, event names have not changed
 
 ### Deprecated
 - Object: StringToObject();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ https://github.com/nwnxee/unified/compare/build8193.14...HEAD
 - Events: added skippable PlayerDM Login/Logout events to DMActionEvents
 - Events: added skippable RunScript and RunScriptChunk events to DebugEvents
 - Events: added skippable RequestBuy/Sell events to StoreEvents
+- Events: added skippable Heal events to new HealingEvents
 
 ##### New Plugins
 N/A
@@ -30,6 +31,7 @@ N/A
 ### Changed
 - Effect: (Un)PackEffect now supports vector params
 - Events: added a `RESULT` event data tag to LearnScroll in ItemEvents 
+- Events: Renamed HealerKitEvents to HealingEvents, event names have not changed
 
 ### Deprecated
 - Object: StringToObject();

--- a/Plugins/Events/CMakeLists.txt
+++ b/Plugins/Events/CMakeLists.txt
@@ -13,7 +13,7 @@ add_plugin(Events
     "Events/StealthEvents.cpp"
     "Events/SpellEvents.cpp"
     "Events/PartyEvents.cpp"
-    "Events/HealerKitEvents.cpp"
+    "Events/HealingEvents.cpp"
     "Events/SkillEvents.cpp"
     "Events/PolymorphEvents.cpp"
     "Events/EffectEvents.cpp"

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -16,7 +16,7 @@
 #include "Events/StealthEvents.hpp"
 #include "Events/SpellEvents.hpp"
 #include "Events/PartyEvents.hpp"
-#include "Events/HealerKitEvents.hpp"
+#include "Events/HealingEvents.hpp"
 #include "Events/SkillEvents.hpp"
 #include "Events/PolymorphEvents.hpp"
 #include "Events/EffectEvents.hpp"
@@ -106,7 +106,7 @@ Events::Events(Services::ProxyServiceList* services)
     m_stealthEvents     = std::make_unique<StealthEvents>(hooker);
     m_spellEvents       = std::make_unique<SpellEvents>(hooker);
     m_partyEvents       = std::make_unique<PartyEvents>(hooker);
-    m_healerKitEvents   = std::make_unique<HealerKitEvents>(hooker);
+    m_healingEvents     = std::make_unique<HealingEvents>(hooker);
     m_skillEvents       = std::make_unique<SkillEvents>(hooker);
     m_mapEvents         = std::make_unique<MapEvents>(hooker);
     m_polymorphEvents   = std::make_unique<PolymorphEvents>(hooker);

--- a/Plugins/Events/Events.hpp
+++ b/Plugins/Events/Events.hpp
@@ -26,7 +26,7 @@ class MapEvents;
 class StealthEvents;
 class SpellEvents;
 class PartyEvents;
-class HealerKitEvents;
+class HealingEvents;
 class SkillEvents;
 class PolymorphEvents;
 class EffectEvents;
@@ -120,7 +120,7 @@ private:
     std::unique_ptr<StealthEvents> m_stealthEvents;
     std::unique_ptr<SpellEvents> m_spellEvents;
     std::unique_ptr<PartyEvents> m_partyEvents;
-    std::unique_ptr<HealerKitEvents> m_healerKitEvents;
+    std::unique_ptr<HealingEvents> m_healingEvents;
     std::unique_ptr<SkillEvents> m_skillEvents;
     std::unique_ptr<PolymorphEvents> m_polymorphEvents;
     std::unique_ptr<EffectEvents> m_effectEvents;

--- a/Plugins/Events/Events/HealingEvents.cpp
+++ b/Plugins/Events/Events/HealingEvents.cpp
@@ -23,7 +23,7 @@ HealingEvents::HealingEvents(Services::HooksProxy* hooker)
     });
     Events::InitOnFirstSubscribe("NWNX_ON_HEAL_.*", [hooker]() {
         s_OnApplyHealHook = hooker->RequestExclusiveHook
-                <API::Functions::_ZN21CNWSEffectListHandler11OnApplyHealEP10CNWSObjectP11CGameEffecti, int64_t, CNWSEffectListHandler*, CNWSObject*, CGameEffect*, int32_t>
+                <API::Functions::_ZN21CNWSEffectListHandler11OnApplyHealEP10CNWSObjectP11CGameEffecti, int32_t, CNWSEffectListHandler*, CNWSObject*, CGameEffect*, int32_t>
                 (&OnApplyHealHook);
     });
 }
@@ -64,7 +64,7 @@ uint32_t HealingEvents::AIActionHealHook(
     return retVal;
 }
 
-int64_t HealingEvents::OnApplyHealHook(
+int32_t HealingEvents::OnApplyHealHook(
         CNWSEffectListHandler *pThis,
         CNWSObject *pObject,
         CGameEffect *pGameEffect,

--- a/Plugins/Events/Events/HealingEvents.cpp
+++ b/Plugins/Events/Events/HealingEvents.cpp
@@ -1,4 +1,4 @@
-#include "Events/HealerKitEvents.hpp"
+#include "Events/HealingEvents.hpp"
 #include "API/CNWSCreature.hpp"
 #include "API/Functions.hpp"
 #include "API/CNWSObjectActionNode.hpp"
@@ -12,17 +12,23 @@ namespace Events {
 using namespace NWNXLib;
 
 static NWNXLib::Hooking::FunctionHook* s_AIActionHealHook;
+static NWNXLib::Hooking::FunctionHook* s_OnApplyHealHook;
 
-HealerKitEvents::HealerKitEvents(Services::HooksProxy* hooker)
+HealingEvents::HealingEvents(Services::HooksProxy* hooker)
 {
     Events::InitOnFirstSubscribe("NWNX_ON_HEALER_KIT_.*", [hooker]() {
         s_AIActionHealHook = hooker->RequestExclusiveHook
             <API::Functions::_ZN12CNWSCreature12AIActionHealEP20CNWSObjectActionNode, uint32_t, CNWSCreature*, CNWSObjectActionNode*>
             (&AIActionHealHook);
     });
+    Events::InitOnFirstSubscribe("NWNX_ON_HEAL_.*", [hooker]() {
+        s_OnApplyHealHook = hooker->RequestExclusiveHook
+                <API::Functions::_ZN21CNWSEffectListHandler11OnApplyHealEP10CNWSObjectP11CGameEffecti, int64_t, CNWSEffectListHandler*, CNWSObject*, CGameEffect*, int32_t>
+                (&OnApplyHealHook);
+    });
 }
 
-uint32_t HealerKitEvents::AIActionHealHook(
+uint32_t HealingEvents::AIActionHealHook(
     CNWSCreature *pCreature,
     CNWSObjectActionNode *pNode)
 {
@@ -52,9 +58,40 @@ uint32_t HealerKitEvents::AIActionHealHook(
     Events::PushEventData("ITEM_OBJECT_ID", Utils::ObjectIDToString((uintptr_t)(pNode->m_pParameter[1]))); //oidItemUsed
     Events::PushEventData("ITEM_PROPERTY_INDEX", std::to_string((uintptr_t)(pNode->m_pParameter[2]))); //nActiveItemPropertyIndex
     Events::PushEventData("MOVE_TO_TARGET", std::to_string((uintptr_t)(pNode->m_pParameter[3]))); //nMoveToTarget
-    Events::PushEventData("ACTION_RESULT", std::to_string(retVal)); //nMoveToTarget
+    Events::PushEventData("ACTION_RESULT", std::to_string(retVal));
 
     Events::SignalEvent("NWNX_ON_HEALER_KIT_AFTER", pCreature->m_idSelf);
+    return retVal;
+}
+
+int64_t HealingEvents::OnApplyHealHook(
+        CNWSEffectListHandler *pThis,
+        CNWSObject *pObject,
+        CGameEffect *pGameEffect,
+        int32_t bLoadingGame)
+{
+    uint32_t retVal;
+    std::string sAux;
+    int32_t nHealAmount = pGameEffect->GetInteger(0);
+    Events::PushEventData("TARGET_OBJECT_ID", Utils::ObjectIDToString(pObject->m_idSelf));
+    Events::PushEventData("HEAL_AMOUNT", std::to_string(nHealAmount));
+
+    if (Events::SignalEvent("NWNX_ON_HEAL_BEFORE", pGameEffect->m_oidCreator, &sAux))
+    {
+        retVal = s_OnApplyHealHook->CallOriginal<int64_t>(pThis, pObject, pGameEffect, bLoadingGame);
+    }
+    else
+    {
+        nHealAmount = atoi(sAux.c_str());
+        pGameEffect->SetInteger(0, nHealAmount);
+        retVal = s_OnApplyHealHook->CallOriginal<int64_t>(pThis, pObject, pGameEffect, bLoadingGame);
+    }
+
+    Events::PushEventData("TARGET_OBJECT_ID", Utils::ObjectIDToString(pObject->m_idSelf));
+    Events::PushEventData("HEAL_AMOUNT", std::to_string(nHealAmount));
+    Events::PushEventData("ACTION_RESULT", std::to_string(retVal));
+
+    Events::SignalEvent("NWNX_ON_HEAL_AFTER", pGameEffect->m_oidCreator);
     return retVal;
 }
 

--- a/Plugins/Events/Events/HealingEvents.hpp
+++ b/Plugins/Events/Events/HealingEvents.hpp
@@ -6,13 +6,14 @@
 
 namespace Events {
 
-class HealerKitEvents
+class HealingEvents
 {
 public:
-    HealerKitEvents(NWNXLib::Services::HooksProxy* hooker);
+    HealingEvents(NWNXLib::Services::HooksProxy* hooker);
 
 private:
     static uint32_t AIActionHealHook(CNWSCreature *pCreature, CNWSObjectActionNode *pNode);
+    static int64_t OnApplyHealHook(CNWSEffectListHandler *pThis, CNWSObject *pObject, CGameEffect *pGameEffect, int32_t bLoadingGame);
 
 };
 

--- a/Plugins/Events/Events/HealingEvents.hpp
+++ b/Plugins/Events/Events/HealingEvents.hpp
@@ -13,7 +13,7 @@ public:
 
 private:
     static uint32_t AIActionHealHook(CNWSCreature *pCreature, CNWSObjectActionNode *pNode);
-    static int64_t OnApplyHealHook(CNWSEffectListHandler *pThis, CNWSObject *pObject, CGameEffect *pGameEffect, int32_t bLoadingGame);
+    static int32_t OnApplyHealHook(CNWSEffectListHandler *pThis, CNWSObject *pObject, CGameEffect *pGameEffect, int32_t bLoadingGame);
 
 };
 

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -534,6 +534,18 @@ _______________________________________
     ACTION_RESULT         | int    | |
 
 _______________________________________
+    ## Healing Events
+    - NWNX_ON_HEAL_BEFORE
+    - NWNX_ON_HEAL_AFTER
+
+    `OBJECT_SELF` = The creature performing the heal
+
+    Event Data Tag        | Type   | Notes |
+    ----------------------|--------|-------|
+    TARGET_OBJECT_ID      | object | Convert to object with StringToObject() |
+    HEAL_AMOUNT           | int    | How many HP the heal will provide |
+
+_______________________________________
     ## Party Action Events
     - NWNX_ON_PARTY_*_BEFORE
     - NWNX_ON_PARTY_*_AFTER
@@ -1218,7 +1230,7 @@ string NWNX_Events_GetEventData(string tag);
 /// ONLY WORKS WITH THE FOLLOWING EVENTS:
 /// - Feat events
 /// - Item events
-/// - Healer's Kit event
+/// - Healing events
 /// - CombatMode events
 /// - Party events
 /// - Skill events
@@ -1256,6 +1268,7 @@ void NWNX_Events_SkipEvent();
 /// - Ammo Reload event -> Forced ammunition returned
 /// - Trap events -> "1" or "0"
 /// - Sticky Player Name event -> "1" or "0"
+/// - Heal event -> Amount of HP to heal
 void NWNX_Events_SetEventResult(string data);
 
 /// Returns the current event name


### PR DESCRIPTION
Can be skipped, HP to heal can be returned in BEFORE with `NWNX_Events_SetEventResult`

Sample usage:
```c
#include "nwnx_events"

void main()
{
    object oPC = OBJECT_SELF;
    string sCurrentEvent = NWNX_Events_GetCurrentEvent();
    if (sCurrentEvent == "NWNX_ON_HEAL_BEFORE")
    {
        object oHealed = StringToObject(NWNX_Events_GetEventData("TARGET_OBJECT_ID"));
        int iHealAmount = StringToInt(NWNX_Events_GetEventData("HEAL_AMOUNT"));
        NWNX_Events_SkipEvent();
        if (GetIsPC(oHealed))
            NWNX_Events_SetEventResult(IntToString(iHealAmount+2));
        else
            NWNX_Events_SetEventResult(IntToString(iHealAmount-2));
    }

```