### PR TITLE
Unlimited potions tweak: Fix GetItemActivated() returning null

### DIFF
--- a/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.cpp
+++ b/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.cpp
@@ -4,6 +4,8 @@
 #include "Utils.hpp"
 
 #include "API/Functions.hpp"
+#include "API/CNWSItem.hpp"
+#include "API/CNWSCreature.hpp"
 
 namespace Tweaks {
 
@@ -16,16 +18,30 @@ static NWNXLib::Hooking::FunctionHook* s_AddEventDeltaTimeHook = nullptr;
 FixUnlimitedPotionsBug::FixUnlimitedPotionsBug(Services::HooksProxy* hooker)
 {
     hooker->RequestSharedHook<Functions::_ZN12CNWSCreature21AIActionItemCastSpellEP20CNWSObjectActionNode, uint32_t>(&CNWSCreature__AIActionItemCastSpell_hook);
-    hooker->RequestExclusiveHook<Functions::_ZN15CServerAIMaster17AddEventDeltaTimeEjjjjjPv>(&CServerAIMaster__AddEventDeltaTime);
+    hooker->RequestSharedHook<Functions::_ZN15CServerAIMaster17AddEventDeltaTimeEjjjjjPv, BOOL>(&CServerAIMaster__AddEventDeltaTime);
     s_AddEventDeltaTimeHook = hooker->FindHookByAddress(Functions::_ZN15CServerAIMaster17AddEventDeltaTimeEjjjjjPv);
 }
 
-BOOL FixUnlimitedPotionsBug::CServerAIMaster__AddEventDeltaTime(CServerAIMaster* thisPtr, uint32_t nDaysFromNow, uint32_t nTimeFromNow, OBJECT_ID nCallerObjectId, OBJECT_ID nObjectId, uint32_t nEventId, void* pScript)
+void FixUnlimitedPotionsBug::CServerAIMaster__AddEventDeltaTime(bool before, CServerAIMaster* thisPtr, uint32_t nDaysFromNow, uint32_t nTimeFromNow, OBJECT_ID nCallerObjectId, OBJECT_ID nObjectId, uint32_t nEventId, void* pScript)
 {
-    if (s_bUsableItemRemoval && nEventId == Constants::Event::DestroyObject)
-        nTimeFromNow = 0;
+    if (before || !s_bUsableItemRemoval || nEventId != Constants::Event::DestroyObject)
+        return;
 
-    return s_AddEventDeltaTimeHook->CallOriginal<BOOL>(thisPtr, nDaysFromNow, nTimeFromNow, nCallerObjectId, nObjectId, nEventId, pScript);
+    if (auto* pItem = Utils::AsNWSItem(Utils::GetGameObject(nObjectId)))
+    {
+        pItem->m_bAbleToModifyActionQueue = false;
+        auto* pOwnerCreature = Utils::AsNWSCreature(Utils::GetGameObject(pItem->m_oidPossessor));
+        if (!pOwnerCreature && pItem->m_oidPossessor != Constants::OBJECT_INVALID)
+        {
+            auto* pContainer = Utils::AsNWSItem(Utils::GetGameObject(pItem->m_oidPossessor));
+            if(pContainer)
+                pOwnerCreature = Utils::AsNWSCreature(Utils::GetGameObject(pContainer->m_oidPossessor));
+        }
+        if (pOwnerCreature && pOwnerCreature->m_bPlayerCharacter)
+        {
+            auto ret = pOwnerCreature->RemoveItem(pItem, true, true, false, true);
+        }
+    }
 }
 
 void FixUnlimitedPotionsBug::CNWSCreature__AIActionItemCastSpell_hook(bool before, CNWSCreature*, CNWSObjectActionNode*)

--- a/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.cpp
+++ b/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.cpp
@@ -22,7 +22,7 @@ FixUnlimitedPotionsBug::FixUnlimitedPotionsBug(Services::HooksProxy* hooker)
     s_AddEventDeltaTimeHook = hooker->FindHookByAddress(Functions::_ZN15CServerAIMaster17AddEventDeltaTimeEjjjjjPv);
 }
 
-void FixUnlimitedPotionsBug::CServerAIMaster__AddEventDeltaTime(bool before, CServerAIMaster* thisPtr, uint32_t nDaysFromNow, uint32_t nTimeFromNow, OBJECT_ID nCallerObjectId, OBJECT_ID nObjectId, uint32_t nEventId, void* pScript)
+void FixUnlimitedPotionsBug::CServerAIMaster__AddEventDeltaTime(bool before, CServerAIMaster*, uint32_t, uint32_t, OBJECT_ID, OBJECT_ID nObjectId, uint32_t nEventId, void*)
 {
     if (before || !s_bUsableItemRemoval || nEventId != Constants::Event::DestroyObject)
         return;
@@ -39,7 +39,7 @@ void FixUnlimitedPotionsBug::CServerAIMaster__AddEventDeltaTime(bool before, CSe
         }
         if (pOwnerCreature && pOwnerCreature->m_bPlayerCharacter)
         {
-            auto ret = pOwnerCreature->RemoveItem(pItem, true, true, false, true);
+            pOwnerCreature->RemoveItem(pItem, true, true, false, true);
         }
     }
 }

--- a/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.hpp
+++ b/Plugins/Tweaks/Tweaks/FixUnlimitedPotionsBug.hpp
@@ -14,7 +14,7 @@ public:
 
 private:
     static void CNWSCreature__AIActionItemCastSpell_hook(bool before, CNWSCreature* thisPtr, CNWSObjectActionNode* pNode);
-    static BOOL CServerAIMaster__AddEventDeltaTime(CServerAIMaster* thisPtr, uint32_t nDaysFromNow, uint32_t nTimeFromNow, OBJECT_ID nCallerObjectId, OBJECT_ID nObjectId, uint32_t nEventId, void* pScript);
+    static void CServerAIMaster__AddEventDeltaTime(bool before, CServerAIMaster* thisPtr, uint32_t nDaysFromNow, uint32_t nTimeFromNow, OBJECT_ID nCallerObjectId, OBJECT_ID nObjectId, uint32_t nEventId, void* pScript);
 };
 
 }


### PR DESCRIPTION
Fixes #1029 

Only tested a coupe of use cases: Healing potions and an amulet with a `Cast Spell: Activate Item` property as explained in #1029. It returned the right item in the 2nd case.
Hopefully this fixes issues with other existing scripts as well.