### PR TITLE
Send dm all creator lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ N/A
 - Player: SetObjectHiliteColorOverride()
 - Player: RemoveEffectFromTURD()
 - Player: SetSpawnLocation()
+- Player: SendDMAllCreatorLists()
 - Util: GetWorldTime()
 - Util: {Get|Set}ResourceOverride()
 - Weapon: {Get|Set}OneHalfStrength()

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -339,6 +339,10 @@ void NWNX_Player_RemoveEffectFromTURD(object oPlayer, string sEffectTag);
 /// @param locSpawn The location.
 void NWNX_Player_SetSpawnLocation(object oPlayer, location locSpawn);
 
+/// @brief Resends palettes to a DM.
+/// @param oPlayer - the DM to send them to.
+void NWNX_Player_SendDMAllCreatorLists(object oPlayer);
+
 /// @}
 
 void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable)
@@ -856,5 +860,12 @@ void NWNX_Player_SetSpawnLocation(object oPlayer, location locSpawn)
     NWNX_PushArgumentObject(NWNX_Player, sFunc, GetAreaFromLocation(locSpawn));
     NWNX_PushArgumentObject(NWNX_Player, sFunc, oPlayer);
 
+    NWNX_CallFunction(NWNX_Player, sFunc);
+}
+
+void NWNX_Player_SendDMAllCreatorLists(object oPlayer)
+{
+    string sFunc = "SendDMAllCreatorLists";
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, oPlayer);
     NWNX_CallFunction(NWNX_Player, sFunc);
 }

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -1659,7 +1659,7 @@ ArgumentStack Player::SendDMAllCreatorLists(ArgumentStack&& args)
     {
         auto *pCreature = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(pPlayer->m_oidNWSObject);
 
-        if(pCreature->m_pStats->GetIsDM())
+        if(pCreature && pCreature->m_pStats->GetIsDM())
         {
             if (auto* pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
             {

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -98,6 +98,7 @@ Player::Player(Services::ProxyServiceList* services)
     REGISTER(SetObjectHiliteColorOverride);
     REGISTER(RemoveEffectFromTURD);
     REGISTER(SetSpawnLocation);
+    REGISTER(SendDMAllCreatorLists);
 
 #undef REGISTER
 
@@ -1646,6 +1647,28 @@ ArgumentStack Player::SetSpawnLocation(ArgumentStack&& args)
             pCreature->m_vDesiredAreaLocation = {x, y, z};
             pCreature->m_bDesiredAreaUpdateComplete = false;
             Utils::SetOrientation(pCreature, facing);
+        }
+    }
+
+    return Services::Events::Arguments();
+}
+
+ArgumentStack Player::SendDMAllCreatorLists(ArgumentStack&& args)
+{
+    if(auto *pPlayer = player(args))
+    {
+        auto *pCreature = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(pPlayer->m_oidNWSObject);
+
+        if(pCreature->m_pStats->GetIsDM())
+        {
+            if (auto* pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
+            {
+                auto original = pPlayer->m_bWasSentITP;
+                pPlayer->m_bWasSentITP=false;
+                pMessage->SendServerToPlayerDungeonMasterCreatorLists(pPlayer);
+                pPlayer->m_bWasSentITP=original;
+            }
+
         }
     }
 

--- a/Plugins/Player/Player.hpp
+++ b/Plugins/Player/Player.hpp
@@ -58,6 +58,7 @@ private:
     ArgumentStack SetObjectHiliteColorOverride      (ArgumentStack&& args);
     ArgumentStack RemoveEffectFromTURD              (ArgumentStack&& args);
     ArgumentStack SetSpawnLocation                  (ArgumentStack&& args);
+    ArgumentStack SendDMAllCreatorLists             (ArgumentStack&& args);
 
     CNWSPlayer *player(ArgumentStack& args);
 


### PR DESCRIPTION
Resends dm all palettes.

Use case: Updating palettes through the developer folder and wanting to send them to all DM's without a relog.