### PR TITLE
Creature: add Get/SetWalkAnimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ N/A
 N/A
 
 ##### New NWScript Functions
-N/A
+- Creature: {Get|Set}WalkAnimation()
 
 ### Changed
 N/A

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -168,6 +168,8 @@ Creature::Creature(Services::ProxyServiceList* services)
     REGISTER(SetEncounter);
     REGISTER(GetEncounter);
     REGISTER(GetIsBartering);
+    REGISTER(GetWalkAnimation);
+    REGISTER(SetWalkAnimation);
 
 #undef REGISTER
 }
@@ -2655,6 +2657,31 @@ ArgumentStack Creature::GetArmorClassVersus(ArgumentStack&& args)
         retVal = pCreature->m_pStats->GetArmorClassVersus(pVersus, bTouchAttack);
     }
     return Services::Events::Arguments(retVal);
+}
+
+ArgumentStack Creature::GetWalkAnimation(ArgumentStack&& args)
+{
+    int32_t retVal = -1;
+    if (auto *pCreature = creature(args))
+    {
+        retVal = pCreature->m_nWalkAnimation;
+    }
+    return Services::Events::Arguments(retVal);
+}
+
+ArgumentStack Creature::SetWalkAnimation(ArgumentStack&& args)
+{
+    if (auto* pCreature = creature(args))
+    {
+        auto animation = Services::Events::ExtractArgument<int32_t>(args);
+
+        if (animation >= 0)
+        {
+            pCreature->m_nWalkAnimation = animation;
+        }
+    }
+
+    return Services::Events::Arguments();
 }
 
 }

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -126,6 +126,8 @@ private:
     ArgumentStack SetEncounter                  (ArgumentStack&& args);
     ArgumentStack GetEncounter                  (ArgumentStack&& args);
     ArgumentStack GetIsBartering                (ArgumentStack&& args);
+    ArgumentStack GetWalkAnimation              (ArgumentStack&& args);
+    ArgumentStack SetWalkAnimation              (ArgumentStack&& args);
 
     CNWSCreature *creature(ArgumentStack& args);
 

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -792,6 +792,16 @@ int NWNX_Creature_GetLastItemCasterLevel(object oCreature);
 /// @return -255 on Error, Flat footed AC if oVersus is invalid or the Attacked AC versus oVersus.
 int NWNX_Creature_GetArmorClassVersus(object oAttacked, object oVersus, int nTouch=FALSE);
 
+/// @brief Gets the current walk animation of oCreature.
+/// @param oCreature The target creature.
+/// @return -1 on Error, otherwise the walk animation number
+int NWNX_Creature_GetWalkAnimation(object oCreature);
+
+/// @brief Sets the current walk animation of oCreature.
+/// @param oCreature The target creature.
+/// @param nAnimation The walk animation number.
+void NWNX_Creature_SetWalkAnimation(object oCreature, int nAnimation);
+
 /// @}
 
 void NWNX_Creature_AddFeat(object creature, int feat)
@@ -2004,4 +2014,21 @@ int NWNX_Creature_GetArmorClassVersus(object oAttacked, object oVersus, int nTou
     NWNX_CallFunction(NWNX_Creature, sFunc);
 
     return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
+}
+
+int NWNX_Creature_GetWalkAnimation(object oCreature)
+{
+    string sFunc = "GetWalkAnimation";
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+
+    return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_SetWalkAnimation(object oCreature, int nAnimation)
+{
+    string sFunc = "SetWalkAnimation";
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, nAnimation);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
 }


### PR DESCRIPTION
This patch allows the walk animations of creatures to be changed, without the need for the "Special Walk" item property. This is useful for giving PCs or creatures custom animations that also move the player around (think jumping, rolling, crawling, etc.).