### PR TITLE
CI: Update Dockerfiles to use new base image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
       run: |
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
           echo "/usr/lib/ccache" >> $GITHUB_PATH
+          echo "::set-output name=nwn_build::$(grep 'set(TARGET_NWN_BUILD ' CMakeLists.txt | cut -d' ' -f2 | sed 's/)//')"
+          echo "::set-output name=nwn_build_revision::$(grep 'set(TARGET_NWN_BUILD_REVISION ' CMakeLists.txt | cut -d' ' -f2 | sed 's/)//')"
 
     - name: Cache Additional Dependencies
       uses: actions/cache@v2
@@ -148,7 +150,7 @@ jobs:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "latest"
         prerelease: false
-        title: "Development Build"
+        title: "build${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-HEAD"
         files: |
            ./NWNX-EE.zip
            ./NWScript.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,11 @@ jobs:
       working-directory: ${{runner.workspace}}/unified/Binaries
       run: cmake -E tar cfv ../NWNX-EE.zip --format=zip .
 
+    - name: Pack the Binaries for Docker
+      if: github.event_name == 'push'
+      working-directory: ${{runner.workspace}}/unified/Binaries
+      run: cmake -E tar cfv ../NWNX-EE.tar .
+
     - name: Pack the Scripts
       if: github.event_name == 'push'
       working-directory: ${{runner.workspace}}/unified
@@ -130,18 +135,25 @@ jobs:
       run: zip -j ./NWScript.zip `find . -name "*.nss" | grep -Pv '_t+[0-9]{0,1}.nss'`
 
     - name: Upload Binaries
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       if: github.event_name == 'push'
       with:
        path: ./NWNX-EE.zip
        name: NWNX-EE.zip
 
     - name: Upload Scripts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       if: github.event_name == 'push'
       with:
         path: ./NWScript.zip
         name: NWScript.zip
+
+    - name: Upload Tar Binaries for Docker
+      uses: actions/upload-artifact@v2
+      if: github.event_name == 'push'
+      with:
+        name: NWNX-EE.tar
+        path: ./NWNX-EE.tar
 
     - name: Deploy Latest Development Build
       uses: "marvinpinto/action-automatic-releases@latest"
@@ -164,12 +176,14 @@ jobs:
 
       - name: Set outputs
         id: vars
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: |
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
       - name: Download Binaries
         uses: actions/download-artifact@v2
         with:
-          name: NWNX-EE.zip
+          name: NWNX-EE.tar
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -194,6 +208,16 @@ jobs:
           context: ./
           file: ./gha.Dockerfile
           push: true
+          build-args: NWNXEE_BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/nwnxee-base
+          labels: |
+              org.opencontainers.image.title=NWNX:EE
+              org.opencontainers.image.description=This is the NWNX:EE image. NWNX:EE is a framework that developers can use to modify existing hardcoded rules or inject brand new functionality into Neverwinter Nights: Enhanced edition.
+              org.opencontainers.image.author=NWNX:EE Community
+              org.opencontainers.image.vendor=NWNX:EE Community
+              org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
+              org.opencontainers.image.created=${{ steps.vars.outputs.created }}
+              org.opencontainers.image.revision=${{ github.sha }}
+              org.opencontainers.image.documentation=https://nwnxee.github.io/unified
           tags: |
             ${{ github.repository }}:latest
             ${{ github.repository }}:${{ steps.vars.outputs.sha_short }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       id: dependencies-cache
       with:
         path: "~/dependencies"
-        key: dependencies-6
+        key: dependencies-2020-11-16
 
     - name: Install Cache Additional Dependencies
       env:
@@ -48,9 +48,9 @@ jobs:
         if [[ "$CACHE_HIT" == 'true' ]]; then
           sudo cp --force --recursive ~/dependencies/* /
         else
-          sudo apt-get install libhunspell-dev libluajit-5.1-dev ccache libmariadbclient-dev-compat
+          sudo apt-get install libhunspell-dev libluajit-5.1-dev ccache libmariadb-dev-compat
           mkdir -p ~/dependencies
-          for dep in libhunspell-dev libluajit-5.1-dev ccache libmariadbclient-dev-compat; do
+          for dep in libhunspell-dev libluajit-5.1-dev ccache libmariadb-dev-compat libluajit-5.1-2 libluajit-5.1-common libmariadb-dev libmariadb-dev-compat libmariadb3; do
               dpkg -L $dep | while IFS= read -r f; do if test -f $f; then echo $f; fi; done | xargs cp --parents --target-directory ~/dependencies/
           done
         fi

--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -7,15 +7,9 @@ on:
     paths:
       - 'builder.Dockerfile'
       - '**docker-builder.yml'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'builder.Dockerfile'
-      - '**docker-builder.yml'
 
 jobs:
-  docker:
+  docker-builder:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
@@ -25,6 +19,7 @@ jobs:
       id: vars
       run: |
         echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        echo "::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -49,6 +44,13 @@ jobs:
         context: ./
         file: ./builder.Dockerfile
         push: true
+        labels: |
+          org.opencontainers.image.title=NWNX:EE Builder Factory
+          org.opencontainers.image.description=This image serves as the factory for compiling the sources, and must be updated whenever the build dependencies change. This docker image created is pushed to Dockerhub and GHCR and is the base image when users build their own docker images for NWNX:EE.
+          org.opencontainers.image.author=NWNX:EE Community
+          org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
+          org.opencontainers.image.created=${{ steps.vars.outputs.created }}
+          org.opencontainers.image.revision=${{ github.sha }}
         tags: |
           ${{ github.repository_owner }}/builder:latest
           ${{ github.repository_owner }}/builder:${{ steps.vars.outputs.sha_short }}

--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -3,7 +3,6 @@
 # image when users build their own docker images for NWNX:EE.
 
 FROM debian:buster-slim
-LABEL maintainer "jakobknutsen@gmail.com"
 
 RUN buildDeps="build-essential \
     git \

--- a/gha.Dockerfile
+++ b/gha.Dockerfile
@@ -1,39 +1,10 @@
-# This image is created after a Github Actions build, we use the artifacts from
+# This image is created after a Github Actions build and should only be used then. We use the artifacts from
 # that build instead of rebuilding from source again then push our image to Dockerhub and GHCR.
 
-FROM beamdog/nwserver:8193.16
+ARG NWNXEE_BASE_IMAGE=nwnxee/nwnxee-base
+FROM $NWNXEE_BASE_IMAGE
 RUN mkdir -p /nwn/nwnx
-COPY ./NWNX-EE.zip /nwn/nwnx
-
-# Install plugin run dependencies
-RUN runDeps="hunspell \
-    libmariadb3 \
-    libpq5 \
-    libsqlite3-0 \
-    libruby2.5 \
-    luajit libluajit-5.1 \
-    libssl1.1 \
-    inotify-tools \
-    patch \
-    unzip \
-    dotnet-runtime-5.0 \
-    dotnet-apphost-pack-5.0" \
-    installDeps="ca-certificates wget" \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends $installDeps \
-    && wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-    && dpkg -i packages-microsoft-prod.deb \
-    && apt-get update \
-    && apt-get -y install --no-install-recommends $runDeps \
-    && ln -s /usr/lib/x86_64-linux-gnu/libmariadb.so.3 /usr/lib/x86_64-linux-gnu/libmariadbclient.so.18 \
-    && rm -rf /var/cache/apt /var/lib/apt/lists/*
-
-# Unzip the built binaries from Github Actions
-RUN unzip /nwn/nwnx/NWNX-EE.zip -d /nwn/nwnx && rm /nwn/nwnx/NWNX-EE.zip
-
-# Patch run-server.sh with our modifications
-COPY ./Scripts/Docker/run-server.patch /nwn
-RUN patch /nwn/run-server.sh < /nwn/run-server.patch
+ADD ./NWNX-EE.tar /nwn/nwnx
 
 # Configure nwserver to run with nwnx
 ENV NWNX_CORE_LOAD_PATH=/nwn/nwnx/


### PR DESCRIPTION
Also includes:
- label our builds build8193.16-HEAD for example
- building against libmariadb and not libmariadbclient and caching all deps properly
- using ADD instead of COPY so docker only needs one new layer as it auto-extracts the tar
- OCI labels

Note: This Pull Request build will break due to needing the changes from PR #1147 