### PR TITLE
Fix circleci deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,34 +33,6 @@ jobs:
       - run: CC="gcc" CXX="g++" cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .
       - run: make docs
       - run: make dark-docs
-      - persist_to_workspace:
-          root: Documentation/
-          paths:
-            - light
-            - dark
-  docs-deploy:
-    docker:
-      - image: node:8.10.0
-    steps:
-      - checkout
-      - attach_workspace:
-          at: Documentation
-      - run:
-          name: Install and configure dependencies
-          command: |
-            npm install -g --silent gh-pages@2.0.1
-            git config user.email "ci-build@nwnx.io"
-            git config user.name "ci-build"
-      - add_ssh_keys:
-          fingerprints:
-            - "2c:48:0b:5e:9c:d0:99:80:4b:57:1d:0e:09:16:5a:67"
-      - run:
-          name: Move dark into a subdirectory of light for pages
-          command: |
-            mv Documentation/dark Documentation/light/
-      - run:
-          name: Deploy docs to gh-pages branch
-          command: gh-pages --dotfiles --message "[skip ci] Updates" --dist Documentation/light
 
 workflows:
   version: 2
@@ -74,19 +46,3 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - docs-deploy:
-          requires:
-            - build
-            - docs-build
-          filters:
-            branches:
-              only:
-                - master
-      - deploy:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,14 @@ on:
     paths-ignore:
       - '**.md'
       - 'docgen/**'
+      - .circleci/**
   pull_request:
     branches:
       - master
     paths-ignore:
       - '**.md'
       - 'docgen/**'
+      - .circleci/**
 
 env:
   CC: gcc-7 -m64

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,11 +6,17 @@ on:
     paths:
       - '**.cpp'
       - '**.hpp'
+      - '**.inl'
+      - '**.h'
+      - '**.c'
   pull_request:
     branches: master
     paths:
       - '**.cpp'
       - '**.hpp'
+      - '**.inl'
+      - '**.h'
+      - '**.c'
   schedule:
     - cron: '31 8 * * 3'
 

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -2,6 +2,10 @@ name: Container Security Analysis
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '**.md'
+      - 'docgen/**'
+      - .circleci/**
   pull_request:
 jobs:
   build:


### PR DESCRIPTION
Binaries and docs are still being built on Circle but deploying them clashes with our own build so removing them for now. Should we decide to return to Circle then we'll have to revert.