### PR TITLE
Player: Don't remove the effect from the TURD while inside the loop

### DIFF
--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -1664,14 +1664,16 @@ ArgumentStack Player::RemoveEffectFromTURD(ArgumentStack&& args)
 
         if (pTURD && pTURD->m_oidPlayer == oidPlayer)
         {
+            std::vector<uint64_t> remove(128);
             for (int i = 0; i < pTURD->m_appliedEffects.num; i++)
             {
                 auto *pEffect = pTURD->m_appliedEffects.element[i];
 
                 if (pEffect->m_sCustomTag == effectTag)
-                    pTURD->RemoveEffect(pEffect);
+                    remove.push_back(pEffect->m_nID);
             }
-
+            for (auto id: remove)
+                pTURD->RemoveEffectById(id);
             break;
         }
     }


### PR DESCRIPTION
We use this remove effect by tag loop a few times, wonder if we should throw it in Utils or something.