### PR TITLE
Weaponpluginmisc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ https://github.com/nwnxee/unified/compare/build8193.14...HEAD
 - Events: added skippable PlayerDM Login/Logout events to DMActionEvents
 - Events: added skippable RunScript and RunScriptChunk events to DebugEvents
 - Events: added skippable RequestBuy/Sell events to StoreEvents
+- Weapon: added 'NWNX_WEAPON_GOOD_AIM_SLING' non-halfling sling users with the feat Good Aim gain an additional +1 AB as a halfling currently does. Note: Throwing weapons are already included in the base game
 
 ##### New Plugins
 N/A
@@ -26,10 +27,13 @@ N/A
 - Player: SetObjectMouseCursorOverride()
 - Player: SetObjectHiliteColorOverride()
 - Util: GetWorldTime()
+- Weapon: SetOneHalfStrength()
 
 ### Changed
 - Effect: (Un)PackEffect now supports vector params
-- Events: added a `RESULT` event data tag to LearnScroll in ItemEvents 
+- Events: added a `RESULT` event data tag to LearnScroll in ItemEvents
+- Weapon: SetWeapon****Feat functions may be called multiple times for the same weapon, associating a new feat each time
+- Weapon: weapon feats defined in the 2da are no longer overridden by SetWeapon***Feat and will be used in addition to any set feats
 
 ### Deprecated
 - Object: StringToObject();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ N/A
 - Player: SetObjectMouseCursorOverride()
 - Player: SetObjectHiliteColorOverride()
 - Util: GetWorldTime()
-- Weapon: SetOneHalfStrength()
+- Weapon: {Get|Set}OneHalfStrength()
 
 ### Changed
 - Effect: (Un)PackEffect now supports vector params

--- a/Plugins/Weapon/NWScript/nwnx_weapon.nss
+++ b/Plugins/Weapon/NWScript/nwnx_weapon.nss
@@ -114,10 +114,16 @@ struct NWNX_Weapon_DevastatingCriticalEvent_Data NWNX_Weapon_GetDevastatingCriti
 /// @note This is only for use with the Devastating Critical Event Script.
 void NWNX_Weapon_BypassDevastatingCritical();
 
-/// @brief Sets weapon to gain 1.5 strength bonus.
+/// @brief Sets weapon to gain .5 strength bonus.
 /// @param oWeapon Should be a melee weapon.
 /// @param nEnable TRUE for bonus. FALSE to turn off bonus.
-void NWNX_Weapon_SetOneHalfStrength(object oWeapon, int nEnable);
+/// @param bPersist whether the two hand state should persist to the gff file.
+void NWNX_Weapon_SetOneHalfStrength(object oWeapon, int nEnable, int bPersist = FALSE);
+
+/// @brief Gets if the weapon is set to gain addition .5 strength bonus
+/// @param oWeapon the weapon
+/// @return FALSE/0 if weapon is not receiving the bonus. TRUE/1 if it does.
+int NWNX_Weapon_GetOneHalfStrength(object oWeapon);
 
 /// @}
 
@@ -304,10 +310,20 @@ struct NWNX_Weapon_DevastatingCriticalEvent_Data NWNX_Weapon_GetDevastatingCriti
     return data;
 }
 
-void NWNX_Weapon_SetOneHalfStrength(object oWeapon, int nEnable)
+void NWNX_Weapon_SetOneHalfStrength(object oWeapon, int nEnable, int bPersist = FALSE)
 {
     string sFunc = "SetOneHalfStrength";
+    NWNX_PushArgumentInt(NWNX_Weapon, sFunc, bPersist);
     NWNX_PushArgumentInt(NWNX_Weapon, sFunc, nEnable);
     NWNX_PushArgumentObject(NWNX_Weapon, sFunc, oWeapon);
     NWNX_CallFunction(NWNX_Weapon, sFunc);
+}
+
+int NWNX_Weapon_GetOneHalfStrength(object oWeapon)
+{
+    string sFunc = "GetOneHalfStrength";
+    NWNX_PushArgumentObject(NWNX_Weapon, sFunc, oWeapon);
+    NWNX_CallFunction(NWNX_Weapon, sFunc);
+
+    return NWNX_GetReturnValueInt(NWNX_Weapon, sFunc);
 }

--- a/Plugins/Weapon/NWScript/nwnx_weapon.nss
+++ b/Plugins/Weapon/NWScript/nwnx_weapon.nss
@@ -114,6 +114,11 @@ struct NWNX_Weapon_DevastatingCriticalEvent_Data NWNX_Weapon_GetDevastatingCriti
 /// @note This is only for use with the Devastating Critical Event Script.
 void NWNX_Weapon_BypassDevastatingCritical();
 
+// @brief Sets weapon to gain 1.5 strength bonus.
+// @param oWeapon Should be a melee weapon.
+// @param nEnable TRUE for bonus. FALSE to turn off bonus.
+void NWNX_Weapon_SetOneHalfStrength(object oWeapon, int nEnable);
+
 /// @}
 
 void NWNX_Weapon_SetWeaponFocusFeat(int nBaseItem, int nFeat)
@@ -297,4 +302,12 @@ struct NWNX_Weapon_DevastatingCriticalEvent_Data NWNX_Weapon_GetDevastatingCriti
     data.nDamage = NWNX_GetReturnValueInt(NWNX_Weapon, sFunc);
 
     return data;
+}
+
+void NWNX_Weapon_SetOneHalfStrength(object oWeapon, int nEnable)
+{
+    string sFunc = "SetOneHalfStrength";
+    NWNX_PushArgumentInt(NWNX_Weapon, sFunc, nEnable);
+    NWNX_PushArgumentObject(NWNX_Weapon, sFunc, oWeapon);
+    NWNX_CallFunction(NWNX_Weapon, sFunc);
 }

--- a/Plugins/Weapon/NWScript/nwnx_weapon.nss
+++ b/Plugins/Weapon/NWScript/nwnx_weapon.nss
@@ -114,9 +114,9 @@ struct NWNX_Weapon_DevastatingCriticalEvent_Data NWNX_Weapon_GetDevastatingCriti
 /// @note This is only for use with the Devastating Critical Event Script.
 void NWNX_Weapon_BypassDevastatingCritical();
 
-// @brief Sets weapon to gain 1.5 strength bonus.
-// @param oWeapon Should be a melee weapon.
-// @param nEnable TRUE for bonus. FALSE to turn off bonus.
+/// @brief Sets weapon to gain 1.5 strength bonus.
+/// @param oWeapon Should be a melee weapon.
+/// @param nEnable TRUE for bonus. FALSE to turn off bonus.
 void NWNX_Weapon_SetOneHalfStrength(object oWeapon, int nEnable);
 
 /// @}

--- a/Plugins/Weapon/README.md
+++ b/Plugins/Weapon/README.md
@@ -43,6 +43,7 @@ NWNX_Weapon_SetDevastatingCriticalEventScript() | Set a script to be called when
 NWNX_Weapon_GetDevastatingCriticalEventData() | Must be called inside the devastating critical event script. Returns a structure with the data of the devastating critical event (weapon, target and damage)
 NWNX_Weapon_BypassDevastatingCritical() | Must be called inside the devastating critical event script. If called, no devastating critical will occur.
 NWNX_Weapon_SetOneHalfStrength() | Gives a melee weapon extra damage equal to one-half strength modifier.
+NWNX_Weapon_GetOneHalfStrength() | Retrieves if a melee weapon is receiving extra strength
 
 The NWNX_Weapon_SetOption() function can be used to define the attack and damage bonusses of the Greater Weapon Focus Feats and Greater Weapon Specialization Feats respectively. 
 

--- a/Plugins/Weapon/README.md
+++ b/Plugins/Weapon/README.md
@@ -25,23 +25,24 @@ NWNX_Weapon_SetWeaponFocusFeat(BASE_ITEM_KATAR, FEAT_WEAPON_FOCUS_KATAR);
 
 Script function | Description  
 ----------------|-------------
-NWNX_Weapon_SetWeaponFocusFeat() | Associate a weapon focus feat to a weapon 
+NWNX_Weapon_SetWeaponFocusFeat() | Associate a weapon focus feat to a weapon. You may set multiple feats for each weapon and all will function. 
 NWNX_Weapon_SetWeaponFinesseSize() | Define the required creature size for a weapon in order to be finessable
 NWNX_Weapon_SetWeaponUnarmed() | Set the weapon to be considered unarmed regarding the finesse feat
-NWNX_Weapon_SetWeaponImprovedCriticalFeat() | Associate a weapon improved critical feat to a weapon 
-NWNX_Weapon_SetWeaponSpecializationFeat() | Associate a weapon specialization feat to a weapon 
-NWNX_Weapon_SetEpicWeaponFocusFeat() | Associate an epic weapon focus feat to a weapon 
-NWNX_Weapon_SetEpicWeaponSpecializationFeat() | Associate an epic weapon specialization feat to a weapon 
-NWNX_Weapon_SetEpicWeaponOverwhelmingCriticalFeat() | Associate an epic weapon overwhelming critical feat to a weapon 
-NWNX_Weapon_SetEpicWeaponDevastatingCriticalFeat() | Associate an epic weapon devastating critical feat to a weapon 
-NWNX_Weapon_SetWeaponOfChoiceFeat() | Associate a weapon of choice feat to a weapon 
-NWNX_Weapon_SetGreaterWeaponFocusFeat() | Associate a greater weapon focus feat (default: +1 attack bonus) to a weapon
-NWNX_Weapon_SetGreaterWeaponSpecializationFeat() | Associate a greater weapon specialization feat (default: +2 damage bonus) to a weapon
+NWNX_Weapon_SetWeaponImprovedCriticalFeat() | Associate a weapon improved critical feat to a weapon You may set multiple feats for each weapon and all will function.
+NWNX_Weapon_SetWeaponSpecializationFeat() | Associate a weapon specialization feat to a weapon You may set multiple feats for each weapon and all will function.
+NWNX_Weapon_SetEpicWeaponFocusFeat() | Associate an epic weapon focus feat to a weapon You may set multiple feats for each weapon and all will function.
+NWNX_Weapon_SetEpicWeaponSpecializationFeat() | Associate an epic weapon specialization feat to a weapon You may set multiple feats for each weapon and all will function.
+NWNX_Weapon_SetEpicWeaponOverwhelmingCriticalFeat() | Associate an epic weapon overwhelming critical feat to a weapon You may set multiple feats for each weapon and all will function.
+NWNX_Weapon_SetEpicWeaponDevastatingCriticalFeat() | Associate an epic weapon devastating critical feat to a weapon You may set multiple feats for each weapon and all will function.
+NWNX_Weapon_SetWeaponOfChoiceFeat() | Associate a weapon of choice feat to a weapon You may set multiple feats for each weapon and all will function.
+NWNX_Weapon_SetGreaterWeaponFocusFeat() | Associate a greater weapon focus feat (default: +1 attack bonus) to a weapon You may set multiple feats for each weapon and all will function.
+NWNX_Weapon_SetGreaterWeaponSpecializationFeat() | Associate a greater weapon specialization feat (default: +2 damage bonus) to a weapon You may set multiple feats for each weapon and all will function.
 NWNX_Weapon_SetWeaponIsMonkWeapon() | Set the weapon to be considered a monk weapon
 NWNX_Weapon_SetOption() | Set different options of the plugin
 NWNX_Weapon_SetDevastatingCriticalEventScript() | Set a script to be called when a devastating critical event occurs
 NWNX_Weapon_GetDevastatingCriticalEventData() | Must be called inside the devastating critical event script. Returns a structure with the data of the devastating critical event (weapon, target and damage)
 NWNX_Weapon_BypassDevastatingCritical() | Must be called inside the devastating critical event script. If called, no devastating critical will occur.
+NWNX_Weapon_SetOneHalfStrength() | Gives a melee weapon extra damage equal to one-half strength modifier.
 
 The NWNX_Weapon_SetOption() function can be used to define the attack and damage bonusses of the Greater Weapon Focus Feats and Greater Weapon Specialization Feats respectively. 
 

--- a/Plugins/Weapon/Weapon.cpp
+++ b/Plugins/Weapon/Weapon.cpp
@@ -53,6 +53,8 @@ Weapon::Weapon(Services::ProxyServiceList* services)
     REGISTER(GetEventData);
     REGISTER(SetEventData);
     REGISTER(SetOneHalfStrength);
+    REGISTER(GetOneHalfStrength);
+
 #undef REGISTER
 
     m_GetWeaponFocusHook = GetServices()->m_hooks->RequestExclusiveHook<Functions::_ZN17CNWSCreatureStats14GetWeaponFocusEP8CNWSItem>(&Weapon::GetWeaponFocus);
@@ -1204,11 +1206,27 @@ ArgumentStack Weapon::SetOneHalfStrength(ArgumentStack&& args)
     }
 
     auto bMulti = Services::Events::ExtractArgument<int32_t>(args);
+    bool bPersist = !!Services::Events::ExtractArgument<int32_t>(args);
     if(bMulti)
-        g_plugin->GetServices()->m_perObjectStorage->Set(objectId, "ONE_HALF_STRENGTH", 1);
+        g_plugin->GetServices()->m_perObjectStorage->Set(objectId, "ONE_HALF_STRENGTH", 1, bPersist);
     else
         g_plugin->GetServices()->m_perObjectStorage->Remove(objectId, "ONE_HALF_STRENGTH");
 
     return Services::Events::Arguments();
 }
+
+ArgumentStack Weapon::GetOneHalfStrength(ArgumentStack&& args)
+{
+    auto objectId = Services::Events::ExtractArgument<ObjectID>(args);
+    int32_t retVal = 0;
+    if(objectId != Constants::OBJECT_INVALID)
+    {
+        auto exist = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(objectId, "ONE_HALF_STRENGTH");
+        if(exist)
+            retVal = exist.value();
+    }
+
+    return Services::Events::Arguments(retVal);
+}
+
 }

--- a/Plugins/Weapon/Weapon.cpp
+++ b/Plugins/Weapon/Weapon.cpp
@@ -10,7 +10,9 @@
 #include "API/CNWBaseItem.hpp"
 #include "API/CNWRules.hpp"
 #include "Utils.hpp"
+#include "Services/Config/Config.hpp"
 #include "Services/Messaging/Messaging.hpp"
+#include "Services/PerObjectStorage/PerObjectStorage.hpp"
 
 using namespace NWNXLib;
 using namespace NWNXLib::API;
@@ -50,7 +52,7 @@ Weapon::Weapon(Services::ProxyServiceList* services)
     REGISTER(SetDevastatingCriticalEventScript);
     REGISTER(GetEventData);
     REGISTER(SetEventData);
-
+    REGISTER(SetOneHalfStrength);
 #undef REGISTER
 
     m_GetWeaponFocusHook = GetServices()->m_hooks->RequestExclusiveHook<Functions::_ZN17CNWSCreatureStats14GetWeaponFocusEP8CNWSItem>(&Weapon::GetWeaponFocus);
@@ -74,6 +76,8 @@ Weapon::Weapon(Services::ProxyServiceList* services)
     m_WeaponFinesseSizeMap.insert({Constants::BaseItem::Rapier, (uint8_t) Constants::CreatureSize::Medium});
 
     m_DCScript="";
+
+    m_GASling=GetServices()->m_config->Get<bool>("GOOD_AIM_SLING", false);
 }
 
 Weapon::~Weapon()
@@ -94,7 +98,15 @@ ArgumentStack Weapon::SetWeaponFocusFeat(ArgumentStack&& args)
     CNWBaseItem *pBaseItem = Globals::Rules()->m_pBaseItemArray->GetBaseItem(w_bitem);
       ASSERT_OR_THROW(pBaseItem);
 
-    m_WeaponFocusMap.insert({w_bitem, feat});
+    auto w = m_WeaponFocusMap.find(w_bitem);
+    if ( w != m_WeaponFocusMap.end())
+    {
+        w->second.emplace((uint32_t)feat);
+    }
+    else
+    {
+        m_WeaponFocusMap.insert({w_bitem, {(uint32_t)feat}});
+    }
     auto featName = pFeat->GetNameText();
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Weapon Focus Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
@@ -116,7 +128,15 @@ ArgumentStack Weapon::SetGreaterWeaponFocusFeat(ArgumentStack&& args)
     CNWBaseItem *pBaseItem = Globals::Rules()->m_pBaseItemArray->GetBaseItem(w_bitem);
       ASSERT_OR_THROW(pBaseItem);
 
-    m_GreaterWeaponFocusMap.insert({w_bitem, feat});
+    auto w = m_GreaterWeaponFocusMap.find(w_bitem);
+    if ( w != m_WeaponFocusMap.end())
+    {
+        w->second.emplace((uint32_t)feat);
+    }
+    else
+    {
+        m_GreaterWeaponFocusMap.insert({w_bitem, {(uint32_t)feat}});
+    }
     auto featName = pFeat->GetNameText();
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Greater Weapon Focus Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
@@ -138,7 +158,15 @@ ArgumentStack Weapon::SetEpicWeaponFocusFeat(ArgumentStack&& args)
     CNWBaseItem *pBaseItem = Globals::Rules()->m_pBaseItemArray->GetBaseItem(w_bitem);
       ASSERT_OR_THROW(pBaseItem);
 
-    m_EpicWeaponFocusMap.insert({w_bitem, feat});
+    auto w = m_EpicWeaponFocusMap.find(w_bitem);
+    if ( w != m_EpicWeaponFocusMap.end())
+    {
+        w->second.emplace((uint32_t)feat);
+    }
+    else
+    {
+        m_EpicWeaponFocusMap.insert({w_bitem, {(uint32_t)feat}});
+    }
     auto featName = pFeat->GetNameText();
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Epic Weapon Focus Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
@@ -237,7 +265,15 @@ ArgumentStack Weapon::SetWeaponImprovedCriticalFeat(ArgumentStack&& args)
     CNWBaseItem *pBaseItem = Globals::Rules()->m_pBaseItemArray->GetBaseItem(w_bitem);
       ASSERT_OR_THROW(pBaseItem);
 
-    m_WeaponImprovedCriticalMap.insert({w_bitem, feat});
+    auto w = m_WeaponImprovedCriticalMap.find(w_bitem);
+    if ( w != m_WeaponImprovedCriticalMap.end())
+    {
+        w->second.emplace((uint32_t)feat);
+    }
+    else
+    {
+        m_WeaponImprovedCriticalMap.insert({w_bitem, {(uint32_t)feat}});
+    }
     auto featName = pFeat->GetNameText();
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Improved Critical Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
@@ -259,7 +295,15 @@ ArgumentStack Weapon::SetWeaponSpecializationFeat(ArgumentStack&& args)
     CNWBaseItem *pBaseItem = Globals::Rules()->m_pBaseItemArray->GetBaseItem(w_bitem);
       ASSERT_OR_THROW(pBaseItem);
 
-    m_WeaponSpecializationMap.insert({w_bitem, feat});
+    auto w = m_WeaponSpecializationMap.find(w_bitem);
+    if ( w != m_WeaponSpecializationMap.end())
+    {
+        w->second.emplace((uint32_t)feat);
+    }
+    else
+    {
+        m_WeaponSpecializationMap.insert({w_bitem, {(uint32_t)feat}});
+    }
     auto featName = pFeat->GetNameText();
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Weapon Specialization Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
@@ -281,7 +325,15 @@ ArgumentStack Weapon::SetGreaterWeaponSpecializationFeat(ArgumentStack&& args)
     CNWBaseItem *pBaseItem = Globals::Rules()->m_pBaseItemArray->GetBaseItem(w_bitem);
       ASSERT_OR_THROW(pBaseItem);
 
-    m_GreaterWeaponSpecializationMap.insert({w_bitem, feat});
+    auto w = m_GreaterWeaponSpecializationMap.find(w_bitem);
+    if ( w != m_GreaterWeaponSpecializationMap.end())
+    {
+        w->second.emplace((uint32_t)feat);
+    }
+    else
+    {
+        m_GreaterWeaponSpecializationMap.insert({w_bitem, {(uint32_t)feat}});
+    }
     auto featName = pFeat->GetNameText();
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Greater Weapon Specialization Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
@@ -303,7 +355,15 @@ ArgumentStack Weapon::SetEpicWeaponSpecializationFeat(ArgumentStack&& args)
     CNWBaseItem *pBaseItem = Globals::Rules()->m_pBaseItemArray->GetBaseItem(w_bitem);
       ASSERT_OR_THROW(pBaseItem);
 
-    m_EpicWeaponSpecializationMap.insert({w_bitem, feat});
+    auto w = m_EpicWeaponSpecializationMap.find(w_bitem);
+    if ( w != m_EpicWeaponSpecializationMap.end())
+    {
+        w->second.emplace((uint32_t)feat);
+    }
+    else
+    {
+        m_EpicWeaponSpecializationMap.insert({w_bitem, {(uint32_t)feat}});
+    }
     auto featName = pFeat->GetNameText();
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Epic Weapon Specialization Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
@@ -325,7 +385,15 @@ ArgumentStack Weapon::SetEpicWeaponOverwhelmingCriticalFeat(ArgumentStack&& args
     CNWBaseItem *pBaseItem = Globals::Rules()->m_pBaseItemArray->GetBaseItem(w_bitem);
       ASSERT_OR_THROW(pBaseItem);
 
-    m_EpicWeaponOverwhelmingCriticalMap.insert({w_bitem, feat});
+    auto w = m_EpicWeaponOverwhelmingCriticalMap.find(w_bitem);
+    if ( w != m_EpicWeaponOverwhelmingCriticalMap.end())
+    {
+        w->second.emplace((uint32_t)feat);
+    }
+    else
+    {
+        m_EpicWeaponOverwhelmingCriticalMap.insert({w_bitem, {(uint32_t)feat}});
+    }
     auto featName = pFeat->GetNameText();
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Overwhelming Critical Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
@@ -347,7 +415,15 @@ ArgumentStack Weapon::SetEpicWeaponDevastatingCriticalFeat(ArgumentStack&& args)
     CNWBaseItem *pBaseItem = Globals::Rules()->m_pBaseItemArray->GetBaseItem(w_bitem);
       ASSERT_OR_THROW(pBaseItem);
 
-    m_EpicWeaponDevastatingCriticalMap.insert({w_bitem, feat});
+    auto w = m_EpicWeaponDevastatingCriticalMap.find(w_bitem);
+    if ( w != m_EpicWeaponDevastatingCriticalMap.end())
+    {
+        w->second.emplace((uint32_t)feat);
+    }
+    else
+    {
+        m_EpicWeaponDevastatingCriticalMap.insert({w_bitem, {(uint32_t)feat}});
+    }
     auto featName = pFeat->GetNameText();
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Devastating Critical Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
@@ -369,7 +445,15 @@ ArgumentStack Weapon::SetWeaponOfChoiceFeat(ArgumentStack&& args)
     CNWBaseItem *pBaseItem = Globals::Rules()->m_pBaseItemArray->GetBaseItem(w_bitem);
       ASSERT_OR_THROW(pBaseItem);
 
-    m_WeaponOfChoiceMap.insert({w_bitem, feat});
+    auto w = m_WeaponOfChoiceMap.find(w_bitem);
+    if ( w != m_WeaponOfChoiceMap.end())
+    {
+        w->second.emplace((uint32_t)feat);
+    }
+    else
+    {
+        m_WeaponOfChoiceMap.insert({w_bitem, {(uint32_t)feat}});
+    }
     auto featName = pFeat->GetNameText();
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Weapon of Choice Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
@@ -435,50 +519,50 @@ ArgumentStack Weapon::SetEventData(ArgumentStack&& args)
 
 int32_t Weapon::GetWeaponFocus(CNWSCreatureStats* pStats, CNWSItem* pWeapon)
 {
-    int32_t feat = -1;
+    int32_t bApplicableFeatExists = 0;
+    int32_t bHasApplicableFeat = 0;
     Weapon& plugin = *g_plugin;
 
-    if (pWeapon == nullptr)
+
+    auto w = plugin.m_WeaponFocusMap.find(pWeapon == nullptr ? (uint32_t)Constants::BaseItem::Gloves : pWeapon->m_nBaseItem);
+
+    bApplicableFeatExists = w != plugin.m_WeaponFocusMap.end();
+
+    if (bApplicableFeatExists)
     {
-        auto w = plugin.m_WeaponFocusMap.find(Constants::BaseItem::Gloves);
-        feat = (w == plugin.m_WeaponFocusMap.end()) ? -1 : w->second;
-    }
-    else
-    {
-        auto w = plugin.m_WeaponFocusMap.find(pWeapon->m_nBaseItem);
-        feat = (w == plugin.m_WeaponFocusMap.end()) ? -1 : w->second;
+        for (auto feat : w->second)
+        {
+            bHasApplicableFeat = (pStats->HasFeat(feat) || (feat == Constants::Feat::WeaponFocus_Creature &&
+            pStats->HasFeat(Constants::Feat::WeaponFocus_UnarmedStrike)));
+
+            if (bHasApplicableFeat) break;
+        }
     }
 
-    if (feat == Constants::Feat::WeaponFocus_Creature &&
-       pStats->HasFeat(Constants::Feat::WeaponFocus_UnarmedStrike))
-    {
-        return 1;
-    }
-    return (feat > -1 ? pStats->HasFeat(feat) : plugin.m_GetWeaponFocusHook->CallOriginal<int32_t>(pStats, pWeapon));
+    return (bApplicableFeatExists && bHasApplicableFeat ? 1 : plugin.m_GetWeaponFocusHook->CallOriginal<int32_t>(pStats, pWeapon));
 }
 
 int32_t Weapon::GetEpicWeaponFocus(CNWSCreatureStats* pStats, CNWSItem* pWeapon)
 {
-    int32_t feat = -1;
+    int32_t bApplicableFeatExists = 0;
+    int32_t bHasApplicableFeat = 0;
     Weapon& plugin = *g_plugin;
 
-    if (pWeapon == nullptr)
-    {
-        auto w = plugin.m_EpicWeaponFocusMap.find(Constants::BaseItem::Gloves);
-        feat = (w == plugin.m_EpicWeaponFocusMap.end()) ? -1 : w->second;
-    }
-    else
-    {
-        auto w = plugin.m_EpicWeaponFocusMap.find(pWeapon->m_nBaseItem);
-        feat = (w == plugin.m_EpicWeaponFocusMap.end()) ? -1 : w->second;
-    }
+    auto w = plugin.m_EpicWeaponFocusMap.find(pWeapon == nullptr ? (uint32_t)Constants::BaseItem::Gloves : pWeapon->m_nBaseItem);
 
-    if (feat == Constants::Feat::EpicWeaponFocus_Creature &&
-       pStats->HasFeat(Constants::Feat::EpicWeaponFocus_Unarmed))
+    bApplicableFeatExists = w != plugin.m_EpicWeaponFocusMap.end();
+
+    if (bApplicableFeatExists)
     {
-        return 1;
+        for (auto feat : w->second)
+        {
+            bHasApplicableFeat = (pStats->HasFeat(feat) || (feat == Constants::Feat::EpicWeaponFocus_Creature &&
+            pStats->HasFeat(Constants::Feat::EpicWeaponFocus_Unarmed)));
+
+            if (bHasApplicableFeat) break;
+        }
     }
-    return (feat > -1 ? pStats->HasFeat(feat) : plugin.m_GetEpicWeaponFocusHook->CallOriginal<int32_t>(pStats, pWeapon));
+    return (bApplicableFeatExists && bHasApplicableFeat ? 1 : plugin.m_GetEpicWeaponFocusHook->CallOriginal<int32_t>(pStats, pWeapon));
 }
 
 int32_t Weapon::GetWeaponFinesse(CNWSCreatureStats* pStats, CNWSItem* pWeapon)
@@ -493,97 +577,122 @@ int32_t Weapon::GetWeaponFinesse(CNWSCreatureStats* pStats, CNWSItem* pWeapon)
 
 int32_t Weapon::GetWeaponImprovedCritical(CNWSCreatureStats* pStats, CNWSItem* pWeapon)
 {
-    int32_t feat = -1;
+    int32_t bApplicableFeatExists = 0;
+    int32_t bHasApplicableFeat = 0;
     Weapon& plugin = *g_plugin;
 
-    if (pWeapon == nullptr)
+
+    auto w = plugin.m_WeaponImprovedCriticalMap.find(pWeapon == nullptr ? (uint32_t)Constants::BaseItem::Gloves : pWeapon->m_nBaseItem);
+
+    bApplicableFeatExists = w != plugin.m_WeaponImprovedCriticalMap.end();
+
+    if (bApplicableFeatExists)
     {
-        auto w = plugin.m_WeaponImprovedCriticalMap.find(Constants::BaseItem::Gloves);
-        feat = (w == plugin.m_WeaponImprovedCriticalMap.end()) ? -1 : w->second;
-    }
-    else
-    {
-        auto w = plugin.m_WeaponImprovedCriticalMap.find(pWeapon->m_nBaseItem);
-        feat = (w == plugin.m_WeaponImprovedCriticalMap.end()) ? -1 : w->second;
+        for (auto feat : w->second)
+        {
+            bHasApplicableFeat = (pStats->HasFeat(feat));
+
+            if (bHasApplicableFeat) break;
+        }
     }
 
-    return (feat > -1 ? pStats->HasFeat(feat) : plugin.m_GetWeaponImprovedCriticalHook->CallOriginal<int32_t>(pStats, pWeapon));
+    return (bApplicableFeatExists && bHasApplicableFeat ? 1 : plugin.m_GetWeaponImprovedCriticalHook->CallOriginal<int32_t>(pStats, pWeapon));
 }
 
 int32_t Weapon::GetWeaponSpecialization(CNWSCreatureStats* pStats, CNWSItem* pWeapon)
 {
-    int32_t feat = -1;
+    int32_t bApplicableFeatExists = 0;
+    int32_t bHasApplicableFeat = 0;
     Weapon& plugin = *g_plugin;
 
-    if (pWeapon == nullptr)
+
+    auto w = plugin.m_WeaponSpecializationMap.find(pWeapon == nullptr ? (uint32_t)Constants::BaseItem::Gloves : pWeapon->m_nBaseItem);
+
+    bApplicableFeatExists = w != plugin.m_WeaponSpecializationMap.end();
+
+    if (bApplicableFeatExists)
     {
-        auto w = plugin.m_WeaponSpecializationMap.find(Constants::BaseItem::Gloves);
-        feat = (w == plugin.m_WeaponSpecializationMap.end()) ? -1 : w->second;
-    }
-    else
-    {
-        auto w = plugin.m_WeaponSpecializationMap.find(pWeapon->m_nBaseItem);
-        feat = (w == plugin.m_WeaponSpecializationMap.end()) ? -1 : w->second;
+        for (auto feat : w->second)
+        {
+            bHasApplicableFeat = (pStats->HasFeat(feat));
+
+            if (bHasApplicableFeat) break;
+        }
     }
 
-    return (feat > -1 ? pStats->HasFeat(feat) : plugin.m_GetWeaponSpecializationHook->CallOriginal<int32_t>(pStats, pWeapon));
+    return (bApplicableFeatExists && bHasApplicableFeat ? 1 : plugin.m_GetWeaponSpecializationHook->CallOriginal<int32_t>(pStats, pWeapon));
 }
 
 int32_t Weapon::GetEpicWeaponSpecialization(CNWSCreatureStats* pStats, CNWSItem* pWeapon)
 {
-    int32_t feat = -1;
+    int32_t bApplicableFeatExists = 0;
+    int32_t bHasApplicableFeat = 0;
     Weapon& plugin = *g_plugin;
 
-    if (pWeapon == nullptr)
+
+    auto w = plugin.m_EpicWeaponSpecializationMap.find(pWeapon == nullptr ? (uint32_t)Constants::BaseItem::Gloves : pWeapon->m_nBaseItem);
+
+    bApplicableFeatExists = w != plugin.m_EpicWeaponSpecializationMap.end();
+
+    if (bApplicableFeatExists)
     {
-        auto w = plugin.m_EpicWeaponSpecializationMap.find(Constants::BaseItem::Gloves);
-        feat = (w == plugin.m_EpicWeaponSpecializationMap.end()) ? -1 : w->second;
-    }
-    else
-    {
-        auto w = plugin.m_EpicWeaponSpecializationMap.find(pWeapon->m_nBaseItem);
-        feat = (w == plugin.m_EpicWeaponSpecializationMap.end()) ? -1 : w->second;
+        for (auto feat : w->second)
+        {
+            bHasApplicableFeat = (pStats->HasFeat(feat));
+
+            if (bHasApplicableFeat) break;
+        }
     }
 
-    return (feat > -1 ? pStats->HasFeat(feat) : plugin.m_GetEpicWeaponSpecializationHook->CallOriginal<int32_t>(pStats, pWeapon));
+    return (bApplicableFeatExists && bHasApplicableFeat ? 1 : plugin.m_GetEpicWeaponSpecializationHook->CallOriginal<int32_t>(pStats, pWeapon));
 }
 
 int32_t Weapon::GetEpicWeaponOverwhelmingCritical(CNWSCreatureStats* pStats, CNWSItem* pWeapon)
 {
-    int32_t feat = -1;
+    int32_t bApplicableFeatExists = 0;
+    int32_t bHasApplicableFeat = 0;
     Weapon& plugin = *g_plugin;
 
-    if (pWeapon == nullptr)
+
+    auto w = plugin.m_EpicWeaponOverwhelmingCriticalMap.find(pWeapon == nullptr ? (uint32_t)Constants::BaseItem::Gloves : pWeapon->m_nBaseItem);
+
+    bApplicableFeatExists = w != plugin.m_EpicWeaponOverwhelmingCriticalMap.end();
+
+    if (bApplicableFeatExists)
     {
-        auto w = plugin.m_EpicWeaponOverwhelmingCriticalMap.find(Constants::BaseItem::Gloves);
-        feat = (w == plugin.m_EpicWeaponOverwhelmingCriticalMap.end()) ? -1 : w->second;
-    }
-    else
-    {
-        auto w = plugin.m_EpicWeaponOverwhelmingCriticalMap.find(pWeapon->m_nBaseItem);
-        feat = (w == plugin.m_EpicWeaponOverwhelmingCriticalMap.end()) ? -1 : w->second;
+        for (auto feat : w->second)
+        {
+            bHasApplicableFeat = (pStats->HasFeat(feat));
+
+            if (bHasApplicableFeat) break;
+        }
     }
 
-    return (feat > -1 ? pStats->HasFeat(feat) : plugin.m_GetEpicWeaponOverwhelmingCriticalHook->CallOriginal<int32_t>(pStats, pWeapon));
+    return (bApplicableFeatExists && bHasApplicableFeat ? 1 : plugin.m_GetEpicWeaponOverwhelmingCriticalHook->CallOriginal<int32_t>(pStats, pWeapon));
 }
 
 int32_t Weapon::GetEpicWeaponDevastatingCritical(CNWSCreatureStats* pStats, CNWSItem* pWeapon)
 {
-    int32_t feat = -1;
+    int32_t bApplicableFeatExists = 0;
+    int32_t bHasApplicableFeat = 0;
     Weapon& plugin = *g_plugin;
-    bool bFlag = false;
 
-    if (pWeapon == nullptr)
+
+    auto w = plugin.m_EpicWeaponDevastatingCriticalMap.find(pWeapon == nullptr ? (uint32_t)Constants::BaseItem::Gloves : pWeapon->m_nBaseItem);
+
+    bApplicableFeatExists = w != plugin.m_EpicWeaponDevastatingCriticalMap.end();
+
+    if (bApplicableFeatExists)
     {
-        auto w = plugin.m_EpicWeaponDevastatingCriticalMap.find(Constants::BaseItem::Gloves);
-        feat = (w == plugin.m_EpicWeaponDevastatingCriticalMap.end()) ? -1 : w->second;
+        for (auto feat : w->second)
+        {
+            bHasApplicableFeat = (pStats->HasFeat(feat));
+
+            if (bHasApplicableFeat) break;
+        }
     }
-    else
-    {
-        auto w = plugin.m_EpicWeaponDevastatingCriticalMap.find(pWeapon->m_nBaseItem);
-        feat = (w == plugin.m_EpicWeaponDevastatingCriticalMap.end()) ? -1 : w->second;
-    }
-    bFlag = feat > -1 ? pStats->HasFeat(feat) : plugin.m_GetEpicWeaponDevastatingCriticalHook->CallOriginal<int32_t>(pStats, pWeapon);
+
+    bool bFlag = bApplicableFeatExists && bHasApplicableFeat ? 1 : plugin.m_GetEpicWeaponDevastatingCriticalHook->CallOriginal<int32_t>(pStats, pWeapon);
 
     if (bFlag && !plugin.m_DCScript.empty())
     {
@@ -610,19 +719,33 @@ int32_t Weapon::GetEpicWeaponDevastatingCritical(CNWSCreatureStats* pStats, CNWS
 
 int32_t Weapon::GetIsWeaponOfChoice(CNWSCreatureStats* pStats, uint32_t nBaseItem)
 {
-    int32_t feat = -1;
+    int32_t bApplicableFeatExists = 0;
+    int32_t bHasApplicableFeat = 0;
     Weapon& plugin = *g_plugin;
 
-    auto w = plugin.m_WeaponOfChoiceMap.find(nBaseItem);
-    feat = (w == plugin.m_WeaponOfChoiceMap.end()) ? -1 : w->second;
 
-    return (feat > -1) ? pStats->HasFeat(feat) : plugin.m_GetIsWeaponOfChoiceHook->CallOriginal<int32_t>(pStats, nBaseItem);
+    auto w = plugin.m_WeaponOfChoiceMap.find(nBaseItem);
+
+    bApplicableFeatExists = w != plugin.m_WeaponOfChoiceMap.end();
+
+    if (bApplicableFeatExists)
+    {
+        for (auto feat : w->second)
+        {
+            bHasApplicableFeat = (pStats->HasFeat(feat));
+
+            if (bHasApplicableFeat) break;
+        }
+    }
+
+    return bApplicableFeatExists && bHasApplicableFeat ? 1 : plugin.m_GetIsWeaponOfChoiceHook->CallOriginal<int32_t>(pStats, nBaseItem);
 }
 
 //This one is required for correctly update PC sheet
 int32_t Weapon::GetMeleeDamageBonus(CNWSCreatureStats* pStats, int32_t bOffHand, uint8_t nCreatureWeaponIndex)
 {
-    int32_t feat = -1;
+    int32_t bApplicableFeatExists = 0;
+    int32_t bHasApplicableFeat = 0;
     Weapon& plugin = *g_plugin;
     CNWSItem* pWeapon = nullptr;
     uint32_t nBaseItem;
@@ -648,12 +771,28 @@ int32_t Weapon::GetMeleeDamageBonus(CNWSCreatureStats* pStats, int32_t bOffHand,
     else
     {
         nBaseItem = pWeapon->m_nBaseItem;
+        auto bStr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pWeapon, "ONE_HALF_STRENGTH");
+        if(bStr && bStr.value())
+            nBonus += pStats->m_nStrengthModifier/2;
     }
 
-    auto w = plugin.m_GreaterWeaponSpecializationMap.find(nBaseItem);
-    feat = (w == plugin.m_GreaterWeaponSpecializationMap.end()) ? -1 : w->second;
 
-    if (feat > -1 && pStats->HasFeat(feat))
+    auto w = plugin.m_GreaterWeaponSpecializationMap.find(nBaseItem);
+
+    bApplicableFeatExists = w != plugin.m_GreaterWeaponSpecializationMap.end();
+
+    if (bApplicableFeatExists)
+    {
+        for (auto feat : w->second)
+        {
+            bHasApplicableFeat = (pStats->HasFeat(feat));
+
+            if (bHasApplicableFeat) break;
+        }
+    }
+
+
+    if (bApplicableFeatExists && bHasApplicableFeat)
     {
         return nBonus + plugin.m_GreaterWeaponSpecializationDamageBonus;
     }
@@ -663,7 +802,8 @@ int32_t Weapon::GetMeleeDamageBonus(CNWSCreatureStats* pStats, int32_t bOffHand,
 
 int32_t Weapon::GetDamageBonus(CNWSCreatureStats* pStats, CNWSCreature *pCreature, int32_t bOffHand)
 {
-    int32_t feat = -1;
+    int32_t bApplicableFeatExists = 0;
+    int32_t bHasApplicableFeat = 0;
     Weapon& plugin = *g_plugin;
     CNWSItem* pWeapon = nullptr;
     uint32_t nBaseItem;
@@ -686,12 +826,28 @@ int32_t Weapon::GetDamageBonus(CNWSCreatureStats* pStats, CNWSCreature *pCreatur
     else
     {
         nBaseItem = pWeapon->m_nBaseItem;
+        auto bStr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pWeapon, "ONE_HALF_STRENGTH");
+        if(bStr && bStr.value())
+            nBonus += pStats->m_nStrengthModifier/2;
     }
 
-    auto w = plugin.m_GreaterWeaponSpecializationMap.find(nBaseItem);
-    feat = (w == plugin.m_GreaterWeaponSpecializationMap.end()) ? -1 : w->second;
 
-    if (feat > -1 && pStats->HasFeat(feat))
+    auto w = plugin.m_GreaterWeaponSpecializationMap.find(nBaseItem);
+
+    bApplicableFeatExists = w != plugin.m_GreaterWeaponSpecializationMap.end();
+
+    if (bApplicableFeatExists)
+    {
+        for (auto feat : w->second)
+        {
+            bHasApplicableFeat = (pStats->HasFeat(feat));
+
+            if (bHasApplicableFeat) break;
+        }
+
+    }
+
+    if (bApplicableFeatExists && bHasApplicableFeat)
     {
         nBonus += plugin.m_GreaterWeaponSpecializationDamageBonus;
     }
@@ -702,7 +858,8 @@ int32_t Weapon::GetDamageBonus(CNWSCreatureStats* pStats, CNWSCreature *pCreatur
 //This one is required for correctly update PC sheet
 int32_t Weapon::GetRangedDamageBonus(CNWSCreatureStats* pStats)
 {
-    int32_t feat = -1;
+    int32_t bApplicableFeatExists = 0;
+    int32_t bHasApplicableFeat = 0;
     Weapon& plugin = *g_plugin;
     CNWSItem* pWeapon = nullptr;
     uint32_t nBaseItem;
@@ -721,9 +878,20 @@ int32_t Weapon::GetRangedDamageBonus(CNWSCreatureStats* pStats)
     }
 
     auto w = plugin.m_GreaterWeaponSpecializationMap.find(nBaseItem);
-    feat = (w == plugin.m_GreaterWeaponSpecializationMap.end()) ? -1 : w->second;
 
-    if (feat > -1 && pStats->HasFeat(feat))
+    bApplicableFeatExists = w != plugin.m_GreaterWeaponSpecializationMap.end();
+
+    if (bApplicableFeatExists)
+    {
+        for (auto feat : w->second)
+        {
+            bHasApplicableFeat = (pStats->HasFeat(feat));
+
+            if (bHasApplicableFeat) break;
+        }
+    }
+
+    if (bApplicableFeatExists && bHasApplicableFeat)
     {
         nBonus += plugin.m_GreaterWeaponSpecializationDamageBonus;
     }
@@ -737,7 +905,8 @@ int32_t Weapon::GetAttackModifierVersus(CNWSCreatureStats* pStats, CNWSCreature*
     CNWSCombatRound* pCombatRound;
     CNWSItem* pWeapon = nullptr;
     uint32_t nBaseItem;
-    int32_t feat = -1;
+    int32_t bApplicableFeatExists = 0;
+    int32_t bHasApplicableFeat = 0;
 
     int nMod = plugin.m_GetAttackModifierVersusHook->CallOriginal<int32_t>(pStats, pCreature);
 
@@ -758,11 +927,27 @@ int32_t Weapon::GetAttackModifierVersus(CNWSCreatureStats* pStats, CNWSCreature*
     }
 
     auto w = plugin.m_GreaterWeaponFocusMap.find(nBaseItem);
-    feat = (w == plugin.m_GreaterWeaponFocusMap.end()) ? -1 : w->second;
 
-    if (feat > -1 && pStats->HasFeat(feat))
+    bApplicableFeatExists = w != plugin.m_GreaterWeaponFocusMap.end();
+
+    if (bApplicableFeatExists)
+    {
+        for (auto feat : w->second)
+        {
+            bHasApplicableFeat = (pStats->HasFeat(feat));
+
+            if (bHasApplicableFeat) break;
+        }
+    }
+
+    if (bApplicableFeatExists && bHasApplicableFeat)
     {
         nMod += plugin.m_GreaterFocusAttackBonus;
+    }
+
+    if(plugin.m_GASling && nBaseItem == Constants::BaseItem::Sling && pStats->m_nRace != Constants::RacialType::Halfling && pStats->HasFeat(Constants::Feat::GoodAim))
+    {
+        nMod += 1;
     }
 
     return nMod;
@@ -771,7 +956,8 @@ int32_t Weapon::GetAttackModifierVersus(CNWSCreatureStats* pStats, CNWSCreature*
 //This one is required for correctly update PC sheet
 int32_t Weapon::GetMeleeAttackBonus(CNWSCreatureStats* pStats, int32_t bOffHand, int32_t bIncludeBase, int32_t bTouchAttack)
 {
-    int32_t feat = -1;
+    int32_t bApplicableFeatExists = 0;
+    int32_t bHasApplicableFeat = 0;
     Weapon& plugin = *g_plugin;
     CNWSItem* pWeapon = nullptr;
     uint32_t nBaseItem;
@@ -802,9 +988,20 @@ int32_t Weapon::GetMeleeAttackBonus(CNWSCreatureStats* pStats, int32_t bOffHand,
     }
 
     auto w = plugin.m_GreaterWeaponFocusMap.find(nBaseItem);
-    feat = (w == plugin.m_GreaterWeaponFocusMap.end()) ? -1 : w->second;
 
-    if (feat > -1 && pStats->HasFeat(feat))
+    bApplicableFeatExists = w != plugin.m_GreaterWeaponFocusMap.end();
+
+    if (bApplicableFeatExists)
+    {
+        for (auto feat : w->second)
+        {
+            bHasApplicableFeat = (pStats->HasFeat(feat));
+
+            if (bHasApplicableFeat) break;
+        }
+    }
+
+    if (bApplicableFeatExists && bHasApplicableFeat)
     {
         return nBonus + plugin.m_GreaterFocusAttackBonus;
     }
@@ -815,7 +1012,8 @@ int32_t Weapon::GetMeleeAttackBonus(CNWSCreatureStats* pStats, int32_t bOffHand,
 //This one is required for correctly update PC sheet
 int32_t Weapon::GetRangedAttackBonus(CNWSCreatureStats* pStats, int32_t bIncludeBase, int32_t bTouchAttack)
 {
-    int32_t feat = -1;
+    int32_t bApplicableFeatExists = 0;
+    int32_t bHasApplicableFeat = 0;
     Weapon& plugin = *g_plugin;
     CNWSItem* pWeapon = nullptr;
     uint32_t nBaseItem;
@@ -837,13 +1035,28 @@ int32_t Weapon::GetRangedAttackBonus(CNWSCreatureStats* pStats, int32_t bInclude
     nBaseItem = pWeapon->m_nBaseItem;
 
     auto w = plugin.m_GreaterWeaponFocusMap.find(nBaseItem);
-    feat = (w == plugin.m_GreaterWeaponFocusMap.end()) ? -1 : w->second;
 
-    if (feat > -1 && pStats->HasFeat(feat))
+    bApplicableFeatExists = w != plugin.m_GreaterWeaponFocusMap.end();
+
+    if (bApplicableFeatExists)
     {
-        return nBonus + plugin.m_GreaterFocusAttackBonus;
+        for (auto feat : w->second)
+        {
+            bHasApplicableFeat = (pStats->HasFeat(feat));
+
+            if (bHasApplicableFeat) break;
+        }
     }
 
+    if (bApplicableFeatExists && bHasApplicableFeat)
+    {
+        nBonus += plugin.m_GreaterFocusAttackBonus;
+    }
+
+    if(plugin.m_GASling && nBaseItem == Constants::BaseItem::Sling && pStats->m_nRace != Constants::RacialType::Halfling && pStats->HasFeat(Constants::Feat::GoodAim))
+    {
+        nBonus += 1;
+    }
     return nBonus;
 }
 
@@ -980,4 +1193,22 @@ int Weapon::GetLevelByClass(CNWSCreatureStats *pStats, uint32_t nClassType)
     return 0;
 }
 
+ArgumentStack Weapon::SetOneHalfStrength(ArgumentStack&& args)
+{
+    auto objectId = Services::Events::ExtractArgument<ObjectID>(args);
+
+    if(objectId == Constants::OBJECT_INVALID)
+    {
+        LOG_INFO("Invalid Object Passed into SetOneHalfStrength");
+        return Services::Events::Arguments();
+    }
+
+    auto bMulti = Services::Events::ExtractArgument<int32_t>(args);
+    if(bMulti)
+        g_plugin->GetServices()->m_perObjectStorage->Set(objectId, "ONE_HALF_STRENGTH", 1);
+    else
+        g_plugin->GetServices()->m_perObjectStorage->Remove(objectId, "ONE_HALF_STRENGTH");
+
+    return Services::Events::Arguments();
+}
 }

--- a/Plugins/Weapon/Weapon.hpp
+++ b/Plugins/Weapon/Weapon.hpp
@@ -54,6 +54,7 @@ private:
     ArgumentStack GetEventData                         (ArgumentStack&& args);
     ArgumentStack SetEventData                         (ArgumentStack&& args);
     ArgumentStack SetOneHalfStrength                   (ArgumentStack&& args);
+    ArgumentStack GetOneHalfStrength                   (ArgumentStack&& args);
 
     NWNXLib::Hooking::FunctionHook* m_GetWeaponFocusHook;
     NWNXLib::Hooking::FunctionHook* m_GetEpicWeaponFocusHook;

--- a/Plugins/Weapon/Weapon.hpp
+++ b/Plugins/Weapon/Weapon.hpp
@@ -53,6 +53,7 @@ private:
     ArgumentStack SetDevastatingCriticalEventScript    (ArgumentStack&& args);
     ArgumentStack GetEventData                         (ArgumentStack&& args);
     ArgumentStack SetEventData                         (ArgumentStack&& args);
+    ArgumentStack SetOneHalfStrength                   (ArgumentStack&& args);
 
     NWNXLib::Hooking::FunctionHook* m_GetWeaponFocusHook;
     NWNXLib::Hooking::FunctionHook* m_GetEpicWeaponFocusHook;
@@ -88,17 +89,17 @@ private:
     static int32_t GetUseMonkAttackTables           (CNWSCreatureStats *pStats, int32_t bForceUnarmed);
     static int32_t ToggleMode                       (CNWSCreature *pCreature, uint8_t nMode);
 
-    std::map<std::uint32_t, std::uint32_t> m_WeaponFocusMap;
-    std::map<std::uint32_t, std::uint32_t> m_EpicWeaponFocusMap;
+    std::map<std::uint32_t, std::set<std::uint32_t>> m_WeaponFocusMap;
+    std::map<std::uint32_t, std::set<std::uint32_t>> m_EpicWeaponFocusMap;
     std::map<std::uint32_t, std::uint8_t>  m_WeaponFinesseSizeMap;
-    std::map<std::uint32_t, std::uint32_t> m_WeaponImprovedCriticalMap;
-    std::map<std::uint32_t, std::uint32_t> m_WeaponSpecializationMap;
-    std::map<std::uint32_t, std::uint32_t> m_EpicWeaponSpecializationMap;
-    std::map<std::uint32_t, std::uint32_t> m_EpicWeaponOverwhelmingCriticalMap;
-    std::map<std::uint32_t, std::uint32_t> m_EpicWeaponDevastatingCriticalMap;
-    std::map<std::uint32_t, std::uint32_t> m_WeaponOfChoiceMap;
-    std::map<std::uint32_t, std::uint32_t> m_GreaterWeaponSpecializationMap;
-    std::map<std::uint32_t, std::uint32_t> m_GreaterWeaponFocusMap;
+    std::map<std::uint32_t, std::set<std::uint32_t>> m_WeaponImprovedCriticalMap;
+    std::map<std::uint32_t, std::set<std::uint32_t>> m_WeaponSpecializationMap;
+    std::map<std::uint32_t, std::set<std::uint32_t>> m_EpicWeaponSpecializationMap;
+    std::map<std::uint32_t, std::set<std::uint32_t>> m_EpicWeaponOverwhelmingCriticalMap;
+    std::map<std::uint32_t, std::set<std::uint32_t>> m_EpicWeaponDevastatingCriticalMap;
+    std::map<std::uint32_t, std::set<std::uint32_t>> m_WeaponOfChoiceMap;
+    std::map<std::uint32_t, std::set<std::uint32_t>> m_GreaterWeaponSpecializationMap;
+    std::map<std::uint32_t, std::set<std::uint32_t>> m_GreaterWeaponFocusMap;
 
     std::set<std::uint32_t>  m_WeaponUnarmedSet;
     std::set<std::uint32_t>  m_MonkWeaponSet;
@@ -113,5 +114,6 @@ private:
 
     int m_GreaterFocusAttackBonus = 1;
     int m_GreaterWeaponSpecializationDamageBonus = 2;
+    bool m_GASling = false;
 };
 }


### PR DESCRIPTION
1) Good AIIM SLING SWITCH NWNX_WEAPON_GOOD_AIM_SLING if true allows non-halflings to gain +1 AB with slings if they have good AIM. This is a correction for the base game which includes throwing weapons but tied slings specifically to the halfling race.

Developer Note: I wanted to do the above as a tweak but fitting function had an exclusive hook in nwnx weapons

2) New function (SetOneHalfStrength) gives a melee weapon an addition Strength/2 damage. For use with One and a half weapons to signify holding them two handed.

Modifications:

1) Weapon feats (focus, spec, etc.) now support having multiple feats for each weapon

2) The weapon feats defined in baseitems.2da serves as a fallback instead of being overriden