### PR TITLE
Events: Rename Stealth events, add result to force/bypass HiPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ https://github.com/nwnxee/unified/compare/build8193.16...HEAD
 - Events: added `ACTION_RESULT` to Feat/Skill/Lock events for use in the _AFTER
 - Events: added Spell Interruption events to SpellEvents
 - Events: added Journal Open/Close events to JournalEvents
+- Events: Stealth Mode can now bypass or perform Hide in Plain Sight with return values of "0" or "1" respectively
 - Tweaks: `NWNX_TWEAKS_HIDE_PLAYERS_ON_CHAR_LIST`
 - Tweaks: `NWNX_TWEAKS_FIX_ARMOR_DEX_BONUS_UNDER_ONE`
 - Tweaks: `NWNX_TWEAKS_FIX_ITEM_NULLPTR_IN_CITEMREPOSITORY`
@@ -51,6 +52,7 @@ The following plugins were added:
 - We now only allow builds with the `CMAKE_BUILD_TYPE=RelWithDebInfo` configuration. `Debug` builds produce unexpected behaviour and `Release` builds are generally unnecessary and mess with Assert functionality.
 
 ### Deprecated
+- Events: Stealth Events have had their name changed from NWNX_ON_{ENTER|EXIT}_STEALTH_* to NWNX_ON_STEALTH_{ENTER|EXIT}_*. Please update your scripts as the old names will eventually be removed.
 - Tweaks: `NWNX_TWEAKS_HIDE_DMS_ON_CHAR_LIST` has been deprecated, use `NWNX_TWEAKS_HIDE_PLAYERS_ON_CHAR_LIST` now
 
 ### Removed

--- a/Plugins/Events/Events/StealthEvents.cpp
+++ b/Plugins/Events/Events/StealthEvents.cpp
@@ -1,5 +1,6 @@
 #include "Events/StealthEvents.hpp"
 #include "API/CNWSCreature.hpp"
+#include "API/CNWSCreatureStats.hpp"
 #include "API/Functions.hpp"
 #include "Utils.hpp"
 #include "Events.hpp"
@@ -15,7 +16,8 @@ static NWNXLib::Hooking::FunctionHook* s_DoListenDetectionHook;
 
 StealthEvents::StealthEvents(Services::HooksProxy* hooker)
 {
-    Events::InitOnFirstSubscribe("NWNX_ON_E.*_STEALTH_.*", [hooker]() {
+    // TODO: Deprecate ON_E*_STEALTH in favor of ON_STEALTH_E*
+    Events::InitOnFirstSubscribe("NWNX_ON_(E.*_STEALTH_.*|STEALTH_E.*)", [hooker]() {
         s_SetStealthModeHook = hooker->RequestExclusiveHook
             <API::Functions::_ZN12CNWSCreature14SetStealthModeEh>
             (&SetStealthModeHook);
@@ -38,23 +40,55 @@ void StealthEvents::SetStealthModeHook(CNWSCreature* thisPtr, uint8_t nStealthMo
 {
     const bool willBeStealthed = nStealthMode != 0;
     const bool currentlyStealthed = thisPtr->m_nStealthMode != 0;
+    std::string sResult;
 
     if (!currentlyStealthed && willBeStealthed)
     {
-        if (Events::SignalEvent("NWNX_ON_ENTER_STEALTH_BEFORE", thisPtr->m_idSelf))
+        // TODO: Deprecate ON_E*_STEALTH in favor of ON_STEALTH_E*
+        if (Events::SignalEvent("NWNX_ON_ENTER_STEALTH_BEFORE", thisPtr->m_idSelf) &&
+            Events::SignalEvent("NWNX_ON_STEALTH_ENTER_BEFORE", thisPtr->m_idSelf, &sResult))
         {
             s_SetStealthModeHook->CallOriginal<void>(thisPtr, nStealthMode);
         }
         else
         {
-            thisPtr->ClearActivities(1);
+            if (sResult == "0")
+            {
+                bool bHadHIPS = false;
+                if (thisPtr->m_pStats->HasFeat(Constants::Feat::HideInPlainSight))
+                {
+                    thisPtr->m_pStats->RemoveFeat(Constants::Feat::HideInPlainSight);
+                    bHadHIPS = true;
+                }
+                s_SetStealthModeHook->CallOriginal<void>(thisPtr, nStealthMode);
+                if (bHadHIPS)
+                    thisPtr->m_pStats->AddFeat(Constants::Feat::HideInPlainSight);
+            }
+            else if (sResult == "1")
+            {
+                bool bNoHIPS = false;
+                if (!thisPtr->m_pStats->HasFeat(Constants::Feat::HideInPlainSight))
+                {
+                    thisPtr->m_pStats->AddFeat(Constants::Feat::HideInPlainSight);
+                    bNoHIPS = true;
+                }
+                s_SetStealthModeHook->CallOriginal<void>(thisPtr, nStealthMode);
+                if (bNoHIPS)
+                    thisPtr->m_pStats->RemoveFeat(Constants::Feat::HideInPlainSight);
+            }
+            else
+                thisPtr->ClearActivities(1);
         }
 
+        // TODO: Deprecate ON_E*_STEALTH in favor of ON_STEALTH_E*
         Events::SignalEvent("NWNX_ON_ENTER_STEALTH_AFTER", thisPtr->m_idSelf);
+        Events::SignalEvent("NWNX_ON_STEALTH_ENTER_AFTER", thisPtr->m_idSelf);
     }
     else if(currentlyStealthed && !willBeStealthed)
     {
-        if (Events::SignalEvent("NWNX_ON_EXIT_STEALTH_BEFORE", thisPtr->m_idSelf))
+        // TODO: Deprecate ON_E*_STEALTH in favor of ON_STEALTH_E*
+        if (Events::SignalEvent("NWNX_ON_EXIT_STEALTH_BEFORE", thisPtr->m_idSelf) &&
+            Events::SignalEvent("NWNX_ON_STEALTH_EXIT_BEFORE", thisPtr->m_idSelf))
         {
             s_SetStealthModeHook->CallOriginal<void>(thisPtr, nStealthMode);
         }
@@ -63,7 +97,9 @@ void StealthEvents::SetStealthModeHook(CNWSCreature* thisPtr, uint8_t nStealthMo
             thisPtr->SetActivity(1, true);
         }
 
+        // TODO: Deprecate ON_E*_STEALTH in favor of ON_STEALTH_E*
         Events::SignalEvent("NWNX_ON_EXIT_STEALTH_AFTER", thisPtr->m_idSelf);
+        Events::SignalEvent("NWNX_ON_STEALTH_EXIT_AFTER", thisPtr->m_idSelf);
     }
 }
 

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -23,13 +23,14 @@ __________________________________________
 
 _______________________________________
     ## Stealth Events
-    - NWNX_ON_ENTER_STEALTH_BEFORE
-    - NWNX_ON_ENTER_STEALTH_AFTER
-    - NWNX_ON_EXIT_STEALTH_BEFORE
-    - NWNX_ON_EXIT_STEALTH_AFTER
+    - NWNX_ON_STEALTH_ENTER_BEFORE
+    - NWNX_ON_STEALTH_ENTER_AFTER
+    - NWNX_ON_STEALTH_EXIT_BEFORE
+    - NWNX_ON_STEALTH_EXIT_AFTER
 
     `OBJECT_SELF` = The creature entering or exiting stealth.
 
+    @note NWNX_ON_{ENTER|EXIT}_STEALTH_{BEFORE|AFTER} has been deprecated. Please use these new event names.
 _______________________________________
     ## Examine Events
     - NWNX_ON_EXAMINE_OBJECT_BEFORE
@@ -1345,6 +1346,7 @@ void NWNX_Events_SkipEvent();
 /// - Trap events -> "1" or "0"
 /// - Sticky Player Name event -> "1" or "0"
 /// - Heal event -> Amount of HP to heal
+/// - Stealth event -> "1" to perform HiPS (without the feat), "0" to bypass HiPS
 void NWNX_Events_SetEventResult(string data);
 
 /// Returns the current event name


### PR DESCRIPTION
As discussed in #817 it's probably better if the Stealth events are named NWNX_ON_STEALTH_* instead of NWNX_ON_{ENTER|EXIT}_STEALTH so they have been changed, while still supporting the old names for a while. (Though if you use both you'll have them fire both times, so don't use both)

Additionally, I added the ability to bypass or perform Hide In Plain Sight by setting an event result. Basically it just momentarily gives the actor the HiPS feat before and removes it right after the entrance to Stealth Mode.

Here is an example if you wanted to give Epic Rangers a Wilderness Hide in Plain Sight when above ground and outdoors:
```c
#include "nwnx_events"

void main()
{
    object oPC = OBJECT_SELF;
    if (NWNX_Events_GetCurrentEvent() == "NWNX_ON_STEALTH_ENTER_BEFORE")
    {
        object oArea = GetArea(oPC);
        if (GetHasFeat(FEAT_EPIC_RANGER, oPC) && GetIsAreaNatural(oArea) && !GetIsAreaInterior(oArea))
        {
            SendMessageToPC(oPC, "Using Wilderness Hide in Plain Sight");
            NWNX_Events_SetEventResult("1");
            NWNX_Events_SkipEvent();
        }
    }
}
```