### PR TITLE
Tweak: Fix an item nullptr reference crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ https://github.com/nwnxee/unified/compare/build8193.16...HEAD
 - Events: added `ACTION_RESULT` to Feat/Skill/Lock events for use in the _AFTER
 - Tweaks: `NWNX_TWEAKS_HIDE_PLAYERS_ON_CHAR_LIST`
 - Tweaks: `NWNX_TWEAKS_FIX_ARMOR_DEX_BONUS_UNDER_ONE`
+- Tweaks: `NWNX_TWEAKS_FIX_ITEM_NULLPTR_IN_CITEMREPOSITORY`
 
 ##### New Plugins
 The following plugins were added:

--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -21,4 +21,5 @@ add_plugin(Tweaks
     "Tweaks/UnhardcodeShields.cpp"
     "Tweaks/BlockDMSpawnItem.cpp"
     "Tweaks/FixArmorDexBonusUnderOne.cpp"
+    "Tweaks/FixItemNullptrInCItemRepository.cpp"
 )

--- a/Plugins/Tweaks/README.md
+++ b/Plugins/Tweaks/README.md
@@ -31,6 +31,7 @@ Tweaks stuff. See below.
 * `NWNX_TWEAKS_UNHARDCODE_SHIELDS`: true or false
 * `NWNX_TWEAKS_BLOCK_DM_SPAWNITEM`: true or false
 * `NWNX_TWEAKS_FIX_ARMOR_DEX_BONUS_UNDER_ONE`: true or false
+* `NWNX_TWEAKS_FIX_ITEM_NULLPTR_IN_CITEMREPOSITORY`: true or false
 
 ## Environment variable values
 

--- a/Plugins/Tweaks/Tweaks.cpp
+++ b/Plugins/Tweaks/Tweaks.cpp
@@ -20,6 +20,7 @@
 #include "Tweaks/UnhardcodeShields.hpp"
 #include "Tweaks/BlockDMSpawnItem.hpp"
 #include "Tweaks/FixArmorDexBonusUnderOne.hpp"
+#include "Tweaks/FixItemNullptrInCItemRepository.hpp"
 
 #include "Services/Config/Config.hpp"
 
@@ -170,10 +171,17 @@ Tweaks::Tweaks(Services::ProxyServiceList* services)
         LOG_INFO("Blocking the dm_spawnitem console command");
         m_BlockDMSpawnItem = std::make_unique<BlockDMSpawnItem>(GetServices()->m_hooks.get());
     }
+
     if (GetServices()->m_config->Get<bool>("FIX_ARMOR_DEX_BONUS_UNDER_ONE", false))
     {
         LOG_INFO("Allowing armors with max DEX bonus under 1.");
         m_FixArmorDexBonusUnderOne = std::make_unique<FixArmorDexBonusUnderOne>(GetServices()->m_hooks.get());
+    }
+
+    if (GetServices()->m_config->Get<bool>("FIX_ITEM_NULLPTR_IN_CITEMREPOSITORY", false))
+    {
+        LOG_INFO("Will check for invalid items in the CItemRepository List.");
+        m_FixItemNullptrInCItemRepository = std::make_unique<FixItemNullptrInCItemRepository>(GetServices()->m_hooks.get());
     }
 }
 

--- a/Plugins/Tweaks/Tweaks.hpp
+++ b/Plugins/Tweaks/Tweaks.hpp
@@ -26,6 +26,7 @@ class FixUnlimitedPotionsBug;
 class UnhardcodeShields;
 class BlockDMSpawnItem;
 class FixArmorDexBonusUnderOne;
+class FixItemNullptrInCItemRepository;
 
 class Tweaks : public NWNXLib::Plugin
 {
@@ -55,6 +56,7 @@ private:
     std::unique_ptr<UnhardcodeShields> m_UnhardcodeShields;
     std::unique_ptr<BlockDMSpawnItem> m_BlockDMSpawnItem;
     std::unique_ptr<FixArmorDexBonusUnderOne> m_FixArmorDexBonusUnderOne;
+    std::unique_ptr<FixItemNullptrInCItemRepository> m_FixItemNullptrInCItemRepository;
 };
 
 }

--- a/Plugins/Tweaks/Tweaks/FixItemNullptrInCItemRepository.cpp
+++ b/Plugins/Tweaks/Tweaks/FixItemNullptrInCItemRepository.cpp
@@ -1,0 +1,74 @@
+#include "Tweaks/FixItemNullptrInCItemRepository.hpp"
+
+#include "Services/Hooks/Hooks.hpp"
+#include "Utils.hpp"
+
+#include "API/C2DA.hpp"
+#include "API/CAppManager.hpp"
+#include "API/CItemRepository.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/CNWSItem.hpp"
+#include "API/CNWSPlayer.hpp"
+#include "API/CNWSRules.hpp"
+#include "API/CServerExoApp.hpp"
+#include "API/CTwoDimArrays.hpp"
+#include "API/Functions.hpp"
+#include <cmath>
+
+namespace Tweaks {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+FixItemNullptrInCItemRepository::FixItemNullptrInCItemRepository(Services::HooksProxy* hooker)
+{
+    hooker->RequestExclusiveHook<Functions::_ZN15CItemRepository23CalculateContentsWeightEv>
+                                    (&CItemRepository__CalculateContentsWeight_hook);
+}
+
+int64_t FixItemNullptrInCItemRepository::CItemRepository__CalculateContentsWeight_hook(CItemRepository *pThis)
+{
+    int64_t nResult = 0;
+    CNWItemProperty *pItemProperty;
+    float fReduction;
+    auto *pServer = Globals::AppManager()->m_pServerExoApp;
+    std::vector<CExoLinkedListNode*> badItem(32);
+    for (auto *node = pThis->m_oidItems.m_pcExoLinkedListInternal->pHead; node; node = node->pNext)
+    {
+        auto *pItem = pThis->ItemListGetItem(node);
+        auto *pParentItem = pServer->GetItemByGameObjectID(pThis->m_oidParent);
+        if (pItem == nullptr)
+        {
+            badItem.push_back(node);
+            CExoString playerName = "unknown";
+            auto *pCreature = Utils::AsNWSCreature(pServer->GetGameObject(pThis->m_oidParent));
+            if (!pCreature)
+                pCreature = Utils::AsNWSCreature(pServer->GetGameObject(pParentItem->m_oidPossessor));
+            if (pCreature)
+            {
+                auto *pPlayer = pServer->GetClientObjectByObjectId(pCreature->m_idSelf);
+                if (pPlayer)
+                    playerName = pPlayer->GetPlayerName();
+            }
+            ASSERT_FAIL_MSG("An item repository owned by a character played by `%s` referenced a nullptr item", playerName.CStr());
+            continue;
+        }
+        if (pParentItem && pParentItem->GetPropertyByTypeExists(0x20, 0))
+        {
+            pParentItem->GetPropertyByType(&pItemProperty, 0x20u, 0);
+            auto costTable = Globals::Rules()->m_p2DArrays->GetIPRPCostTable(0xFu);
+            auto costTableValue = pItemProperty->m_nCostTableValue;
+            costTable->GetFLOATEntry(costTableValue, CExoString("Value"), &fReduction);
+            auto itemWeight = pItem->GetWeight();
+            auto nItemAdjustedWeight = itemWeight - (itemWeight * fReduction);
+            nResult += (int64_t)floor(nItemAdjustedWeight);
+        }
+        else
+            nResult += pItem->GetWeight();
+    }
+    for (auto bad: badItem)
+        pThis->m_oidItems.Remove(bad);
+    return nResult;
+}
+
+}

--- a/Plugins/Tweaks/Tweaks/FixItemNullptrInCItemRepository.hpp
+++ b/Plugins/Tweaks/Tweaks/FixItemNullptrInCItemRepository.hpp
@@ -11,7 +11,7 @@ public:
     FixItemNullptrInCItemRepository(NWNXLib::Services::HooksProxy* hooker);
 
 private:
-    static int64_t CItemRepository__CalculateContentsWeight_hook(CItemRepository *pThis);
+    static int32_t CItemRepository__CalculateContentsWeight_hook(CItemRepository *pThis);
 };
 
 }

--- a/Plugins/Tweaks/Tweaks/FixItemNullptrInCItemRepository.hpp
+++ b/Plugins/Tweaks/Tweaks/FixItemNullptrInCItemRepository.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Common.hpp"
+#include "Services/Hooks/Hooks.hpp"
+
+namespace Tweaks {
+
+class FixItemNullptrInCItemRepository
+{
+public:
+    FixItemNullptrInCItemRepository(NWNXLib::Services::HooksProxy* hooker);
+
+private:
+    static int64_t CItemRepository__CalculateContentsWeight_hook(CItemRepository *pThis);
+};
+
+}


### PR DESCRIPTION
Closes #837 - well the second part, but we're going to close that issue and open a new one if more crashes occur

This crash may be solved by upstream nwn version 8193.17 so this tweak may be able to be disabled and eventually removed once nwnx moves forward.