### PR TITLE
Visibility: add NWNX_VISIBILITY_ALWAYS_VISIBLE and NWNX_VISIBILITY_ALWAYS_VISIBLE_DM_ONLY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ N/A
 
 ### Changed
 - Events: `NWNX_ON_DM_SPAWN_OBJECT_*` now provides the resref as event data.
+- Visibility: added two new visibility types to always show an object regardless of range.
 
 ### Deprecated
 - Tweaks: `NWNX_TWEAKS_HIDE_DMS_ON_CHAR_LIST` has been deprecated, use `NWNX_TWEAKS_HIDE_PLAYERS_ON_CHAR_LIST` now

--- a/Plugins/Visibility/NWScript/nwnx_visibility.nss
+++ b/Plugins/Visibility/NWScript/nwnx_visibility.nss
@@ -9,69 +9,69 @@ const string NWNX_Visibility = "NWNX_Visibility"; ///< @private
 /// @name Visibility Types
 /// @anchor vis_types
 /// @{
-const int NWNX_VISIBILITY_DEFAULT   = -1;
-const int NWNX_VISIBILITY_VISIBLE   = 0;
-const int NWNX_VISIBILITY_HIDDEN    = 1;
-const int NWNX_VISIBILITY_DM_ONLY   = 2;
+const int NWNX_VISIBILITY_DEFAULT                 = -1;
+const int NWNX_VISIBILITY_VISIBLE                 = 0;
+const int NWNX_VISIBILITY_HIDDEN                  = 1;
+const int NWNX_VISIBILITY_DM_ONLY                 = 2;
+const int NWNX_VISIBILITY_ALWAYS_VISIBLE          = 3;
+const int NWNX_VISIBILITY_ALWAYS_VISIBLE_DM_ONLY  = 4;
 ///@}
 
-/// @brief Queries the existing visibility override for given (player, target) pair.
+/// @brief Queries the existing visibility override for given (oPlayer, oTarget) pair.
+///        If oPlayer is OBJECT_INVALID, the global visibility override will be returned.
 ///
-/// If player is OBJECT_INVALID, the global visibility override will be returned
-/// * Player == VALID -> returns:
-///  * NWNX_VISIBILITY_DEFAULT = Player override not set
-///  * NWNX_VISIBILITY_VISIBLE = Target is always visible for player
-///  * NWNX_VISIBILITY_HIDDEN  = Target is always hidden for player
-/// * Player == OBJECT_INVALID -> returns:
-///  * NWNX_VISIBILITY_DEFAULT = Global override not set
-///  * NWNX_VISIBILITY_VISIBLE = Target is globally visible
-///  * NWNX_VISIBILITY_HIDDEN  = Target is globally hidden
-///  * NWNX_VISIBILITY_DM_ONLY = Target is only visible to DMs
-/// @param player The PC Object or OBJECT_INVALID.
-/// @param target The object for which we're querying the visibility.
+///  * NWNX_VISIBILITY_DEFAULT = Override not set.
+///  * NWNX_VISIBILITY_VISIBLE = Target is visible but still adheres to default visibility rules.
+///  * NWNX_VISIBILITY_HIDDEN  = Target is always hidden.
+///  * NWNX_VISIBILITY_DM_ONLY = Target is only visible to DMs but still adheres to default visibility rules.
+///  * NWNX_VISIBILITY_ALWAYS_VISIBLE = Target is always visible in all circumstances.
+///  * NWNX_VISIBILITY_ALWAYS_VISIBLE_DM_ONLY = Target is always visible only to DMs in all circumstances.
+///
+/// @param oPlayer The PC Object or OBJECT_INVALID.
+/// @param oTarget The object for which we're querying the visibility override.
 /// @return The @ref vis_types "Visibility Type".
-int NWNX_Visibility_GetVisibilityOverride(object player, object target);
+int NWNX_Visibility_GetVisibilityOverride(object oPlayer, object oTarget);
 
-/// @brief Overrides the default visibility rules about how player perceives the target object.
+/// @brief Overrides the default visibility rules about how oPlayer perceives oTarget.
+///        If oPlayer is OBJECT_INVALID, the global visibility override will be set.
 ///
-/// If player is OBJECT_INVALID, the global visibility override will be set
-/// * Player == VALID -> override:
-///  * NWNX_VISIBILITY_DEFAULT = Remove the player override
-///  * NWNX_VISIBILITY_VISIBLE = Target is always visible for player
-///  * NWNX_VISIBILITY_HIDDEN  = Target is always hidden for player
-/// * Player == OBJECT_INVALID -> override:
-///  * NWNX_VISIBILITY_DEFAULT = Remove the global override
-///  * NWNX_VISIBILITY_VISIBLE = Target is globally visible
-///  * NWNX_VISIBILITY_HIDDEN  = Target is globally hidden
-///  * NWNX_VISIBILITY_DM_ONLY = Target is only visible to DMs
+///  * NWNX_VISIBILITY_DEFAULT = Remove a set override.
+///  * NWNX_VISIBILITY_VISIBLE = Target is visible but still adheres to default visibility rules.
+///  * NWNX_VISIBILITY_HIDDEN  = Target is always hidden.
+///  * NWNX_VISIBILITY_DM_ONLY = Target is only visible to DMs but still adheres to default visibility rules.
+///  * NWNX_VISIBILITY_ALWAYS_VISIBLE = Target is always visible in all circumstances.
+///  * NWNX_VISIBILITY_ALWAYS_VISIBLE_DM_ONLY = Target is always visible to DMs in all circumstances.
+///
+/// @warning Setting too many objects to ALWAYS_VISIBLE in an area will impact the performance of your players. Use sparingly.
 ///
 /// @note Player state overrides the global state which means if a global state is set
 /// to NWNX_VISIBILITY_HIDDEN or NWNX_VISIBILITY_DM_ONLY but the player's state is
 /// set to NWNX_VISIBILITY_VISIBLE for the target, the object will be visible to the player.
-/// @param player The PC Object or OBJECT_INVALID.
-/// @param target The object for which we're altering the visibility.
-/// @param override The visibility type from @ref vis_types "Visibility Types".
-void NWNX_Visibility_SetVisibilityOverride(object player, object target, int override);
+///
+/// @param oPlayer The PC Object or OBJECT_INVALID.
+/// @param oTarget The object for which we're altering the visibility.
+/// @param nOverride The visibility type from @ref vis_types "Visibility Types".
+void NWNX_Visibility_SetVisibilityOverride(object oPlayer, object oTarget, int nOverride);
 
 /// @}
 
-int NWNX_Visibility_GetVisibilityOverride(object player, object target)
+int NWNX_Visibility_GetVisibilityOverride(object oPlayer, object oTarget)
 {
     string sFunc = "GetVisibilityOverride";
 
-    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, target);
-    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, player);
+    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, oTarget);
+    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, oPlayer);
     NWNX_CallFunction(NWNX_Visibility, sFunc);
 
     return NWNX_GetReturnValueInt(NWNX_Visibility, sFunc);
 }
 
-void NWNX_Visibility_SetVisibilityOverride(object player, object target, int override)
+void NWNX_Visibility_SetVisibilityOverride(object oPlayer, object oTarget, int nOverride)
 {
     string sFunc = "SetVisibilityOverride";
 
-    NWNX_PushArgumentInt(NWNX_Visibility, sFunc, override);
-    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, target);
-    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, player);
+    NWNX_PushArgumentInt(NWNX_Visibility, sFunc, nOverride);
+    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, oTarget);
+    NWNX_PushArgumentObject(NWNX_Visibility, sFunc, oPlayer);
     NWNX_CallFunction(NWNX_Visibility, sFunc);
 }

--- a/Plugins/Visibility/Visibility.hpp
+++ b/Plugins/Visibility/Visibility.hpp
@@ -15,15 +15,12 @@ public:
     virtual ~Visibility();
 
 private:
+    static int32_t TestObjectVisibleHook(CNWSMessage*, CNWSObject*, CNWSObject*);
+    static int32_t GetGlobalOverride(ObjectID);
+    static int32_t GetPersonalOverride(ObjectID, ObjectID);
 
-    static int32_t TestObjectVisibleHook(CNWSMessage *pThis, CNWSObject *pAreaObject, CNWSObject *pPlayerGameObject);
-    NWNXLib::Hooking::FunctionHook* m_TestObjectVisibilityHook;
-
-    static int32_t GetGlobalOverride(ObjectID targetId);
-    static int32_t GetPersonalOverride(ObjectID playerId, ObjectID targetId);
-
-    ArgumentStack GetVisibilityOverride (ArgumentStack&& args);
-    ArgumentStack SetVisibilityOverride (ArgumentStack&& args);
+    ArgumentStack GetVisibilityOverride (ArgumentStack&&);
+    ArgumentStack SetVisibilityOverride (ArgumentStack&&);
 };
 
 }


### PR DESCRIPTION
Adds two new visibility types to NWNX_Visibility: `NWNX_VISIBILITY_ALWAYS_VISIBLE` and `NWNX_VISIBILITY_ALWAYS_VISIBLE_DM_ONLY`

These allow you to override the visibility of objects beyond the 45m visibility limit, as such it should be used sparingly or your players' performance will be impacted.