### PR TITLE
CI: Use GHA for our builder factory now too. - Add missing libmysqlclient20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,14 +7,16 @@ on:
     paths-ignore:
       - '**.md'
       - 'docgen/**'
-      - .circleci/**
+      - '.circleci/**'
+      - 'builder.Dockerfile'
   pull_request:
     branches:
       - master
     paths-ignore:
       - '**.md'
       - 'docgen/**'
-      - .circleci/**
+      - '.circleci/**'
+      - 'builder.Dockerfile'
 
 env:
   CC: gcc-7 -m64
@@ -188,7 +190,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./
-          file: ./Dockerfile-gha
+          file: ./gha.Dockerfile
           push: true
           tags: |
             ${{ github.repository }}:latest

--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -1,0 +1,59 @@
+name: Build Docker Builder Factory
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'builder.Dockerfile'
+      - '**docker-builder.yml'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'builder.Dockerfile'
+      - '**docker-builder.yml'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set outputs
+      id: vars
+      run: |
+        echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ secrets.GHCR_USERNAME }}
+        password: ${{ secrets.CR_PAT }}
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./builder.Dockerfile
+        push: true
+        tags: |
+          ${{ github.repository_owner }}/builder:latest
+          ${{ github.repository_owner }}/builder:${{ steps.vars.outputs.sha_short }}
+          ghcr.io/${{ github.repository_owner }}/builder:latest
+          ghcr.io/${{ github.repository_owner }}/builder:${{ steps.vars.outputs.sha_short }}
+
+    - name: Image digest
+      run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# This image is for users who wish to build their images themselves. It uses the builder factory that is created
+# via the builder.Dockerfile
+
 FROM nwnxee/builder as builder
 WORKDIR /nwnx/home
 COPY ./ .

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY --from=builder /nwnx/home/Binaries/* /nwn/nwnx/
 
 # Install plugin run dependencies
 RUN runDeps="hunspell \
+    libmysqlclient20 \
     libmariadb3 \
     libpq5 \
     libsqlite3-0 \

--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,0 +1,28 @@
+# This image serves as the factory for compiling the sources, and must be updated whenever the
+# build dependencies change. This docker image created is pushed to Dockerhub and GHCR and is the base
+# image when users build their own docker images for NWNX:EE.
+
+FROM debian:buster-slim
+LABEL maintainer "jakobknutsen@gmail.com"
+
+RUN buildDeps="build-essential \
+    git \
+    ssh-client \
+    zip \
+    cmake \
+    gperf \
+    gcc-7 \
+    g++-7 \
+    default-libmysqlclient-dev \
+    libpq-dev \
+    libsqlite3-dev \
+    libseccomp-dev \
+    ruby-dev \
+    libssl-dev \
+    libhunspell-dev \
+    pkg-config \
+    libluajit-5.1-dev" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends $buildDeps \
+    && apt-get clean \
+    && rm -r /var/lib/apt/lists /var/cache/apt

--- a/gha.Dockerfile
+++ b/gha.Dockerfile
@@ -1,3 +1,6 @@
+# This image is created after a Github Actions build, we use the artifacts from
+# that build instead of rebuilding from source again then push our image to Dockerhub and GHCR.
+
 FROM beamdog/nwserver:8193.16
 RUN mkdir -p /nwn/nwnx
 COPY ./NWNX-EE.zip /nwn/nwnx

--- a/gha.Dockerfile
+++ b/gha.Dockerfile
@@ -7,6 +7,7 @@ COPY ./NWNX-EE.zip /nwn/nwnx
 
 # Install plugin run dependencies
 RUN runDeps="hunspell \
+    libmysqlclient20 \
     libmariadb3 \
     libpq5 \
     libsqlite3-0 \


### PR DESCRIPTION
- Rename Dockerfiles to use proper convention `<purpose>.Dockerfile`
- Add some comments to Dockerfile headers

This brings the building of the docker image for the builder factory into GitHub Actions and pushes the images to Dockerhub and GHCR. This means the [nwnxee/unified-docker-builder repository](https://github.com/nwnxee/unified-docker-builder) would no longer be needed and could be archived.