### PR TITLE
Events: add ServerSendArea event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ https://github.com/nwnxee/unified/compare/build8193.14...HEAD
 - Events: added skippable RunScript and RunScriptChunk events to DebugEvents
 - Events: added skippable RequestBuy/Sell events to StoreEvents
 - Events: added skippable Heal events to new HealingEvents
+- Events: added ServerSendArea event to ClientEvents
 - Tweaks: added `NWNX_TWEAKS_BLOCK_DM_SPAWNITEM` to block the usage of dm_spawnitem
 - Weapon: added 'NWNX_WEAPON_GOOD_AIM_SLING' non-halfling sling users with the feat Good Aim gain an additional +1 AB as a halfling currently does. Note: Throwing weapons are already included in the base game
 

--- a/Plugins/Events/Events/ClientEvents.hpp
+++ b/Plugins/Events/Events/ClientEvents.hpp
@@ -16,6 +16,7 @@ private:
     static int32_t OnServerCharacterSave(CNWSPlayer*, int32_t);
     static int32_t CheckStickyPlayerNameReservedHook(CServerExoApp*, CExoString*, CExoString*, CExoString*, int32_t);
     static int32_t SendServerToPlayerModule_ExportReplyHook(CNWSMessage*, CNWSPlayer*);
+    static void SendServerToPlayerArea_ClientAreaHook(bool, CNWSMessage*, CNWSPlayer*, CNWSArea*, float, float, float, const Vector*, BOOL);
 };
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1169,6 +1169,18 @@ _______________________________________
     PRICE                 | int    | The buy or sell price |
 
 _______________________________________
+    ## Server Send Area Events
+    - NWNX_ON_SERVER_SEND_AREA_BEFORE
+    - NWNX_ON_SERVER_SEND_AREA_AFTER
+
+    `OBJECT_SELF` = The player
+
+    Event Data Tag        | Type   | Notes
+    ----------------------|--------|-------
+    AREA                  | object | The area the server is sending. Convert to object with StringToObject() |
+    PLAYER_NEW_TO_MODULE  | int    | TRUE if it's the player's first time logging into the server since a restart |
+
+_______________________________________
 */
 /*
 const int NWNX_EVENTS_OBJECT_TYPE_CREATURE          = 5;


### PR DESCRIPTION
For that obscure issue where you need to override some resource before they're actually sent to the player.