### PR TITLE
CI: Use both latest and buildVVVV.VV-HEAD tags on pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,19 @@ jobs:
         name: NWNX-EE.tar
         path: ./NWNX-EE.tar
 
-    - name: Deploy Latest Development Build
+    - name: Tag With Version and Release
+      uses: "marvinpinto/action-automatic-releases@latest"
+      if: github.event_name == 'push'
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "build${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-HEAD"
+        prerelease: false
+        title: "build${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-HEAD"
+        files: |
+          ./NWNX-EE.zip
+          ./NWScript.zip
+
+    - name: Tag With Latest and Release
       uses: "marvinpinto/action-automatic-releases@latest"
       if: github.event_name == 'push'
       with:

--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -1,13 +1,15 @@
 name: Build Docker Builder Factory
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
     paths:
       - 'builder.Dockerfile'
       - '**docker-builder.yml'
-
+  schedule:
+    - cron: '5 4 14 * *'
 jobs:
   docker-builder:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Also added the docker builder workflow to be able to be manually triggered and scheduled monthly.