### PR TITLE
WIP: Effect/Itemproperty extending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ N/A
 - Creature: {Get|Set}LastItemCasterLeve()
 - Creature: GetArmorClassVersus()
 - Effect: ReplaceEffect()
+- Effect: GetTrueEffectCount()
+- Effect: GetTrueEffect()
+- Effect: RemoveEffectById()
+- Effect: ReplaceEffectByElement()
+- Effect: SetEffectImmunityBypass()
 - Player: ToggleDM()
 - ItemProperty: GetActiveProperty()
 - Object: DoSpellImmunity()
@@ -44,6 +49,7 @@ N/A
 
 ### Changed
 - Effect: (Un)PackEffect now supports vector params
+- Effect: UnpackEffect additionally now supports outputting the effect ID.
 - Events: added a `RESULT` event data tag to LearnScroll in ItemEvents
 - Weapon: SetWeapon****Feat functions may be called multiple times for the same weapon, associating a new feat each time
 - Weapon: weapon feats defined in the 2da are no longer overridden by SetWeapon***Feat and will be used in addition to any set feats

--- a/Plugins/Effect/Effect.hpp
+++ b/Plugins/Effect/Effect.hpp
@@ -15,10 +15,21 @@ public:
     virtual ~Effect();
 
 private:
+    struct m_bypassRed
+    {
+      uint16_t m_nPropertyName;
+      int32_t m_nSubType;
+      int32_t m_nCostTableValue;
+      int32_t m_nParam1Value;
+      bool bReverse;
+    };
     std::string m_effectExpiredData;
     uint32_t m_effectExpiredDepth;
     ObjectID m_effectExpiredCreator;
     bool m_bBypassImm = false;
+    bool m_bInitRed = false;
+    uint8_t m_iMaterial;
+    std::unordered_multimap<int32_t, m_bypassRed> m_bypass;
 
     NWNXLib::Hooking::FunctionHook* m_GetEffectImmunityHook;
 
@@ -33,10 +44,20 @@ private:
     ArgumentStack ReplaceEffectByElement(ArgumentStack&& args);
     ArgumentStack RemoveEffectById(ArgumentStack&& args);
     ArgumentStack SetEffectImmunityBypass(ArgumentStack&& args);
+    ArgumentStack SetDamageReductionBypass(ArgumentStack&& args);
+
     static int32_t  GetEffectImmunityHook(CNWSCreatureStats *pStats, uint8_t nType, CNWSCreature * pVersus, BOOL bConsiderFeats=true);
+
+    static void OnItemPropertyAppliedHook(bool, CServerAIMaster*, CNWSItem*, CNWItemProperty*, CNWSCreature*, uint32_t, BOOL);
+    static void OnApplyDamageReductionHook(bool, CNWSEffectListHandler*, CNWSObject*, CGameEffect*, BOOL);
+    static void OnApplyEffectImmunityHook(bool, CNWSEffectListHandler*, CNWSObject*, CGameEffect*, BOOL);
+    static void DoDamageReductionHook(bool, CNWSObject*, CNWSCreature*, int32_t, uint8_t, BOOL, BOOL);
+
 
     ArgumentStack ResolveUnpack(CGameEffect *eff, bool bLink=true);
     void InitEffectImmHook();
+    void InitDamageReductionHooks();
+
 };
 
 }

--- a/Plugins/Effect/Effect.hpp
+++ b/Plugins/Effect/Effect.hpp
@@ -18,6 +18,9 @@ private:
     std::string m_effectExpiredData;
     uint32_t m_effectExpiredDepth;
     ObjectID m_effectExpiredCreator;
+    bool m_bBypassImm = false;
+
+    NWNXLib::Hooking::FunctionHook* m_GetEffectImmunityHook;
 
     ArgumentStack PackEffect(ArgumentStack&& args);
     ArgumentStack UnpackEffect(ArgumentStack&& args);
@@ -25,6 +28,15 @@ private:
     ArgumentStack GetEffectExpiredData(ArgumentStack&& args);
     ArgumentStack GetEffectExpiredCreator(ArgumentStack&& args);
     ArgumentStack ReplaceEffect(ArgumentStack&& args);
+    ArgumentStack GetTrueEffectCount(ArgumentStack&& args);
+    ArgumentStack GetTrueEffect(ArgumentStack&& args);
+    ArgumentStack ReplaceEffectByElement(ArgumentStack&& args);
+    ArgumentStack RemoveEffectById(ArgumentStack&& args);
+    ArgumentStack SetEffectImmunityBypass(ArgumentStack&& args);
+    static int32_t  GetEffectImmunityHook(CNWSCreatureStats *pStats, uint8_t nType, CNWSCreature * pVersus, BOOL bConsiderFeats=true);
+
+    ArgumentStack ResolveUnpack(CGameEffect *eff, bool bLink=true);
+    void InitEffectImmHook();
 };
 
 }

--- a/Plugins/Effect/NWScript/nwnx_effect.nss
+++ b/Plugins/Effect/NWScript/nwnx_effect.nss
@@ -119,6 +119,15 @@ int NWNX_Effect_RemoveEffectById(object oObject,  string sID);
 /// @param nEnable set to true to turn on.
 void NWNX_Effect_SetEffectImmunityBypass(int nEnable);
 
+/// @brief Sets what item property bypasses a damage reduction material
+/// @param nMaterial the material or cost value of the damage reduction to be bypaassed
+/// @param nPropertyType The Property type (ITEM_PROPERTY*) of the item property that bypasses the reduction
+/// @param nSubType The subtype of the item property. Set to -1 to ignore.
+/// @param nCostValue The Cost Param Value of the item property
+/// @param nParamValue The Param 1 Value of the item property
+/// @param bReverse The damage reduction will instead resist damage if this item property is present.
+void NWNX_Effect_SetDamageReductionBypass(int nMaterial, int nPropertyType, int nSubType=-1, int nCostValue=-1, int nParamValue=-1, int bReverse=FALSE);
+
 /// @}
 
 struct NWNX_EffectUnpacked __NWNX_Effect_ResolveUnpack(string sFunc, int bLink=TRUE)
@@ -387,5 +396,18 @@ void NWNX_Effect_SetEffectImmunityBypass(int nEnable)
 {
     string sFunc = "SetEffectImmunityBypass";
     NWNX_PushArgumentInt(NWNX_Effect, sFunc, nEnable);
+    NWNX_CallFunction(NWNX_Effect, sFunc);
+}
+
+void NWNX_Effect_SetDamageReductionBypass(int nMaterial, int nPropertyType, int nSubType=-1, int nCostValue=-1, int nParamValue=-1, int bReverse=FALSE)
+{
+    string sFunc = "SetDamageReductionBypass";
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, bReverse);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, nParamValue);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, nCostValue);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, nSubType);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, nPropertyType);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, nMaterial);
+
     NWNX_CallFunction(NWNX_Effect, sFunc);
 }

--- a/Plugins/Effect/NWScript/nwnx_effect.nss
+++ b/Plugins/Effect/NWScript/nwnx_effect.nss
@@ -9,6 +9,7 @@ const string NWNX_Effect = "NWNX_Effect"; ///< @private
 /// An unpacked effect
 struct NWNX_EffectUnpacked
 {
+    string sID; ///< @todo Describe
     int nType; ///< @todo Describe
     int nSubType; ///< @todo Describe
 
@@ -90,16 +91,40 @@ object NWNX_Effect_GetEffectExpiredCreator();
 /// @return Number of internal effects updated.
 int NWNX_Effect_ReplaceEffect(object obj, effect eOld, effect eNew);
 
+/// @brief Gets the true effect count
+/// @param oObjece The object to get the count of.
+/// @return the number of effects (item propertiies and other non-exposed effects included)
+int NWNX_Effect_GetTrueEffectCount(object oObject);
+
+/// @brief Gets a specific effect on an object. This can grab effects normally hidden from developers, such as item properties.
+/// @param oObject The object with the effect
+/// @param nElement The point in the array to retrieve (0 to GetTrueEffectCount())
+/// @return A constructed NWNX_EffectUnpacked.
+struct NWNX_EffectUnpacked NWNX_Effect_GetTrueEffect(object oObject, int nElement);
+
+/// @brief Replaces an already applied effect with another.
+/// @param oObject The object with the effect to replace
+/// @param nElement The array element to be replaced
+/// @param e The unpacked effect to replace it with.
+/// @note Cannot replace an effect with a different type.
+void NWNX_Effect_ReplaceEffectByElement(object oObject, int nElement, struct  NWNX_EffectUnpacked e);
+
+/// @brief Removes effect by ID
+/// @param oObject The object to remove the effect from
+/// @param sID The id of the effect, can be retrieved by unpacking effects.
+/// @return FALSE/0 on failure TRUE/1 on success.
+int NWNX_Effect_RemoveEffectById(object oObject,  string sID);
+
+/// @brief Disables effect-level immunities.
+/// @param nEnable set to true to turn on.
+void NWNX_Effect_SetEffectImmunityBypass(int nEnable);
+
 /// @}
 
-struct NWNX_EffectUnpacked NWNX_Effect_UnpackEffect(effect e)
+struct NWNX_EffectUnpacked __NWNX_Effect_ResolveUnpack(string sFunc, int bLink=TRUE)
 {
-    string sFunc = "UnpackEffect";
-
-    NWNX_PushArgumentEffect(NWNX_Effect, sFunc, e);
-    NWNX_CallFunction(NWNX_Effect, sFunc);
-
     struct NWNX_EffectUnpacked n;
+
     n.sTag = NWNX_GetReturnValueString(NWNX_Effect, sFunc);
 
     float fZ = NWNX_GetReturnValueFloat(NWNX_Effect, sFunc);
@@ -134,10 +159,13 @@ struct NWNX_EffectUnpacked NWNX_Effect_UnpackEffect(effect e)
     n.nParam0 = NWNX_GetReturnValueInt(NWNX_Effect, sFunc);
     n.nNumIntegers = NWNX_GetReturnValueInt(NWNX_Effect, sFunc);
 
-    n.bLinkRightValid = NWNX_GetReturnValueInt(NWNX_Effect, sFunc);
-    n.eLinkRight = NWNX_GetReturnValueEffect(NWNX_Effect, sFunc);
-    n.bLinkLeftValid = NWNX_GetReturnValueInt(NWNX_Effect, sFunc);
-    n.eLinkLeft = NWNX_GetReturnValueEffect(NWNX_Effect, sFunc);
+    if(bLink)
+    {
+        n.bLinkRightValid = NWNX_GetReturnValueInt(NWNX_Effect, sFunc);
+        n.eLinkRight = NWNX_GetReturnValueEffect(NWNX_Effect, sFunc);
+        n.bLinkLeftValid = NWNX_GetReturnValueInt(NWNX_Effect, sFunc);
+        n.eLinkLeft = NWNX_GetReturnValueEffect(NWNX_Effect, sFunc);
+    }
 
     n.nCasterLevel = NWNX_GetReturnValueInt(NWNX_Effect, sFunc);
     n.bShowIcon = NWNX_GetReturnValueInt(NWNX_Effect, sFunc);
@@ -151,8 +179,19 @@ struct NWNX_EffectUnpacked NWNX_Effect_UnpackEffect(effect e)
 
     n.nSubType = NWNX_GetReturnValueInt(NWNX_Effect, sFunc);
     n.nType = NWNX_GetReturnValueInt(NWNX_Effect, sFunc);
+    n.sID = NWNX_GetReturnValueString(NWNX_Effect, sFunc);
 
     return n;
+}
+
+struct NWNX_EffectUnpacked NWNX_Effect_UnpackEffect(effect e)
+{
+    string sFunc = "UnpackEffect";
+
+    NWNX_PushArgumentEffect(NWNX_Effect, sFunc, e);
+    NWNX_CallFunction(NWNX_Effect, sFunc);
+
+    return __NWNX_Effect_ResolveUnpack(sFunc);
 }
 effect NWNX_Effect_PackEffect(struct NWNX_EffectUnpacked e)
 {
@@ -256,4 +295,97 @@ int NWNX_Effect_ReplaceEffect(object obj, effect eOld, effect eNew)
     NWNX_CallFunction(NWNX_Effect, sFunc);
 
     return NWNX_GetReturnValueInt(NWNX_Effect, sFunc);
+}
+
+int NWNX_Effect_GetTrueEffectCount(object oObject)
+{
+    string sFunc = "GetTrueEffectCount";
+    NWNX_PushArgumentObject(NWNX_Effect, sFunc, oObject);
+    NWNX_CallFunction(NWNX_Effect, sFunc);
+
+    return  NWNX_GetReturnValueInt(NWNX_Effect,sFunc);
+}
+
+struct NWNX_EffectUnpacked NWNX_Effect_GetTrueEffect(object oObject, int nElement)
+{
+    string sFunc = "GetTrueEffect";
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, nElement);
+    NWNX_PushArgumentObject(NWNX_Effect, sFunc, oObject);
+    NWNX_CallFunction(NWNX_Effect, sFunc);
+
+    return __NWNX_Effect_ResolveUnpack(sFunc, FALSE);
+}
+
+void NWNX_Effect_ReplaceEffectByElement(object oObject, int nElement, struct  NWNX_EffectUnpacked e)
+{
+    string sFunc = "ReplaceEffectByElement";
+
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, e.nSubType);
+
+    NWNX_PushArgumentFloat(NWNX_Effect, sFunc, e.fDuration);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, e.nExpiryCalendarDay);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, e.nExpiryTimeOfDay);
+
+    NWNX_PushArgumentObject(NWNX_Effect, sFunc, e.oCreator);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, e.nSpellId);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, e.bExpose);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, e.bShowIcon);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, e.nCasterLevel);
+
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, e.nParam0);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, e.nParam1);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, e.nParam2);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, e.nParam3);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, e.nParam4);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, e.nParam5);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, e.nParam6);
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, e.nParam7);
+
+    NWNX_PushArgumentFloat(NWNX_Effect, sFunc, e.fParam0);
+    NWNX_PushArgumentFloat(NWNX_Effect, sFunc, e.fParam1);
+    NWNX_PushArgumentFloat(NWNX_Effect, sFunc, e.fParam2);
+    NWNX_PushArgumentFloat(NWNX_Effect, sFunc, e.fParam3);
+
+    NWNX_PushArgumentString(NWNX_Effect, sFunc, e.sParam0);
+    NWNX_PushArgumentString(NWNX_Effect, sFunc, e.sParam1);
+    NWNX_PushArgumentString(NWNX_Effect, sFunc, e.sParam2);
+    NWNX_PushArgumentString(NWNX_Effect, sFunc, e.sParam3);
+    NWNX_PushArgumentString(NWNX_Effect, sFunc, e.sParam4);
+    NWNX_PushArgumentString(NWNX_Effect, sFunc, e.sParam5);
+    NWNX_PushArgumentObject(NWNX_Effect, sFunc, e.oParam0);
+    NWNX_PushArgumentObject(NWNX_Effect, sFunc, e.oParam1);
+    NWNX_PushArgumentObject(NWNX_Effect, sFunc, e.oParam2);
+    NWNX_PushArgumentObject(NWNX_Effect, sFunc, e.oParam3);
+
+    NWNX_PushArgumentFloat(NWNX_Effect, sFunc, e.vParam0.x);
+    NWNX_PushArgumentFloat(NWNX_Effect, sFunc, e.vParam0.y);
+    NWNX_PushArgumentFloat(NWNX_Effect, sFunc, e.vParam0.z);
+
+    NWNX_PushArgumentFloat(NWNX_Effect, sFunc, e.vParam1.x);
+    NWNX_PushArgumentFloat(NWNX_Effect, sFunc, e.vParam1.y);
+    NWNX_PushArgumentFloat(NWNX_Effect, sFunc, e.vParam1.z);
+
+    NWNX_PushArgumentString(NWNX_Effect, sFunc, e.sTag);
+
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, nElement);
+    NWNX_PushArgumentObject(NWNX_Effect, sFunc, oObject);
+    NWNX_CallFunction(NWNX_Effect, sFunc);
+
+}
+
+int NWNX_Effect_RemoveEffectById(object oObject,  string sID)
+{
+    string sFunc = "RemoveEffectById";
+    NWNX_PushArgumentString(NWNX_Effect, sFunc, sID);
+    NWNX_PushArgumentObject(NWNX_Effect, sFunc, oObject);
+    NWNX_CallFunction(NWNX_Effect, sFunc);
+
+    return  NWNX_GetReturnValueInt(NWNX_Effect,sFunc);
+}
+
+void NWNX_Effect_SetEffectImmunityBypass(int nEnable)
+{
+    string sFunc = "SetEffectImmunityBypass";
+    NWNX_PushArgumentInt(NWNX_Effect, sFunc, nEnable);
+    NWNX_CallFunction(NWNX_Effect, sFunc);
 }

--- a/Plugins/Effect/NWScript/nwnx_effect_ext.nss
+++ b/Plugins/Effect/NWScript/nwnx_effect_ext.nss
@@ -1,0 +1,24 @@
+
+//Same as EffectDamageReduction, but you can set a material
+effect EffectDamageReductionExt(int nAmount, int nDamagePower, int nMaterial, int nLimit=0);
+
+//Same as EffectImmunity, but can set a %. Critical hits and sneak attacks ONLY
+effect EffectImmunityExt(int nImmunityType, int nPercent);
+
+effect EffectDamageReductionExt(int nAmount, int nDamagePower, int nMaterial, int nLimit=0)
+{
+    effect e = EffectDamageReduction(nAmount, nDamagePower, nLimit);
+    struct NWNX_EffectUnpacked unpacked = NWNX_Effect_UnpackEffect(e);
+    unpacked.nParam3=nMaterial;
+    return NWNX_Effect_PackEffect(unpacked);
+}
+
+effect EffectImmunityExt(int nImmunityType, int nPercent)
+{
+    effect e =  EffectImmunity(nImmunityType);
+    if(nImmunityType != IMMUNITY_TYPE_SNEAK_ATTACK && nImmunityType != IMMUNITY_TYPE_CRITICAL_HIT)
+        return e;
+    struct NWNX_EffectUnpacked unpacked = NWNX_Effect_UnpackEffect(e);
+    unpacked.nParam4=nPercent;
+    return NWNX_Effect_PackEffect(unpacked);
+}

--- a/Plugins/Effect/NWScript/nwnx_effect_t.nss
+++ b/Plugins/Effect/NWScript/nwnx_effect_t.nss
@@ -4,6 +4,8 @@
 void printeff(struct NWNX_EffectUnpacked n)
 {
     string s = "Unpacked effect: \n";
+
+    s += "sID = " + n.sID + "\n";
     s += "nType = " + IntToString(n.nType) + "\n";
     s += "nSubType = " + IntToString(n.nSubType) + "\n";
 
@@ -97,6 +99,38 @@ void main()
         }
         e = GetNextEffect(oCreature);
     }
+
+    e = EffectLinkEffects(EffectAbilityIncrease(ABILITY_STRENGTH, 6), EffectAbilityIncrease(ABILITY_DEXTERITY, 7));
+    int i;
+    int nCount = NWNX_Effect_GetTrueEffectCount(oCreature);
+    int nCon = GetAbilityScore(oCreature, ABILITY_CONSTITUTION);
+    int nFound;
+    string sID;
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oCreature);
+    struct NWNX_EffectUnpacked replace;
+    NWNX_Tests_Report("NWNX_Effect", "GetTrueEffectCount", NWNX_Effect_GetTrueEffectCount(oCreature) > nCount);
+    for(i=0;i<NWNX_Effect_GetTrueEffectCount(oCreature);i++)
+    {
+        unpacked = NWNX_Effect_GetTrueEffect(oCreature, i);
+        printeff(unpacked);
+        if(unpacked.nType == 36 && unpacked.nParam0 == ABILITY_DEXTERITY && unpacked.nParam1 == 7)
+        {
+            nFound = TRUE;
+            //lets replace it too
+            replace = unpacked;
+            replace.nParam0=ABILITY_CONSTITUTION;
+            sID = replace.sID;
+            NWNX_Effect_ReplaceEffectByElement(oCreature, i, replace);
+        }
+    }
+    NWNX_Tests_Report("NWNX_Effect", "GetTrueEffect", nFound);
+    NWNX_Tests_Report("NWNX_Effect", "ReplaceEffectByElement", GetAbilityScore(oCreature, ABILITY_CONSTITUTION)>nCon);
+    NWNX_Tests_Report("NWNX_Effect", "RemoveEffectById", NWNX_Effect_RemoveEffectById(oCreature, sID));
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectImmunity(IMMUNITY_TYPE_ABILITY_DECREASE), oCreature);
+    NWNX_Effect_SetEffectImmunityBypass(TRUE);
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectAbilityDecrease(ABILITY_CONSTITUTION, 7), oCreature);
+    NWNX_Effect_SetEffectImmunityBypass(FALSE);
+    NWNX_Tests_Report("NWNX_Effect", "SetEffectImmunityBypass", GetAbilityScore(oCreature,ABILITY_CONSTITUTION)<nCon);
 
     WriteTimestampedLogEntry("NWNX_Effect unit test end.");
 }


### PR DESCRIPTION
The +5 (or whatever) remains in effect and the material property acts as an or.

% based critical/sneak attack immunity.

Plugin choice: Placed in effect as % based critical/sneak attack immunity uses an exclusive hook (though not yet approved).

Damage reduction can go anywhere.

Known issues:
When multiple linked damage reduction is restored incorrectly.
% based immunities only work if the item property hook is active.

To do: Documentation

Things I don't like: forced reservation of an effect ParamInteger, but it at least provides specific-effect material based DR which won't get lost when linking multiple material based damage reductions.