### PR TITLE
Tweaks: Add NWNX_TWEAKS_CLEAR_SPELL_EFFECTS_ON_TURDS 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ https://github.com/nwnxee/unified/compare/build8193.16...HEAD
 - Tweaks: `NWNX_TWEAKS_HIDE_PLAYERS_ON_CHAR_LIST`
 - Tweaks: `NWNX_TWEAKS_FIX_ARMOR_DEX_BONUS_UNDER_ONE`
 - Tweaks: `NWNX_TWEAKS_FIX_ITEM_NULLPTR_IN_CITEMREPOSITORY`
+- Tweaks: `NWNX_TWEAKS_CLEAR_SPELL_EFFECTS_ON_TURDS`
 
 ##### New Plugins
 The following plugins were added:

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -1660,6 +1660,9 @@ ArgumentStack Player::RemoveEffectFromTURD(ArgumentStack&& args)
       ASSERT_OR_THROW(!effectTag.empty());
 
     auto *pTURDList = Utils::GetModule()->m_lstTURDList.m_pcExoLinkedListInternal;
+    if (!pTURDList)
+        return Services::Events::Arguments();
+
     for (auto *pNode = pTURDList->pHead; pNode; pNode = pNode->pNext)
     {
         auto *pTURD = static_cast<CNWSPlayerTURD*>(pNode->pObject);

--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -22,4 +22,5 @@ add_plugin(Tweaks
     "Tweaks/BlockDMSpawnItem.cpp"
     "Tweaks/FixArmorDexBonusUnderOne.cpp"
     "Tweaks/FixItemNullptrInCItemRepository.cpp"
+    "Tweaks/ClearSpellEffectsOnTURDs.cpp"
 )

--- a/Plugins/Tweaks/README.md
+++ b/Plugins/Tweaks/README.md
@@ -32,6 +32,7 @@ Tweaks stuff. See below.
 * `NWNX_TWEAKS_BLOCK_DM_SPAWNITEM`: true or false
 * `NWNX_TWEAKS_FIX_ARMOR_DEX_BONUS_UNDER_ONE`: true or false
 * `NWNX_TWEAKS_FIX_ITEM_NULLPTR_IN_CITEMREPOSITORY`: true or false
+* `NWNX_TWEAKS_CLEAR_SPELL_EFFECTS_ON_TURDS`: true or false
 
 ## Environment variable values
 

--- a/Plugins/Tweaks/Tweaks.cpp
+++ b/Plugins/Tweaks/Tweaks.cpp
@@ -21,6 +21,7 @@
 #include "Tweaks/BlockDMSpawnItem.hpp"
 #include "Tweaks/FixArmorDexBonusUnderOne.hpp"
 #include "Tweaks/FixItemNullptrInCItemRepository.hpp"
+#include "Tweaks/ClearSpellEffectsOnTURDs.hpp"
 
 #include "Services/Config/Config.hpp"
 
@@ -182,6 +183,12 @@ Tweaks::Tweaks(Services::ProxyServiceList* services)
     {
         LOG_INFO("Will check for invalid items in the CItemRepository List.");
         m_FixItemNullptrInCItemRepository = std::make_unique<FixItemNullptrInCItemRepository>(GetServices()->m_hooks.get());
+    }
+
+    if (GetServices()->m_config->Get<bool>("CLEAR_SPELL_EFFECTS_ON_TURDS", false))
+    {
+        LOG_INFO("Effects on logged out users will be removed when a caster rests.");
+        m_ClearSpellEffectsOnTURDs = std::make_unique<ClearSpellEffectsOnTURDs>(GetServices()->m_hooks.get());
     }
 }
 

--- a/Plugins/Tweaks/Tweaks.hpp
+++ b/Plugins/Tweaks/Tweaks.hpp
@@ -27,6 +27,7 @@ class UnhardcodeShields;
 class BlockDMSpawnItem;
 class FixArmorDexBonusUnderOne;
 class FixItemNullptrInCItemRepository;
+class ClearSpellEffectsOnTURDs;
 
 class Tweaks : public NWNXLib::Plugin
 {
@@ -57,6 +58,7 @@ private:
     std::unique_ptr<BlockDMSpawnItem> m_BlockDMSpawnItem;
     std::unique_ptr<FixArmorDexBonusUnderOne> m_FixArmorDexBonusUnderOne;
     std::unique_ptr<FixItemNullptrInCItemRepository> m_FixItemNullptrInCItemRepository;
+    std::unique_ptr<ClearSpellEffectsOnTURDs> m_ClearSpellEffectsOnTURDs;
 };
 
 }

--- a/Plugins/Tweaks/Tweaks/ClearSpellEffectsOnTURDs.cpp
+++ b/Plugins/Tweaks/Tweaks/ClearSpellEffectsOnTURDs.cpp
@@ -23,6 +23,9 @@ void ClearSpellEffectsOnTURDs::CNWSObject__ClearSpellEffectsOnOthers_hook(bool b
     if (before)
     {
         auto *pTURDList = Utils::GetModule()->m_lstTURDList.m_pcExoLinkedListInternal;
+        if (!pTURDList)
+            return;
+
         for (auto *pNode = pTURDList->pHead; pNode; pNode = pNode->pNext)
         {
             auto *pTURD = static_cast<CNWSPlayerTURD*>(pNode->pObject);

--- a/Plugins/Tweaks/Tweaks/ClearSpellEffectsOnTURDs.cpp
+++ b/Plugins/Tweaks/Tweaks/ClearSpellEffectsOnTURDs.cpp
@@ -1,0 +1,48 @@
+#include "Tweaks/ClearSpellEffectsOnTURDs.hpp"
+#include "API/CNWSModule.hpp"
+#include "API/CNWSObject.hpp"
+#include "API/Functions.hpp"
+#include "API/Globals.hpp"
+
+#include "Services/Hooks/Hooks.hpp"
+
+
+namespace Tweaks {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+ClearSpellEffectsOnTURDs::ClearSpellEffectsOnTURDs(Services::HooksProxy* hooker)
+{
+    hooker->RequestSharedHook<Functions::_ZN10CNWSObject25ClearSpellEffectsOnOthersEv, uint32_t>(&CNWSObject__ClearSpellEffectsOnOthers_hook);
+}
+
+
+void ClearSpellEffectsOnTURDs::CNWSObject__ClearSpellEffectsOnOthers_hook(bool before, CNWSObject *pObject)
+{
+    if (before)
+    {
+        auto *pTURDList = Utils::GetModule()->m_lstTURDList.m_pcExoLinkedListInternal;
+        for (auto *pNode = pTURDList->pHead; pNode; pNode = pNode->pNext)
+        {
+            auto *pTURD = static_cast<CNWSPlayerTURD*>(pNode->pObject);
+
+            if (pTURD)
+            {
+                std::vector<uint64_t> remove(128);
+                for (int i = 0; i < pTURD->m_appliedEffects.num; i++)
+                {
+                    auto *pEffect = pTURD->m_appliedEffects.element[i];
+
+                    if (pEffect->m_oidCreator == pObject->m_idSelf)
+                        remove.push_back(pEffect->m_nID);
+                }
+                for (auto id: remove)
+                    pTURD->RemoveEffectById(id);
+            }
+        }
+    }
+}
+
+
+}

--- a/Plugins/Tweaks/Tweaks/ClearSpellEffectsOnTURDs.hpp
+++ b/Plugins/Tweaks/Tweaks/ClearSpellEffectsOnTURDs.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Common.hpp"
+#include "Services/Hooks/Hooks.hpp"
+
+namespace Tweaks {
+
+class ClearSpellEffectsOnTURDs
+{
+public:
+    ClearSpellEffectsOnTURDs(NWNXLib::Services::HooksProxy* hooker);
+
+private:
+    static void CNWSObject__ClearSpellEffectsOnOthers_hook(bool, CNWSObject*);
+};
+
+}


### PR DESCRIPTION
When a caster rests any spell effects on logged out users originating from that caster will be removed.