### PR TITLE
Core: Resolve nwserver functions in backtrace regardless of path and binary name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The following plugins were added:
 
 ### Fixed
 - Administration: fix crash in DeletePlayerCharacter()
+- Core: debug dumps now properly resolve nwserver functions regardless of path and binary name used
 - Creature: removed an unnecessary free() in GetMeetsFeatRequirements() that may have led to crashes
 - Events: fixed a nullptr deref crash in BarterEvents
 - Feedback: fixed a bug where global combatlog and journal feedback message overrides couldn't be removed

--- a/NWNXLib/Platform/Debug.cpp
+++ b/NWNXLib/Platform/Debug.cpp
@@ -43,12 +43,13 @@ std::string GetStackTrace(uint8_t levels)
         for (int i = 0; i < numCapturedFrames; ++i)
         {
             uintptr_t addr, addr2;
+            char path[64];
             char backtraceBuffer[2048];
             std::snprintf(backtraceBuffer, sizeof(backtraceBuffer), "    %s\n", resolvedFrames[i]);
-            if (std::sscanf(backtraceBuffer, "    ./nwserver-linux(+%lx) [%lx]", &addr, &addr2) == 2)
+            if (std::sscanf(backtraceBuffer, "    %63[^(](+%lx) [%lx]", path, &addr, &addr2) == 3)
             {
                 std::snprintf(backtraceBuffer, sizeof(backtraceBuffer),
-                    "    ./nwserver-linux(%s) [0x%lx]\n", ResolveAddress(addr).c_str(), addr2);
+                    "    %s(%s) [0x%lx]\n", path, Platform::Debug::ResolveAddress(addr).c_str(), addr2);
             }
             std::strncat(buffer, backtraceBuffer, sizeof(buffer)-1);
         }

--- a/NWNXLib/Platform/Debug.cpp
+++ b/NWNXLib/Platform/Debug.cpp
@@ -49,7 +49,7 @@ std::string GetStackTrace(uint8_t levels)
             if (std::sscanf(backtraceBuffer, "    %63[^(](+%lx) [%lx]", path, &addr, &addr2) == 3)
             {
                 std::snprintf(backtraceBuffer, sizeof(backtraceBuffer),
-                    "    %s(%s) [0x%lx]\n", path, Platform::Debug::ResolveAddress(addr).c_str(), addr2);
+                    "    %s(%s) [0x%lx]\n", path, ResolveAddress(addr).c_str(), addr2);
             }
             std::strncat(buffer, backtraceBuffer, sizeof(buffer)-1);
         }

--- a/Plugins/Diagnostics/Diagnostics/MemorySanitizer.cpp
+++ b/Plugins/Diagnostics/Diagnostics/MemorySanitizer.cpp
@@ -61,11 +61,12 @@ void MemorySanitizer::ReportError(void *ptr)
         {
             uintptr_t addr, addr2;
             char backtraceBuffer[2048] = "";
+            char path[64];
             std::snprintf(backtraceBuffer, sizeof(backtraceBuffer), "    %s\n", resolvedFrames[i]);
-            if (std::sscanf(backtraceBuffer, "    ./nwserver-linux(+%lx) [%lx]", &addr, &addr2) == 2)
+            if (std::sscanf(backtraceBuffer, "    %63[^(](+%lx) [%lx]", path, &addr, &addr2) == 3)
             {
                 std::snprintf(backtraceBuffer, sizeof(backtraceBuffer),
-                    "    ./nwserver-linux(%s) [0x%lx]\n", Platform::Debug::ResolveAddress(addr).c_str(), addr2);
+                    "    %s(%s) [0x%lx]\n", path, Platform::Debug::ResolveAddress(addr).c_str(), addr2);
             }
             std::strncat(buffer, backtraceBuffer, sizeof(buffer)-1);
         }


### PR DESCRIPTION
won't work if path contains a `(` or longer than 63 characters but should be fine