### PR TITLE
Diagnostics plugin and memory sanitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ https://github.com/nwnxee/unified/compare/build8193.16...HEAD
 The following plugins were added:
 - Feat: Allows to define a variety of effects that are granted to feat holders.
 - Tileset: An advanced plugin that exposes additional tileset and tile properties and allows builders to override the tiles of an area created with CreateArea().
+- Diagnostics: Plugin exposing diagnostic facilities to help server debugging.
 
 ##### New NWScript Functions
 - Area: GetTileInfo()

--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -176,8 +176,8 @@ void NWNXCore::InitialSetupHooks()
     m_services->m_hooks->RequestExclusiveHook<API::Functions::_ZN11CAppManager13DestroyServerEv>(&DestroyServerHandler);
     m_services->m_hooks->RequestSharedHook<API::Functions::_ZN21CServerExoAppInternal8MainLoopEv, int32_t>(&MainLoopInternalHandler);
 
-    m_services->m_hooks->RequestSharedHook<API::Functions::_ZN10CNWSObjectD0Ev, void>(&Services::PerObjectStorage::CNWSObject__CNWSObjectDtor__0_hook);
-    m_services->m_hooks->RequestSharedHook<API::Functions::_ZN8CNWSAreaD0Ev, void>(&Services::PerObjectStorage::CNWSArea__CNWSAreaDtor__0_hook);
+    m_services->m_hooks->RequestSharedHook<API::Functions::_ZN10CNWSObjectD1Ev, void>(&Services::PerObjectStorage::CNWSObject__CNWSObjectDtor__0_hook);
+    m_services->m_hooks->RequestSharedHook<API::Functions::_ZN8CNWSAreaD1Ev, void>(&Services::PerObjectStorage::CNWSArea__CNWSAreaDtor__0_hook);
     m_services->m_hooks->RequestSharedHook<API::Functions::_ZN10CNWSPlayer7EatTURDEP14CNWSPlayerTURD, void>(&Services::PerObjectStorage::CNWSPlayer__EatTURD_hook);
     m_services->m_hooks->RequestSharedHook<API::Functions::_ZN10CNWSPlayer8DropTURDEv, void>(&Services::PerObjectStorage::CNWSPlayer__DropTURD_hook);
     m_services->m_hooks->RequestSharedHook<API::Functions::_ZN8CNWSUUID9SaveToGffEP7CResGFFP10CResStruct, void>(&Services::PerObjectStorage::CNWSUUID__SaveToGff_hook);

--- a/Plugins/Diagnostics/CMakeLists.txt
+++ b/Plugins/Diagnostics/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_plugin(Diagnostics
+        "Diagnostics.cpp"
+        "Diagnostics/MemorySanitizer.cpp"
+)

--- a/Plugins/Diagnostics/Diagnostics.cpp
+++ b/Plugins/Diagnostics/Diagnostics.cpp
@@ -15,18 +15,24 @@ NWNX_PLUGIN_ENTRY Plugin* PluginLoad(Services::ProxyServiceList* services)
 
 namespace Diagnostics {
 
+static bool preloaded = false;
+void auto_constructor() __attribute__((constructor));
+void auto_constructor() { preloaded = true; }
+
 Diagnostics::Diagnostics(Services::ProxyServiceList* services)
         : Plugin(services)
 {
-    if (GetServices()->m_config->Get<bool>("MEMORY_SANITIZER", false))
+    if (preloaded)
     {
         LOG_INFO("Memory sanitizer enabled");
-        m_MemorySanitizer = std::make_unique<MemorySanitizer>(GetServices()->m_hooks.get(), GetServices()->m_tasks.get());
+        m_MemorySanitizer = std::make_unique<MemorySanitizer>(GetServices()->m_hooks.get());
+    }
+    else
+    {
+        LOG_WARNING("Diagnostics will not do anything unless preloaded. See the readme file");
     }
 }
 
-Diagnostics::~Diagnostics()
-{
-}
+Diagnostics::~Diagnostics() { }
 
 }

--- a/Plugins/Diagnostics/Diagnostics.cpp
+++ b/Plugins/Diagnostics/Diagnostics.cpp
@@ -15,21 +15,13 @@ NWNX_PLUGIN_ENTRY Plugin* PluginLoad(Services::ProxyServiceList* services)
 
 namespace Diagnostics {
 
-static bool preloaded = false;
-void auto_constructor() __attribute__((constructor));
-void auto_constructor() { preloaded = true; }
-
 Diagnostics::Diagnostics(Services::ProxyServiceList* services)
         : Plugin(services)
 {
-    if (preloaded)
+    if (GetServices()->m_config->Get<bool>("MEMORY_SANITIZER", false))
     {
         LOG_INFO("Memory sanitizer enabled");
         m_MemorySanitizer = std::make_unique<MemorySanitizer>(GetServices()->m_hooks.get());
-    }
-    else
-    {
-        LOG_WARNING("Diagnostics will not do anything unless preloaded. See the readme file");
     }
 }
 

--- a/Plugins/Diagnostics/Diagnostics.cpp
+++ b/Plugins/Diagnostics/Diagnostics.cpp
@@ -1,0 +1,32 @@
+#include "Diagnostics.hpp"
+#include "Diagnostics/MemorySanitizer.hpp"
+#include "Services/Config/Config.hpp"
+
+
+using namespace NWNXLib;
+
+static Diagnostics::Diagnostics* g_plugin;
+
+NWNX_PLUGIN_ENTRY Plugin* PluginLoad(Services::ProxyServiceList* services)
+{
+    g_plugin = new Diagnostics::Diagnostics(services);
+    return g_plugin;
+}
+
+namespace Diagnostics {
+
+Diagnostics::Diagnostics(Services::ProxyServiceList* services)
+        : Plugin(services)
+{
+    if (GetServices()->m_config->Get<bool>("MEMORY_SANITIZER", false))
+    {
+        LOG_INFO("Memory sanitizer enabled");
+        m_MemorySanitizer = std::make_unique<MemorySanitizer>(GetServices()->m_hooks.get(), GetServices()->m_tasks.get());
+    }
+}
+
+Diagnostics::~Diagnostics()
+{
+}
+
+}

--- a/Plugins/Diagnostics/Diagnostics.hpp
+++ b/Plugins/Diagnostics/Diagnostics.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Plugin.hpp"
+
+namespace Diagnostics {
+
+class MemorySanitizer;
+
+class Diagnostics : public NWNXLib::Plugin
+{
+public:
+    Diagnostics(NWNXLib::Services::ProxyServiceList* services);
+    virtual ~Diagnostics();
+
+private:
+    std::unique_ptr<MemorySanitizer> m_MemorySanitizer;
+};
+
+}

--- a/Plugins/Diagnostics/Diagnostics/MemorySanitizer.cpp
+++ b/Plugins/Diagnostics/Diagnostics/MemorySanitizer.cpp
@@ -1,0 +1,208 @@
+#include "Diagnostics/MemorySanitizer.hpp"
+
+#include "Platform/Debug.hpp"
+#include "Services/Hooks/Hooks.hpp"
+#include "Services/Tasks/Tasks.hpp"
+#include "API/Functions.hpp"
+#include <dlfcn.h>
+#include <execinfo.h>
+
+
+namespace Diagnostics {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+static thread_local bool meta = false;
+struct MetaFunction
+{
+    bool oldmeta;
+    MetaFunction() { oldmeta = meta; meta = true; }
+    ~MetaFunction() { meta = oldmeta; }
+};
+
+
+MemorySanitizer::MemorySanitizer(Services::HooksProxy*, Services::TasksProxy* tasker)
+{
+    enabled = true;
+    tasker = tasker;
+}
+MemorySanitizer::~MemorySanitizer()
+{
+    enabled = false;
+}
+
+void MemorySanitizer::ReportError(void *ptr)
+{
+    try
+    {
+        void **bt = active_allocations.at(ptr);
+        char buffer[16*1024];
+        char** resolvedFrames = backtrace_symbols(bt, 8);
+        std::strncat(buffer, "\n  Allocation backtrace:\n", sizeof(buffer)-1);
+        for (int i = 0; i < 8; ++i)
+        {
+            uintptr_t addr, addr2;
+            char backtraceBuffer[2048];
+            std::snprintf(backtraceBuffer, sizeof(backtraceBuffer), "    %s\n", resolvedFrames[i]);
+            if (std::sscanf(backtraceBuffer, "    ./nwserver-linux(+%lx) [%lx]", &addr, &addr2) == 2)
+            {
+                std::snprintf(backtraceBuffer, sizeof(backtraceBuffer),
+                    "    ./nwserver-linux(%s) [0x%lx]\n", Platform::Debug::ResolveAddress(addr).c_str(), addr2);
+            }
+            std::strncat(buffer, backtraceBuffer, sizeof(buffer)-1);
+        }
+        LOG_NOTICE("%s", buffer);
+    } catch (std::out_of_range& e)
+    {
+        LOG_NOTICE("Pointer %p not found in active allocations list.", ptr);
+    }
+}
+
+#define MSAN_ASSERT(cond, ptr, fmt, ...)      \
+  do { if (!(cond)) {                         \
+        ASSERT_MSG(cond, fmt, ##__VA_ARGS__); \
+        MemorySanitizer::ReportError(ptr);    \
+  } } while(0)
+
+constexpr uint8_t  UNINIT = 0x55;
+constexpr uint32_t MAGIC1 = 0x76aade08;
+constexpr uint64_t MAGIC2 = 0x8d0308b6e7dce543ull;
+constexpr uint64_t MAGIC3 = 0xe561f9248d7563d1ull;
+constexpr uint64_t MAGIC4 = 0x5dd93457b02ebbb6ull;
+struct MemoryFenceHead
+{
+    uint32_t magic1;
+    uint32_t size;
+    uint64_t magic2;
+};
+struct MemoryFenceTail
+{
+    uint64_t magic3;
+    uint64_t magic4;
+};
+constexpr size_t FenceSize = sizeof(MemoryFenceHead) + sizeof(MemoryFenceTail);
+
+static inline void* InitFence(void *ptr, size_t size)
+{
+    MemoryFenceHead *head = (MemoryFenceHead*)ptr;
+    head->magic1 = MAGIC1;
+    head->magic2 = MAGIC2;
+    head->size = size;
+
+    ptr = (uint8_t*)ptr + sizeof(MemoryFenceHead);
+    MemoryFenceTail *tail = (MemoryFenceTail*)((uint8_t*)ptr + size);
+    tail->magic3 = MAGIC3;
+    tail->magic4 = MAGIC4;
+
+    memset(ptr, UNINIT, size);
+    return ptr;
+}
+static inline size_t CheckFence(void *ptr)
+{
+    MemoryFenceHead *head = (MemoryFenceHead*)((uint8_t*)ptr - sizeof(MemoryFenceHead));
+    MSAN_ASSERT(head->magic1 == MAGIC1, ptr, "Buffer overrun detected.");
+    MSAN_ASSERT(head->magic2 == MAGIC2, ptr, "Buffer overrun detected.");
+
+    MemoryFenceTail *tail = (MemoryFenceTail*)((uint8_t*)ptr + head->size);
+    MSAN_ASSERT(tail->magic3 == MAGIC3, ptr, "Buffer overrun detected.");
+    MSAN_ASSERT(tail->magic4 == MAGIC4, ptr, "Buffer overrun detected.");
+    return head->size;
+}
+
+
+
+void *MemorySanitizer::malloc(size_t size)
+{
+    ResolveSymbols();
+    if (!enabled || meta) return real_malloc(size);
+    MetaFunction mf;
+
+    void *ptr = malloc(size + FenceSize);
+    ptr = InitFence(ptr, size);
+
+    void *bt[8];
+    backtrace(bt, 8);
+
+    LOG_NOTICE("allocated %p", ptr);
+    std::lock_guard<std::mutex> guard(lock);
+    active_allocations[ptr] = bt;
+
+    return ptr;
+}
+void MemorySanitizer::free(void *ptr)
+{
+    ResolveSymbols();
+    if (!enabled || meta) return real_free(ptr);
+    MetaFunction mf;
+
+    size_t size = CheckFence(ptr);
+    memset(ptr, UNINIT, size);
+
+    std::lock_guard<std::mutex> guard(lock);
+    MSAN_ASSERT(active_allocations.count(ptr) == 1, ptr, "Freeing non-allocated pointer.");
+    MSAN_ASSERT(pending_free.count(ptr) == 0, ptr, "Double free detected.");
+    pending_free.insert(ptr);
+}
+
+void *MemorySanitizer::calloc(size_t num, size_t size)
+{
+    ResolveSymbols();
+    if (!enabled || meta) return real_calloc(num, size);
+
+    size_t fullsize = num * size;
+    void *ptr = malloc(fullsize);
+    memset(ptr, 0, fullsize);
+    return ptr;
+}
+void *MemorySanitizer::realloc(void *ptr, size_t size)
+{
+    ResolveSymbols();
+    if (!enabled || meta) return real_realloc(ptr, size);
+
+    if (ptr == nullptr) return malloc(size);
+
+    size_t oldsize = CheckFence(ptr);
+    void *newptr = malloc(size);
+    memcpy(newptr, ptr, std::min(oldsize, size));
+    return newptr;
+}
+
+void MemorySanitizer::FreePending()
+{
+    MetaFunction mf;
+    std::lock_guard<std::mutex> guard(lock);
+    
+    for (auto* ptr : pending_free)
+    {
+        size_t size = CheckFence(ptr);
+        for (size_t i = 0; i < size; i++)
+        {
+            if (((char*)ptr)[i] != UNINIT)
+            {
+                MSAN_ASSERT(0, ptr, "Use after free detected. ptr[%d] = %02x", i, ((char*)ptr)[i]);
+                break;
+            }
+        }
+        active_allocations.erase(ptr);
+        real_free((char*)ptr - sizeof(MemoryFenceHead));
+    }
+}
+
+void MemorySanitizer::ResolveSymbols()
+{
+    if (real_malloc) return;
+
+    real_malloc  = (void*(*)(size_t))        dlsym(RTLD_NEXT, "malloc");
+    real_free    = (void(*)(void*))          dlsym(RTLD_NEXT, "free");
+    real_calloc  = (void*(*)(size_t,size_t)) dlsym(RTLD_NEXT, "calloc");
+    real_realloc = (void*(*)(void*,size_t))  dlsym(RTLD_NEXT, "realloc");
+}
+
+}
+
+
+extern "C" void *malloc(size_t size)             { return Diagnostics::MemorySanitizer::malloc(size); }
+extern "C" void *calloc(size_t num, size_t size) { return Diagnostics::MemorySanitizer::calloc(num, size); }
+extern "C" void *realloc(void *ptr, size_t size) { return Diagnostics::MemorySanitizer::realloc(ptr, size);}
+extern "C" void free(void *ptr)                  { return Diagnostics::MemorySanitizer::free(ptr);}

--- a/Plugins/Diagnostics/Diagnostics/MemorySanitizer.cpp
+++ b/Plugins/Diagnostics/Diagnostics/MemorySanitizer.cpp
@@ -23,6 +23,12 @@ struct MetaFunction
 
 MemorySanitizer::MemorySanitizer(Services::HooksProxy* hooker)
 {
+    if (real_malloc == nullptr)
+    {
+        LOG_WARNING("NWNX_Diagnostics.so is not preloaded, memory sanitizer will not work.");
+        LOG_WARNING("Please see Diagnostics/README.md for instructions");
+        return;
+    }
     hooker->RequestSharedHook<Functions::_ZN21CServerExoAppInternal8MainLoopEv, int32_t>(
             +[](bool before, CServerExoAppInternal*)
             {
@@ -30,6 +36,13 @@ MemorySanitizer::MemorySanitizer(Services::HooksProxy* hooker)
                     FreePending();
             });
     enabled = true;
+}
+MemorySanitizer::~MemorySanitizer()
+{
+    if (enabled)
+    {
+        LOG_WARNING("Shutting down MSAN, a crash is imminent. This is not a bug.");
+    }
 }
 
 void MemorySanitizer::ReportError(void *ptr)

--- a/Plugins/Diagnostics/Diagnostics/MemorySanitizer.hpp
+++ b/Plugins/Diagnostics/Diagnostics/MemorySanitizer.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "Common.hpp"
+#include <unordered_map>
+#include <unordered_set>
+#include <mutex>
+
+
+namespace Diagnostics {
+
+class MemorySanitizer
+{
+public:
+    MemorySanitizer(NWNXLib::Services::HooksProxy* hooker, NWNXLib::Services::TasksProxy* tasker);
+    ~MemorySanitizer();
+
+    static void *malloc(size_t size);
+    static void free(void *ptr);
+    static void *calloc(size_t num, size_t size);
+    static void *realloc(void *ptr, size_t size);
+
+    static void FreePending();
+
+    static inline NWNXLib::Services::TasksProxy* tasker;
+    static inline std::unordered_map<void*, void**> active_allocations;
+    static inline std::unordered_set<void*> pending_free;
+
+    static inline std::mutex lock;
+    static inline bool enabled = false;
+
+    static inline void *(*real_calloc)(size_t, size_t);
+    static inline void *(*real_realloc)(void *, size_t);
+    static inline void  (*real_free)(void *);
+    static inline void *(*real_malloc)(size_t);
+
+    static void ResolveSymbols();
+
+    static void ReportError(void *ptr);
+};
+
+}

--- a/Plugins/Diagnostics/Diagnostics/MemorySanitizer.hpp
+++ b/Plugins/Diagnostics/Diagnostics/MemorySanitizer.hpp
@@ -14,6 +14,7 @@ class MemorySanitizer
 {
 public:
     MemorySanitizer(NWNXLib::Services::HooksProxy* hooker);
+    ~MemorySanitizer();
 
     static void *malloc(size_t size);
     static void free(void *ptr);

--- a/Plugins/Diagnostics/Diagnostics/MemorySanitizer.hpp
+++ b/Plugins/Diagnostics/Diagnostics/MemorySanitizer.hpp
@@ -8,11 +8,12 @@
 
 namespace Diagnostics {
 
+struct Backtrace { void *bt[8]; };
+
 class MemorySanitizer
 {
 public:
-    MemorySanitizer(NWNXLib::Services::HooksProxy* hooker, NWNXLib::Services::TasksProxy* tasker);
-    ~MemorySanitizer();
+    MemorySanitizer(NWNXLib::Services::HooksProxy* hooker);
 
     static void *malloc(size_t size);
     static void free(void *ptr);
@@ -22,10 +23,10 @@ public:
     static void FreePending();
 
     static inline NWNXLib::Services::TasksProxy* tasker;
-    static inline std::unordered_map<void*, void**> active_allocations;
+    static inline std::unordered_map<void*, Backtrace> active_allocations;
     static inline std::unordered_set<void*> pending_free;
 
-    static inline std::mutex lock;
+    static inline std::recursive_mutex lock;
     static inline bool enabled = false;
 
     static inline void *(*real_calloc)(size_t, size_t);

--- a/Plugins/Diagnostics/README.md
+++ b/Plugins/Diagnostics/README.md
@@ -1,0 +1,11 @@
+@addtogroup diagnostics Diagnostics
+@page diagnostics Readme
+@ingroup diagnostics
+
+Game diagnostics.
+
+## Environment Variables
+
+| Variable Name | Value | Notes |
+| -------------   | :----: | ------------------------------------ |
+| `NWNX_DIAGNOSTICS_MEMORY_SANITIZER` | true/false | Catches a variety of memory corruption errors |

--- a/Plugins/Diagnostics/README.md
+++ b/Plugins/Diagnostics/README.md
@@ -4,6 +4,14 @@
 
 Game diagnostics.
 
+
+## Environment Variables
+
+| Variable Name | Value | Notes |
+| -------------   | :----: | ------------------------------------ |
+| `NWNX_DIAGNOSTICS_MEMORY_SANITIZER` | true/false | Enables the memory sanitizer |
+
+
 ## Memory Sanitizer
 
 The memory sanitizer catches a few classes of memory corruptions in NWN and NWNX:
@@ -12,7 +20,7 @@ The memory sanitizer catches a few classes of memory corruptions in NWN and NWNX
 * Use after free
 * Double free
 
-To use, you must preload NWNX_Diagnostics.so along with NWNX_Core.so, like:
+To use, in addition to the environment variable, you must preload NWNX_Diagnostics.so along with NWNX_Core.so, like:
 
     LD_PRELOAD=/path/to/NWNX_Core.so:/path/to/NWNX_Diagnostics.so
 

--- a/Plugins/Diagnostics/README.md
+++ b/Plugins/Diagnostics/README.md
@@ -4,8 +4,16 @@
 
 Game diagnostics.
 
-## Environment Variables
+## Memory Sanitizer
 
-| Variable Name | Value | Notes |
-| -------------   | :----: | ------------------------------------ |
-| `NWNX_DIAGNOSTICS_MEMORY_SANITIZER` | true/false | Catches a variety of memory corruption errors |
+The memory sanitizer catches a few classes of memory corruptions in NWN and NWNX:
+
+* Buffer overrun for heap buffers (writing outside the bounds of allocation)
+* Use after free
+* Double free
+
+To use, you must preload NWNX_Diagnostics.so along with NWNX_Core.so, like:
+
+    LD_PRELOAD=/path/to/NWNX_Core.so:/path/to/NWNX_Diagnostics.so
+
+NOTE: Enabling the sanitizer will make it impossible to cleanly shut down the server. When the plugins unload, the server will crash. This is an unavoidable side effect.


### PR DESCRIPTION

The memory sanitizer catches a few classes of memory corruptions in NWN and NWNX:

* Buffer overrun for heap buffers (writing outside the bounds of allocation)
* Use after free
* Double free

To use, you must preload NWNX_Diagnostics.so along with NWNX_Core.so, like:

    LD_PRELOAD=/path/to/NWNX_Core.so:/path/to/NWNX_Diagnostics.so

NOTE: Enabling the sanitizer will make it impossible to cleanly shut down the server. When the plugins unload, the server will crash. This is an unavoidable side effect.


---

Also hook the correct destructors for POS