### PR TITLE
Object: Don't SetNumIntegers to less than 8 in AddIconEffect

### DIFF
--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -643,7 +643,6 @@ ArgumentStack Object::AddIconEffect(ArgumentStack&& args)
         effIcon->m_bExpose    = true;
         effIcon->m_sCustomTag = "NWNX_Object_IconEffect";
 
-        effIcon->SetNumIntegers(1);
         effIcon->m_nParamInteger[0] = nIcon;
 
         if (fDuration > 0.0)


### PR DESCRIPTION
It looks like setting the number of integers to a value less than 8 can cause some buffer overruns later, something to remember.

Copy of backtrace: https://gist.github.com/plenarius/9d2e41da411efefc239426fe83d01071