### PR TITLE
Events: Spell Interruption Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ https://github.com/nwnxee/unified/compare/build8193.16...HEAD
 ### Added
 - Events: added skippable Acquire events to ItemEvents
 - Events: added `ACTION_RESULT` to Feat/Skill/Lock events for use in the _AFTER
+- Events: added Spell Interruption events to SpellEvents
 - Tweaks: `NWNX_TWEAKS_HIDE_PLAYERS_ON_CHAR_LIST`
 - Tweaks: `NWNX_TWEAKS_FIX_ARMOR_DEX_BONUS_UNDER_ONE`
 

--- a/Plugins/Events/Events/SpellEvents.cpp
+++ b/Plugins/Events/Events/SpellEvents.cpp
@@ -43,6 +43,12 @@ SpellEvents::SpellEvents(Services::HooksProxy* hooker)
              <NWNXLib::API::Functions::_ZN12CNWSCreature18BroadcastSpellCastEjht>
              (&BroadcastSpellCastHook);
     });
+
+    Events::InitOnFirstSubscribe("NWNX_ON_SPELL_INTERRUPTED_.*", [hooker]() {
+        hooker->RequestSharedHook<
+                NWNXLib::API::Functions::_ZN21CNWSEffectListHandler15OnEffectAppliedEP10CNWSObjectP11CGameEffecti, int32_t>
+                (&EffectAppliedHook);
+    });
 }
 
 void SpellEvents::CastSpellHook
@@ -167,5 +173,17 @@ void SpellEvents::BroadcastSpellCastHook(CNWSCreature* thisPtr, uint32_t nSpellI
     }
 
     PushAndSignal("NWNX_ON_BROADCAST_CAST_SPELL_AFTER");
+}
+
+void SpellEvents::EffectAppliedHook(bool before, CNWSEffectListHandler*, CNWSObject *pObject, CGameEffect *pGameEffect, int32_t)
+{
+    // An easy way to capture a spell interrupting is when the visual effect is applied
+    // Visual Effect 292 and 293 are for a spell interruption failure (head and hand)
+    if (pGameEffect->m_nType != Constants::EffectTrueType::VisualEffect || !pGameEffect->m_nNumIntegers ||
+        (pGameEffect->m_nParamInteger[0] != 292 && pGameEffect->m_nParamInteger[0] != 293))
+        return;
+
+    Events::PushEventData("SPELL_ID", std::to_string(pObject->m_nLastSpellId));
+    Events::SignalEvent(before ? "NWNX_ON_SPELL_INTERRUPTED_BEFORE" : "NWNX_ON_SPELL_INTERRUPTED_AFTER" , pObject->m_idSelf);
 }
 }

--- a/Plugins/Events/Events/SpellEvents.cpp
+++ b/Plugins/Events/Events/SpellEvents.cpp
@@ -184,6 +184,11 @@ void SpellEvents::EffectAppliedHook(bool before, CNWSEffectListHandler*, CNWSObj
         return;
 
     Events::PushEventData("SPELL_ID", std::to_string(pObject->m_nLastSpellId));
+    Events::PushEventData("SPELL_CLASS", std::to_string(pObject->m_nLastSpellCastMulticlass));
+    Events::PushEventData("SPELL_FEAT", std::to_string(pObject->m_nLastSpellCastFeat));
+    Events::PushEventData("SPELL_DOMAIN", std::to_string(pObject->m_nLastDomainLevel));
+    Events::PushEventData("SPELL_SPONTANEOUS", std::to_string(pObject->m_bLastSpellCastSpontaneous));
+    Events::PushEventData("SPELL_METAMAGIC", std::to_string(pObject->m_nLastSpellCastMetaType));
     Events::SignalEvent(before ? "NWNX_ON_SPELL_INTERRUPTED_BEFORE" : "NWNX_ON_SPELL_INTERRUPTED_AFTER" , pObject->m_idSelf);
 }
 }

--- a/Plugins/Events/Events/SpellEvents.hpp
+++ b/Plugins/Events/Events/SpellEvents.hpp
@@ -37,6 +37,7 @@ private:
     );
     static void ClearMemorizedSpellSlotHook(CNWSCreatureStats*, uint8_t, uint8_t, uint8_t);
     static void BroadcastSpellCastHook(CNWSCreature*, uint32_t, uint8_t, uint16_t);
+    static void EffectAppliedHook(bool, CNWSEffectListHandler*, CNWSObject*, CGameEffect*, int32_t);
 };
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -515,7 +515,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes |
     ----------------------|--------|-------|
-    SPELL_MULTICLASS      | int | Index of the spell casting class (0-2) |
+    SPELL_CLASS           | int | Index of the spell casting class (0-2) |
     SPELL_LEVEL           | int | |
     SPELL_SLOT            | int | |
     SPELL_ID              | int | |
@@ -533,7 +533,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes |
     ----------------------|--------|-------|
-    SPELL_MULTICLASS      | int    | Index of the spell casting class (0-2) |
+    SPELL_CLASS           | int    | Index of the spell casting class (0-2) |
     SPELL_LEVEL           | int    | |
     SPELL_SLOT            | int    | |
 
@@ -547,6 +547,11 @@ _______________________________________
     Event Data Tag        | Type   | Notes |
     ----------------------|--------|-------|
     SPELL_ID              | int | |
+    SPELL_CLASS           | int | Index of the spell casting class (0-2) |
+    SPELL_DOMAIN          | int | |
+    SPELL_METAMAGIC       | int | |
+    SPELL_FEAT            | int | |
+    SPELL_SPONTANEOUS     | int | |
 
 _______________________________________
     ## Healer Kit Use Events

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -538,6 +538,17 @@ _______________________________________
     SPELL_SLOT            | int    | |
 
 _______________________________________
+    ## Spell Interrupted Events
+    - NWNX_ON_SPELL_INTERRUPTED_BEFORE
+    - NWNX_ON_SPELL_INTERRUPTED_AFTER
+
+    `OBJECT_SELF` = The creature whose spell was interrupted
+
+    Event Data Tag        | Type   | Notes |
+    ----------------------|--------|-------|
+    SPELL_ID              | int | |
+
+_______________________________________
     ## Healer Kit Use Events
     - NWNX_ON_HEALER_KIT_BEFORE
     - NWNX_ON_HEALER_KIT_AFTER


### PR DESCRIPTION
Resolves #1077 

Rather than try to dive deep into the mess of `CNWSEffectListHandler::OnApplyDamage` we hook the specific visual effect event for spell interruption. This is not skippable of course.

Note: It's not possible to send the `LAST_DAMAGER_ID` with the event because that value is not yet set before the spell is interrupted so the only data sent is the `SPELL_ID`