### PR TITLE
MaxLevel: Fix issue with plugin failing after a reload when Reload When Empty was set to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The following plugins were added:
 - Events: fixed a nullptr deref crash in BarterEvents
 - Feedback: fixed a bug where global combatlog and journal feedback message overrides couldn't be removed
 - MaxLevel: fixed bug interfering with leveling down NPCs
+- MaxLevel: fixed an issue with the plugin failing after a restart when reload-when-empty was set to true
 - Object: fixed a possible crash in CheckFit()
 - Player: fixed bic getting overwritten when using PossessCreature() and crashing in between areas
 - Race: fixed effect clean up after level up

--- a/Plugins/MaxLevel/MaxLevel.cpp
+++ b/Plugins/MaxLevel/MaxLevel.cpp
@@ -53,7 +53,7 @@ MaxLevel::MaxLevel(Services::ProxyServiceList* services)
     if (m_maxLevel > CORE_MAX_LEVEL)
     {
         GetServices()->m_hooks->RequestSharedHook<Functions::_ZN21CServerExoAppInternal24GetServerInfoFromIniFileEv, void, CServerExoAppInternal *>(&GetServerInfoFromIniFileHook);
-        GetServices()->m_hooks->RequestSharedHook<Functions::_ZN8CNWRules9ReloadAllEv, void, CNWRules *>(&ReloadAllHook);
+        GetServices()->m_hooks->RequestSharedHook<Functions::_ZN10CNWSModule15LoadModuleStartE10CExoStringii, void, CNWSModule*, CExoString, int32_t, int32_t>(&LoadModuleStartHook);
         GetServices()->m_hooks->RequestExclusiveHook<Functions::_ZN17CNWSCreatureStats10CanLevelUpEv>(&CanLevelUpHook);
         GetServices()->m_hooks->RequestExclusiveHook<Functions::_ZN17CNWSCreatureStats22GetExpNeededForLevelUpEv>(&GetExpNeededForLevelUpHook);
         m_LevelDownHook = GetServices()->m_hooks->RequestExclusiveHook<Functions::_ZN17CNWSCreatureStats9LevelDownEP13CNWLevelStats>(&LevelDownHook);
@@ -78,9 +78,9 @@ void MaxLevel::GetServerInfoFromIniFileHook(bool before, CServerExoAppInternal* 
 }
 
 // After Rules aggregates all its information we add to our custom experience table map
-void MaxLevel::ReloadAllHook(bool before, CNWRules* pRules)
+void MaxLevel::LoadModuleStartHook(bool before, CNWSModule *pModule, CExoString, int32_t, int32_t)
 {
-    if (before || !pRules)
+    if (before || !pModule)
         return;
 
     auto *twoda = Globals::Rules()->m_p2DArrays->GetCached2DA("EXPTABLE", true);
@@ -100,6 +100,8 @@ void MaxLevel::ReloadAllHook(bool before, CNWRules* pRules)
             g_plugin->m_nExperienceTableAdded[i] = xpLevel;
         }
     }
+    if (g_plugin->m_maxLevel > CORE_MAX_LEVEL)
+        LOG_INFO("Max Level increased to %d.", g_plugin->m_maxLevel);
 }
 
 // If level is greater than 40 seek the xp_threshold from our custom map

--- a/Plugins/MaxLevel/MaxLevel.hpp
+++ b/Plugins/MaxLevel/MaxLevel.hpp
@@ -21,7 +21,7 @@ private:
     NWNXLib::Hooking::FunctionHook* m_LevelDownHook;
     NWNXLib::Hooking::FunctionHook* m_SummonAssociateHook;
 
-    static void ReloadAllHook(bool, CNWRules* rules);
+    static void LoadModuleStartHook(bool before, CNWSModule *pModule, CExoString, int32_t, int32_t);
     static void LoadSpellGainTableHook(bool, CNWClass* pClass, CExoString *pTable);
     static void LoadSpellKnownTableHook(bool, CNWClass* pClass, CExoString *pTable);
     static uint8_t GetSpellGainHook(CNWClass*, uint8_t, uint8_t);


### PR DESCRIPTION
Closes #821 

Use LoadModuleStart for our hook instead of ReloadAll which would break MaxLevel when Reload When Empty was set to true or give an error message on clean shutdown.