### PR TITLE
Events: Has Feat events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ https://github.com/nwnxee/unified/compare/build8193.16...HEAD
 - Events: added skippable Disarm event to CombatEvents
 - Events: added `ACTION_RESULT` to Feat/Skill/Lock events for use in the _AFTER
 - Events: added Spell Interruption events to SpellEvents
+- Events: added skippable Has Feat event to FeatEvents
 - Tweaks: `NWNX_TWEAKS_HIDE_PLAYERS_ON_CHAR_LIST`
 - Tweaks: `NWNX_TWEAKS_FIX_ARMOR_DEX_BONUS_UNDER_ONE`
 - Tweaks: `NWNX_TWEAKS_FIX_ITEM_NULLPTR_IN_CITEMREPOSITORY`

--- a/Plugins/Events/Events/FeatEvents.cpp
+++ b/Plugins/Events/Events/FeatEvents.cpp
@@ -1,5 +1,6 @@
 #include "Events/FeatEvents.hpp"
 #include "API/CNWSCreature.hpp"
+#include "API/CNWSCreatureStats.hpp"
 #include "API/Functions.hpp"
 #include "API/Globals.hpp"
 #include "Events.hpp"
@@ -13,6 +14,7 @@ using namespace NWNXLib::API;
 using namespace NWNXLib::Services;
 
 static Hooking::FunctionHook* s_UseFeatHook;
+static Hooking::FunctionHook* s_HasFeatHook;
 
 FeatEvents::FeatEvents(Services::HooksProxy* hooker)
 {
@@ -27,6 +29,14 @@ FeatEvents::FeatEvents(Services::HooksProxy* hooker)
             ObjectID,
             Vector*>(FeatEvents::UseFeatHook);
     });
+    Events::InitOnFirstSubscribe("NWNX_ON_HAS_FEAT_.*", [hooker]() {
+        s_HasFeatHook = hooker->RequestExclusiveHook<
+                NWNXLib::API::Functions::_ZN17CNWSCreatureStats7HasFeatEt,
+                int32_t,
+                CNWSCreatureStats*,
+                uint16_t>(FeatEvents::HasFeatHook);
+    });
+    Events::ForceEnableWhitelist("NWNX_ON_HAS_FEAT");
 }
 
 int32_t FeatEvents::UseFeatHook(
@@ -62,6 +72,37 @@ int32_t FeatEvents::UseFeatHook(
     Events::PushEventData("ACTION_RESULT", std::to_string(retVal));
     PushAndSignal("NWNX_ON_USE_FEAT_AFTER");
 
+    return retVal;
+}
+
+int32_t FeatEvents::HasFeatHook(
+        CNWSCreatureStats* thisPtr,
+        uint16_t featID)
+{
+    int32_t retVal;
+    std::string hasFeat;
+
+    if (!Events::IsIDInWhitelist("NWNX_ON_HAS_FEAT", featID))
+    {
+        return s_HasFeatHook->CallOriginal<int32_t>(thisPtr, featID);
+    }
+
+    auto PushAndSignal = [&](std::string ev) -> bool {
+        Events::PushEventData("FEAT_ID", std::to_string(featID));
+        return Events::SignalEvent(ev, thisPtr->m_pBaseCreature->m_idSelf, &hasFeat);
+    };
+
+    if (PushAndSignal("NWNX_ON_HAS_FEAT_BEFORE"))
+    {
+        retVal = s_HasFeatHook->CallOriginal<int32_t>(thisPtr, featID);
+    }
+    else
+    {
+        retVal = hasFeat == "1";
+    }
+
+    Events::PushEventData("ACTION_RESULT", std::to_string(retVal));
+    PushAndSignal("NWNX_ON_HAS_FEAT_AFTER");
     return retVal;
 }
 

--- a/Plugins/Events/Events/FeatEvents.cpp
+++ b/Plugins/Events/Events/FeatEvents.cpp
@@ -87,14 +87,16 @@ int32_t FeatEvents::HasFeatHook(
         return s_HasFeatHook->CallOriginal<int32_t>(thisPtr, featID);
     }
 
+    auto bHasFeat = s_HasFeatHook->CallOriginal<int32_t>(thisPtr, featID);
     auto PushAndSignal = [&](std::string ev) -> bool {
         Events::PushEventData("FEAT_ID", std::to_string(featID));
+        Events::PushEventData("HAS_FEAT", std::to_string(bHasFeat));
         return Events::SignalEvent(ev, thisPtr->m_pBaseCreature->m_idSelf, &hasFeat);
     };
 
     if (PushAndSignal("NWNX_ON_HAS_FEAT_BEFORE"))
     {
-        retVal = s_HasFeatHook->CallOriginal<int32_t>(thisPtr, featID);
+        retVal = bHasFeat;
     }
     else
     {

--- a/Plugins/Events/Events/FeatEvents.hpp
+++ b/Plugins/Events/Events/FeatEvents.hpp
@@ -22,6 +22,11 @@ private:
             ObjectID oidArea,
             Vector* pvTarget
         );
+        static int32_t HasFeatHook
+        (
+            CNWSCreatureStats* thisPtr,
+            uint16_t nFeat
+        );
 };
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -242,15 +242,16 @@ _______________________________________
     ACTION_RESULT         | int    | TRUE/FALSE, only in _AFTER events
 
 _______________________________________
-    NWNX_ON_HAS_FEAT_BEFORE
-    NWNX_ON_HAS_FEAT_AFTER
+    ## Has Feat Events
+    - NWNX_ON_HASFEAT_BEFORE
+    - NWNX_ON_HAS_FEAT_AFTER
 
-    Usage:
-        OBJECT_SELF = The player being checked for the feat
+    `OBJECT_SELF` = The player being checked for the feat
 
-    Event data:
-        Variable Name           Type        Notes
-        FEAT_ID                 int
+    Event Data Tag        | Type   | Notes |
+    ----------------------|--------|-------|
+    FEAT_ID               | int    | |
+    HAS_FEAT              | int    |  Whether they truly have the feat or not |
 
     @note This event should definitely be used with the Event ID Whitelist, which is turned on by default
     for this event. Until you add your Feat ID to the whitelist on module load this event will not function.

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -242,6 +242,26 @@ _______________________________________
     ACTION_RESULT         | int    | TRUE/FALSE, only in _AFTER events
 
 _______________________________________
+    NWNX_ON_HAS_FEAT_BEFORE
+    NWNX_ON_HAS_FEAT_AFTER
+
+    Usage:
+        OBJECT_SELF = The player being checked for the feat
+
+    Event data:
+        Variable Name           Type        Notes
+        FEAT_ID                 int
+
+    @note This event should definitely be used with the Event ID Whitelist, which is turned on by default
+    for this event. Until you add your Feat ID to the whitelist on module load this event will not function.
+    For example if you wish an event to fire when nwn is checking if the creature has Epic Dodge you would perform
+    the following functions on_module_load.
+    ```c
+    NWNX_Events_SubscribeEvent("NWNX_ON_HAS_FEAT_BEFORE", "event_has_feat");
+    NWNX_Events_AddIDToWhitelist("NWNX_ON_HAS_FEAT", FEAT_EPIC_DODGE);
+    ```
+    @warning Toggling the Whitelist to be off for this event will degrade performance.
+_______________________________________
     ## DM Give Events
     - NWNX_ON_DM_GIVE_GOLD_BEFORE
     - NWNX_ON_DM_GIVE_GOLD_AFTER
@@ -1333,6 +1353,7 @@ void NWNX_Events_SkipEvent();
 /// - Trap events -> "1" or "0"
 /// - Sticky Player Name event -> "1" or "0"
 /// - Heal event -> Amount of HP to heal
+/// - Has Feat event -> "1" or "0"
 void NWNX_Events_SetEventResult(string data);
 
 /// Returns the current event name
@@ -1355,6 +1376,7 @@ void NWNX_Events_RemoveObjectFromDispatchList(string sEvent, string sScript, obj
 ///
 /// ONLY WORKS WITH THE FOLLOWING EVENTS -> ID TYPES:
 /// - NWNX_ON_CAST_SPELL -> SpellID
+/// - NWNX_ON_HAS_FEAT -> FeatID (default enabled)
 ///
 /// @note This enables the whitelist for ALL scripts subscribed to sEvent.
 /// @param sEvent The event name without _BEFORE / _AFTER.


### PR DESCRIPTION
This event is used to handle NWN's check on whether a PC has a feat allowing the builder to tailor some feats, especially those related to combat, to their needs

Note the `HAS_FEAT` EventData sends whether they truly have the feat or not.

This event enforces the whitelist by id system so as to not send every Has Feat check to scripting. Builders will have to set which feats they wish to handle with the whitelist.

For example if the builder didn't want Hide in Plain Sight to work in above ground areas during the day they could do the following:

**on_module_load:**

```c
    NWNX_Events_SubscribeEvent("NWNX_ON_HAS_FEAT_BEFORE", "event_has_feat");
    NWNX_Events_AddIDToWhitelist("NWNX_ON_HAS_FEAT", FEAT_HIDE_IN_PLAIN_SIGHT);
```

**event_has_feat:**

```c
#include "nwnx_events"

void main()
{
    object oPC = OBJECT_SELF;
    if (NWNX_Events_GetCurrentEvent() == "NWNX_ON_HAS_FEAT_BEFORE")
    {
        if (StringToInt(NWNX_Events_GetEventData("FEAT_ID")) == FEAT_HIDE_IN_PLAIN_SIGHT )
        {
            int bHasFeat = StringToInt(NWNX_Events_GetEventData("HAS_FEAT"));
            if (bHasFeat && GetIsDay() && GetIsAreaAboveGround(GetArea(oPC)))
            {
                SendMessageToPC(oPC, "Hiding in Plain Sight not possible.");
                NWNX_Events_SetEventResult("0");
                NWNX_Events_SkipEvent();
            }
        }
    }
}
```

Resolves #456 