### PR TITLE
Events: AcquireItem - Check for valid item before firing the event

### DIFF
--- a/Plugins/Events/Events/ItemEvents.cpp
+++ b/Plugins/Events/Events/ItemEvents.cpp
@@ -500,8 +500,12 @@ int32_t ItemEvents::AcquireItemHook(
 {
     int32_t retVal = false;
 
+    if (!pItem || !(*pItem))
+        return s_AcquireItemHook->CallOriginal<int32_t>(thisPtr, pItem, oidPossessor, oidTargetRepo, x, y, bOriginatingFromScript, bDisplayFeedback);
+    
     auto PushAndSignal = [&](const std::string& ev) -> bool {
         Events::PushEventData("ITEM", Utils::ObjectIDToString((*pItem)->m_idSelf));
+        Events::PushEventData("GIVER", Utils::ObjectIDToString(oidPossessor));
         Events::PushEventData("RESULT", std::to_string(retVal));
         return Events::SignalEvent(ev, thisPtr->m_idSelf);
     };

--- a/Plugins/Events/Events/ItemEvents.cpp
+++ b/Plugins/Events/Events/ItemEvents.cpp
@@ -493,18 +493,18 @@ void ItemEvents::SplitItemHook(CNWSCreature *thisPtr, CNWSItem *pItem, int32_t n
 }
 
 int32_t ItemEvents::AcquireItemHook(
-        CNWSCreature* thisPtr, CNWSItem* *pItem,
+        CNWSCreature* thisPtr, CNWSItem* *ppItem,
         ObjectID oidPossessor, ObjectID oidTargetRepo,
         uint8_t x, uint8_t y,
         int32_t bOriginatingFromScript, int32_t bDisplayFeedback)
 {
     int32_t retVal = false;
 
-    if (!pItem || !(*pItem))
-        return s_AcquireItemHook->CallOriginal<int32_t>(thisPtr, pItem, oidPossessor, oidTargetRepo, x, y, bOriginatingFromScript, bDisplayFeedback);
-    
+    if (!ppItem || !(*ppItem))
+        return s_AcquireItemHook->CallOriginal<int32_t>(thisPtr, ppItem, oidPossessor, oidTargetRepo, x, y, bOriginatingFromScript, bDisplayFeedback);
+
     auto PushAndSignal = [&](const std::string& ev) -> bool {
-        Events::PushEventData("ITEM", Utils::ObjectIDToString((*pItem)->m_idSelf));
+        Events::PushEventData("ITEM", Utils::ObjectIDToString((*ppItem)->m_idSelf));
         Events::PushEventData("GIVER", Utils::ObjectIDToString(oidPossessor));
         Events::PushEventData("RESULT", std::to_string(retVal));
         return Events::SignalEvent(ev, thisPtr->m_idSelf);
@@ -512,7 +512,7 @@ int32_t ItemEvents::AcquireItemHook(
 
     if (PushAndSignal("NWNX_ON_ITEM_ACQUIRE_BEFORE"))
     {
-        retVal = s_AcquireItemHook->CallOriginal<int32_t>(thisPtr, pItem, oidPossessor, oidTargetRepo, x, y, bOriginatingFromScript, bDisplayFeedback);
+        retVal = s_AcquireItemHook->CallOriginal<int32_t>(thisPtr, ppItem, oidPossessor, oidTargetRepo, x, y, bOriginatingFromScript, bDisplayFeedback);
     }
     else
     {

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -218,6 +218,7 @@ _______________________________________
     Event Data Tag        | Type   | Notes |
     ----------------------|--------|-------|
     ITEM                  | object | Convert to object with StringToObject()|
+    GIVER                 | object | Convert to object with StringToObject() (will be INVALID if picked up from ground)|
     RESULT                | int    | Returns TRUE in the _AFTER if the acquisition was successful, FALSE otherwise
 
     @note This event currently only works with creatures


### PR DESCRIPTION
 also added GIVER as another event data, OBJECT_INVALID if acquired from ground.