### PR TITLE
Events: Disarm event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ https://github.com/nwnxee/unified/compare/build8193.16...HEAD
 
 ### Added
 - Events: added skippable Acquire events to ItemEvents
+- Events: added skippable Disarm event to CombatEvents
 - Events: added `ACTION_RESULT` to Feat/Skill/Lock events for use in the _AFTER
 - Tweaks: `NWNX_TWEAKS_HIDE_PLAYERS_ON_CHAR_LIST`
 - Tweaks: `NWNX_TWEAKS_FIX_ARMOR_DEX_BONUS_UNDER_ONE`

--- a/Plugins/Events/Events/CombatEvents.cpp
+++ b/Plugins/Events/Events/CombatEvents.cpp
@@ -13,19 +13,16 @@ using namespace NWNXLib;
 using namespace NWNXLib::API;
 using namespace NWNXLib::Services;
 
-NWNXLib::Hooking::FunctionHook* CombatEvents::m_hook;
+static Hooking::FunctionHook* s_ApplyDisarmHook;
 
 CombatEvents::CombatEvents(HooksProxy* hooker)
 {
     Events::InitOnFirstSubscribe("NWNX_ON_START_COMBAT_ROUND_.*", [hooker]() {
-        hooker->RequestSharedHook<
-            API::Functions::_ZN15CNWSCombatRound16StartCombatRoundEj,
-            int32_t,
-            CNWSCombatRound*,
-            uint32_t>
-            (
-                &StartCombatRoundHook
-            );
+        hooker->RequestSharedHook<API::Functions::_ZN15CNWSCombatRound16StartCombatRoundEj, int32_t>(&StartCombatRoundHook);
+    });
+    Events::InitOnFirstSubscribe("NWNX_ON_DISARM_*", [hooker]() {
+        s_ApplyDisarmHook = hooker->RequestExclusiveHook
+                <API::Functions::_ZN21CNWSEffectListHandler13OnApplyDisarmEP10CNWSObjectP11CGameEffecti>(&ApplyDisarmHook);
     });
 }
 
@@ -33,6 +30,33 @@ void CombatEvents::StartCombatRoundHook(bool before, CNWSCombatRound* thisPtr, u
 {
     Events::PushEventData("TARGET_OBJECT_ID", Utils::ObjectIDToString(oidTarget));
     Events::SignalEvent(before ? "NWNX_ON_START_COMBAT_ROUND_BEFORE" : "NWNX_ON_START_COMBAT_ROUND_AFTER" , thisPtr->m_pBaseCreature->m_idSelf);
+}
+
+int32_t CombatEvents::ApplyDisarmHook(CNWSEffectListHandler* pEffectHandler, CNWSObject *pObject, CGameEffect *pEffect, BOOL bLoadingGame)
+{
+
+    int32_t retVal = false;
+
+    auto PushAndSignal = [&](const std::string& ev) -> bool {
+        Events::PushEventData("DISARMER_OBJECT_ID", Utils::ObjectIDToString(pEffect->m_oidCreator));
+        auto nFeatId = pEffect->GetInteger(0) == 1 ? Constants::Feat::ImprovedDisarm : Constants::Feat::Disarm;
+        Events::PushEventData("FEAT_ID", std::to_string(nFeatId));
+        return Events::SignalEvent(ev, pObject->m_idSelf);
+    };
+
+    if (PushAndSignal("NWNX_ON_DISARM_BEFORE"))
+    {
+        retVal = s_ApplyDisarmHook->CallOriginal<int32_t>(pEffectHandler, pObject, pEffect, bLoadingGame);
+    }
+    else
+    {
+        retVal = false;
+    }
+
+    Events::PushEventData("ACTION_RESULT", std::to_string(retVal));
+    PushAndSignal("NWNX_ON_DISARM_AFTER");
+
+    return retVal;
 }
 
 }

--- a/Plugins/Events/Events/CombatEvents.hpp
+++ b/Plugins/Events/Events/CombatEvents.hpp
@@ -13,7 +13,7 @@ public:
 
 private:
     static void StartCombatRoundHook(bool, CNWSCombatRound*, uint32_t);
-    static NWNXLib::Hooking::FunctionHook* m_hook;
+    static int32_t ApplyDisarmHook(CNWSEffectListHandler*, CNWSObject *, CGameEffect *, BOOL);
 };
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -484,6 +484,19 @@ _______________________________________
     TARGET_OBJECT_ID      | object | Convert to object with StringToObject()
 
 _______________________________________
+    ## Disarm Events
+    - NWNX_ON_DISARM_BEFORE
+    - NWNX_ON_DISARM_AFTER
+
+    `OBJECT_SELF` = The creature who is being disarmed
+
+    Event Data Tag        | Type   | Notes
+    ----------------------|--------|-------
+    DISARMER_OBJECT_ID    | object | The object disarming the creature
+    FEAT_ID               | int    | The feat used to perform the disarming (Normal vs Improved Disarm)
+    ACTION_RESULT         | int    | TRUE/FALSE, only in _AFTER events
+
+_______________________________________
     ## Cast Spell Events
     - NWNX_ON_CAST_SPELL_BEFORE
     - NWNX_ON_CAST_SPELL_AFTER
@@ -1289,6 +1302,7 @@ string NWNX_Events_GetEventData(string tag);
 /// - Input Pause Event
 /// - Debug events
 /// - Store events
+/// - Disarm event
 void NWNX_Events_SkipEvent();
 
 /// Set the return value of the event.


### PR DESCRIPTION
Also did some tiny tidying up in CombatEvents as well.

Disarm can now be skipped so as to script the desired outcome.

For example

`on_module_load.nss`
```c
    NWNX_Events_SubscribeEvent("NWNX_ON_DISARM_BEFORE", "event_disarm");
    NWNX_Events_SubscribeEvent("NWNX_ON_VALIDATE_USE_ITEM_BEFORE", "event_equip");
    NWNX_Events_SubscribeEvent("NWNX_ON_VALIDATE_ITEM_EQUIP_BEFORE", "event_equip");
```

`event_disarm.nss`
```c
#include "nwnx_events"
#include "nwnx_time"

void main()
{
    object oPC = OBJECT_SELF;
    string sCurrentEvent = NWNX_Events_GetCurrentEvent();
    if (sCurrentEvent == "NWNX_ON_DISARM_BEFORE")
    {
            NWNX_Events_SkipEvent();
            object oItem = GetItemInSlot(INVENTORY_SLOT_RIGHTHAND,oPC);
            AssignCommand(oPC, ClearAllActions(TRUE));
            AssignCommand(oPC, ActionUnequipItem(oItem));
            SetLocalInt(oItem,"disarmed",NWNX_Time_GetTimeStamp());
            FloatingTextStringOnCreature("You have been disarmed!",oPC,FALSE);
    }
}
```
`event_equip.nss`
```c
    if (sCurrentEvent == "NWNX_ON_VALIDATE_USE_ITEM_BEFORE" || sCurrentEvent == "NWNX_ON_VALIDATE_ITEM_EQUIP_BEFORE")
    {
        object oItem = StringToObject(NWNX_Events_GetEventData("ITEM_OBJECT_ID"));
        if (GetLocalInt(oItem, "disarmed") > (NWNX_Time_GetTimeStamp() - 30))
        {
            int iSecondsLeft = 30 - (NWNX_Time_GetTimeStamp() - GetLocalInt(oItem, "disarmed"));
            if (sCurrentEvent == "NWNX_ON_VALIDATE_ITEM_EQUIP_BEFORE")
                FloatingTextStringOnCreature("You must wait "+IntToString(iSecondsLeft)+" seconds before you can re-equip this recently disarmed weapon.", oPC, FALSE);
            NWNX_Events_SetEventResult("0");
            NWNX_Events_SkipEvent();
            return;
        }        
    }
```