### PR TITLE
Damage: allow placeables to trigger damage script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ N/A
 - Weapon: {Get|Set}OneHalfStrength()
 
 ### Changed
+- Damage: damage event script now also triggered by damage to placeables
 - Effect: (Un)PackEffect now supports vector params
 - Events: added a `RESULT` event data tag to LearnScroll in ItemEvents
 - Weapon: SetWeapon****Feat functions may be called multiple times for the same weapon, associating a new feat each time

--- a/Plugins/Damage/Damage.cpp
+++ b/Plugins/Damage/Damage.cpp
@@ -123,8 +123,8 @@ int32_t Damage::OnApplyDamage(CNWSEffectListHandler *pThis, CNWSObject *pObject,
 
     if (!script.empty())
     {
-        // We only run the OnDamage event for creatures.
-        if (Utils::AsNWSCreature(pObject))
+        // We only run the OnDamage event for creatures and placeables.
+        if (Utils::AsNWSCreature(pObject) || Utils::AsNWSPlaceable(pObject))
         {
             // Prepare the data for the nwscript
             g_plugin->m_DamageData.oidDamager = pEffect->m_oidCreator;


### PR DESCRIPTION
This is useful for making placeables that react to certain damage types. For example, barrels that explode when hit with fire or electricity.