### PR TITLE
Events: Adds Combat Enter/Exit events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ https://github.com/nwnxee/unified/compare/build8193.16...HEAD
 - Events: added `ACTION_RESULT` to Feat/Skill/Lock events for use in the _AFTER
 - Events: added Spell Interruption events to SpellEvents
 - Events: added Journal Open/Close events to JournalEvents
+- Events: added Combat Enter/Exit events to CombatEvents
 - Tweaks: `NWNX_TWEAKS_HIDE_PLAYERS_ON_CHAR_LIST`
 - Tweaks: `NWNX_TWEAKS_FIX_ARMOR_DEX_BONUS_UNDER_ONE`
 - Tweaks: `NWNX_TWEAKS_FIX_ITEM_NULLPTR_IN_CITEMREPOSITORY`

--- a/Plugins/Events/Events/CombatEvents.hpp
+++ b/Plugins/Events/Events/CombatEvents.hpp
@@ -14,6 +14,7 @@ public:
 private:
     static void StartCombatRoundHook(bool, CNWSCombatRound*, uint32_t);
     static int32_t ApplyDisarmHook(CNWSEffectListHandler*, CNWSObject *, CGameEffect *, BOOL);
+    static void SendServerToPlayerAmbientBattleMusicPlayHook(bool, CNWSMessage*, PlayerID oidPlayer, BOOL bPlay);
 };
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -473,6 +473,17 @@ _______________________________________
     You can optionally pass a reason for this in the event result.
 
 _______________________________________
+    ## CombatEnter/Exit Events
+    - NWNX_ON_COMBAT_ENTER_BEFORE
+    - NWNX_ON_COMBAT_ENTER_AFTER
+    - NWNX_ON_COMBAT_EXIT_BEFORE
+    - NWNX_ON_COMBAT_EXIT_AFTER
+
+    `OBJECT_SELF` = The player entering/exiting combat.
+
+    @note Only works for PCs.
+
+_______________________________________
     ## Combat Round Start Events
     - NWNX_ON_START_COMBAT_ROUND_BEFORE
     - NWNX_ON_START_COMBAT_ROUND_AFTER


### PR DESCRIPTION
As requested in #817 - only works for PCs. Hooks into the message from the server to the client to start playing battle music.