### PR TITLE
Player: Added an optional duration parameter to ApplyLoopingVisualEffectToObject()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The following plugins were added:
 - Events: `NWNX_ON_DM_SPAWN_OBJECT_*` now provides the resref as event data.
 - Events: `NWNX_ON_STORE_REQUEST_*_AFTER` now provides the result as event data.
 - Events: ResourceEvents now support valid custom resource directory aliases.
+- Player: added an optional duration parameter to ApplyLoopingVisualEffectToObject()
 - Util: added an optional appearance type parameter to CreateDoor()
 - Util: AddScript(), AddNSSFile() and RemoveNWNXResourceFile() now support valid custom resource directory aliases.
 - Visibility: added two new visibility types to always show an object regardless of range.

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -236,9 +236,10 @@ void NWNX_Player_SetObjectVisualTransformOverride(object oPlayer, object oObject
 /// @param player The player object.
 /// @param target The target object.
 /// @param visualeffect A VFX_DUR_*. Calling again will remove an applied effect. -1 to remove all effects
+/// @param fDuration An optional duration in seconds for the effect to last, or 0.0f for forever.
 /// @note Only really works with looping effects: VFX_DUR_*. Other types *kind* of work, they'll play when
 /// reentering the area and the object is in view or when they come back in view range.
-void NWNX_Player_ApplyLoopingVisualEffectToObject(object player, object target, int visualeffect);
+void NWNX_Player_ApplyLoopingVisualEffectToObject(object player, object target, int visualeffect, float fDuration = 0.0f);
 
 /// @brief Override the name of placeable for player only
 /// @param player The player object.
@@ -707,10 +708,11 @@ void NWNX_Player_SetObjectVisualTransformOverride(object oPlayer, object oObject
     NWNX_CallFunction(NWNX_Player, sFunc);
 }
 
-void NWNX_Player_ApplyLoopingVisualEffectToObject(object player, object target, int visualeffect)
+void NWNX_Player_ApplyLoopingVisualEffectToObject(object player, object target, int visualeffect, float fDuration)
 {
     string sFunc = "ApplyLoopingVisualEffectToObject";
 
+    NWNX_PushArgumentFloat(NWNX_Player, sFunc, fDuration);
     NWNX_PushArgumentInt(NWNX_Player, sFunc, visualeffect);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, target);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, player);


### PR DESCRIPTION
Resolves #847 - This just checks for an expiry when doing the `ComputeGameObjectUpdateForObject` which is about 5-6 times a second when the object is in view.

About halfway through I realized you could just make an nss wrapper like below to do the same thing but I guess this is more convenient.
```c
void ApplyLoopingVisualEffectToObjectDuration(object oPC, object oObject, int vfx, float fDuration)
{
    NWNX_Player_ApplyLoopingVisualEffectToObject(oPC, oObject, vfx);
    DelayCommand(fDuration, NWNX_Player_ApplyLoopingVisualEffectToObject(oPC, oObject, vfx));
}
```