### PR TITLE
Administration: DeletePlayerCharacter now removes TURD as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ N/A
 - Object: {Get|Set|Delete}Persistent{Int|String|Float}()
 
 ### Fixed
+- Administration: DeletePlayerCharacter() now deletes the TURD as well though it can be retained if desired by passing an argument
 - Creature: SetMovementRate() now properly reattaches the creature's legs when switching from NWNX_CREATURE_MOVEMENT_RATE_IMMOBILE to the other constants
 
 ## 8193.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ N/A
 - Object: {Get|Set|Delete}Persistent{Int|String|Float}()
 
 ### Fixed
-- Administration: DeletePlayerCharacter() now deletes the TURD as well though it can be retained if desired by passing an argument
+- Administration: DeletePlayerCharacter() now deletes the TURD as well
 - Creature: SetMovementRate() now properly reattaches the creature's legs when switching from NWNX_CREATURE_MOVEMENT_RATE_IMMOBILE to the other constants
 
 ## 8193.14

--- a/Plugins/Administration/Administration.hpp
+++ b/Plugins/Administration/Administration.hpp
@@ -12,6 +12,7 @@ class Administration : public NWNXLib::Plugin
 public:
     Administration(NWNXLib::Services::ProxyServiceList* services);
     virtual ~Administration();
+    static CExoLinkedListNode* FindTURD(std::string, std::string);
 
     ArgumentStack GetPlayerPassword         (ArgumentStack&& args);
     ArgumentStack SetPlayerPassword         (ArgumentStack&& args);

--- a/Plugins/Administration/NWScript/nwnx_admin.nss
+++ b/Plugins/Administration/NWScript/nwnx_admin.nss
@@ -77,7 +77,8 @@ void NWNX_Administration_ShutdownServer();
 ///
 /// @param oPC The player to delete.
 /// @param bPreserveBackup If true, it will leave the file on server, only appending ".deleted0" to the bic filename.
-void NWNX_Administration_DeletePlayerCharacter(object oPC, int bPreserveBackup = TRUE);
+/// @param bRetainTURD If true, the TURD will not be removed from the running server
+void NWNX_Administration_DeletePlayerCharacter(object oPC, int bPreserveBackup = TRUE, int bRetainTURD = FALSE);
 
 /// @brief Bans the provided IP.
 /// @param ip The IP Address to ban.
@@ -203,10 +204,11 @@ void NWNX_Administration_ShutdownServer()
     NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 
-void NWNX_Administration_DeletePlayerCharacter(object oPC, int bPreserveBackup)
+void NWNX_Administration_DeletePlayerCharacter(object oPC, int bPreserveBackup, int bRetainTURD)
 {
     string sFunc = "DeletePlayerCharacter";
 
+    NWNX_PushArgumentInt(NWNX_Administration, sFunc, bRetainTURD);
     NWNX_PushArgumentInt(NWNX_Administration, sFunc, bPreserveBackup);
     NWNX_PushArgumentObject(NWNX_Administration, sFunc, oPC);
     NWNX_CallFunction(NWNX_Administration, sFunc);

--- a/Plugins/Administration/NWScript/nwnx_admin.nss
+++ b/Plugins/Administration/NWScript/nwnx_admin.nss
@@ -77,8 +77,7 @@ void NWNX_Administration_ShutdownServer();
 ///
 /// @param oPC The player to delete.
 /// @param bPreserveBackup If true, it will leave the file on server, only appending ".deleted0" to the bic filename.
-/// @param bRetainTURD If true, the TURD will not be removed from the running server
-void NWNX_Administration_DeletePlayerCharacter(object oPC, int bPreserveBackup = TRUE, int bRetainTURD = FALSE);
+void NWNX_Administration_DeletePlayerCharacter(object oPC, int bPreserveBackup = TRUE);
 
 /// @brief Bans the provided IP.
 /// @param ip The IP Address to ban.
@@ -204,11 +203,10 @@ void NWNX_Administration_ShutdownServer()
     NWNX_CallFunction(NWNX_Administration, sFunc);
 }
 
-void NWNX_Administration_DeletePlayerCharacter(object oPC, int bPreserveBackup, int bRetainTURD)
+void NWNX_Administration_DeletePlayerCharacter(object oPC, int bPreserveBackup)
 {
     string sFunc = "DeletePlayerCharacter";
 
-    NWNX_PushArgumentInt(NWNX_Administration, sFunc, bRetainTURD);
     NWNX_PushArgumentInt(NWNX_Administration, sFunc, bPreserveBackup);
     NWNX_PushArgumentObject(NWNX_Administration, sFunc, oPC);
     NWNX_CallFunction(NWNX_Administration, sFunc);


### PR DESCRIPTION
Resolves #1023 - an additional argument was added to the `NWNX_Administration_DeletePlayerCharacter` function should the admin wish to retain the TURD for some reason.