### PR TITLE
 Rename: properly updates original name if NWNX_Creature_SetOriginalName() is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ N/A
 - Object: fixed a possible crash in CheckFit()
 - Race: fixed effect clean up after level up
 - Rename: community name only obfuscates once a server reset
+- Rename: properly updates original name if NWNX_Creature_SetOriginalName() is used
 - Weapon: fixed bug in SetGreaterWeaponFocusFeat()
 
 ## 8193.16

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -28,6 +28,7 @@
 #include "Services/Events/Events.hpp"
 #include "Services/Hooks/Hooks.hpp"
 #include "Services/PerObjectStorage/PerObjectStorage.hpp"
+#include "Services/Messaging/Messaging.hpp"
 #include "Encoding.hpp"
 
 
@@ -1837,6 +1838,12 @@ ArgumentStack Creature::SetOriginalName(ArgumentStack&& args)
         {
             ASSERT_OR_THROW(!name.empty());
             pCreature->m_pStats->m_lsFirstName = locName;
+        }
+
+        if (pCreature->m_bPlayerCharacter || pCreature->m_pStats->m_bIsPC || pCreature->m_pStats->m_bIsDMCharacterFile)
+        {
+            g_plugin->GetServices()->m_messaging->BroadcastMessage("NWNX_CREATURE_ORIGINALNAME_SIGNAL",
+                                                                   {NWNXLib::Utils::ObjectIDToString(pCreature->m_idSelf)});
         }
     }
 


### PR DESCRIPTION
Closes #815 

I used a broadcast message here, not 100% I covered everything but I think this is better then telling users they have to update the rename originals as well