### PR TITLE
CI: Add base docker image which contains all the run deps

### DIFF
--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -9,7 +9,8 @@ on:
       - '**docker-base.yml'
       - '**run-server.patch'
       - 'CMakeLists.txt'
-
+  schedule:
+    - cron: '5 4 15 * *'
 jobs:
   docker-base:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -1,0 +1,66 @@
+name: Build Docker NWNXEE Base Image
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'base.Dockerfile'
+      - '**docker-base.yml'
+      - '**run-server.patch'
+      - 'CMakeLists.txt'
+
+jobs:
+  docker-base:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set outputs
+      id: vars
+      run: |
+        echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        echo "::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+        echo "::set-output name=nwn_build::$(grep 'set(TARGET_NWN_BUILD ' CMakeLists.txt | cut -d' ' -f2 | sed 's/)//')"
+        echo "::set-output name=nwn_build_revision::$(grep 'set(TARGET_NWN_BUILD_REVISION ' CMakeLists.txt | cut -d' ' -f2 | sed 's/)//')"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ secrets.GHCR_USERNAME }}
+        password: ${{ secrets.CR_PAT }}
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./base.Dockerfile
+        build-args: BD_NWSERVER_IMAGE=beamdog/nwserver:${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}
+        push: true
+        labels: |
+          org.opencontainers.image.title=NWNX:EE Base
+          org.opencontainers.image.description=This image is the base for NWNX:EE, it includes all the dependencies required to run NWNX and all plugins. It is used as an intermediary container before the freshly built binaries are placed.
+          org.opencontainers.image.author=NWNX:EE Community
+          org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
+          org.opencontainers.image.created=${{ steps.vars.outputs.created }}
+          org.opencontainers.image.revision=${{ github.sha }}
+        tags: |
+          ${{ github.repository_owner }}/nwnxee-base:latest
+          ${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}
+          ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest
+          ghcr.io/${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}
+
+    - name: Image digest
+      run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -1,6 +1,7 @@
 name: Build Docker NWNXEE Base Image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,0 +1,34 @@
+# This image is the base for NWNX:EE, it includes all the dependencies required to run NWNX and all plugins. It
+# is used as an intermediary image before the freshly built binaries are dropped in.
+
+ARG BD_NWSERVER_IMAGE=beamdog/nwserver
+FROM $BD_NWSERVER_IMAGE
+RUN mkdir -p /nwn/nwnx
+
+# Install plugin run dependencies
+RUN runDeps="hunspell \
+    default-libmysqlclient-dev \
+    libmariadb3 \
+    libpq5 \
+    libsqlite3-0 \
+    libruby2.5 \
+    luajit libluajit-5.1 \
+    libssl1.1 \
+    inotify-tools \
+    patch \
+    unzip \
+    dotnet-runtime-5.0 \
+    dotnet-apphost-pack-5.0" \
+    installDeps="ca-certificates wget" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends $installDeps \
+    && wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends $runDeps \
+    && ln -s /usr/lib/x86_64-linux-gnu/libhunspell-?.*.so /usr/lib/x86_64-linux-gnu/libhunspell.so \
+    && rm -rf /var/cache/apt /var/lib/apt/lists/*
+
+# Patch run-server.sh with our modifications
+COPY ./Scripts/Docker/run-server.patch /nwn
+RUN patch /nwn/run-server.sh < /nwn/run-server.patch


### PR DESCRIPTION
This image is an intermediary docker image layer of run dependencies for NWNX. It parses the `CMakeLists.txt` to know which version nwnx is using and thus which version of beamdog/nwnserver to use as the `FROM`. The benefit to using this layer is whenever just nwnx .so's change the end users only download that one layer of .so's instead of downloading these build deps continually.

The only time this `base.Dockerfile` image should need to be updated is when the run dependencies need to be updated. 

It also includes new labels as specified by the OCI standard.