### PR TITLE
Experimental: Attempt to correct a crash involving faction/reputations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ https://github.com/nwnxee/unified/compare/build8193.16...HEAD
 - Events: added Combat Enter/Exit events to CombatEvents
 - Events: Stealth Mode can now bypass or perform Hide in Plain Sight with return values of "0" or "1" respectively
 - Events: Added Skippable/Result Changeable Faction Reputation event to FactionEvents
+- Experimental: Added `NWNX_EXPERIMENTAL_ADJUST_REPUTATION_FIX` in an effort to correct a crash with factions/reputation
 - Tweaks: `NWNX_TWEAKS_HIDE_PLAYERS_ON_CHAR_LIST`
 - Tweaks: `NWNX_TWEAKS_FIX_ARMOR_DEX_BONUS_UNDER_ONE`
 - Tweaks: `NWNX_TWEAKS_FIX_ITEM_NULLPTR_IN_CITEMREPOSITORY`

--- a/Plugins/Experimental/CMakeLists.txt
+++ b/Plugins/Experimental/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_plugin(Experimental
         "Experimental.cpp"
         "Experimentals/SuppressPlayerLoginInfo.cpp"
+        "Experimentals/AdjustReputationFix.cpp"
 )

--- a/Plugins/Experimental/Experimental.cpp
+++ b/Plugins/Experimental/Experimental.cpp
@@ -1,5 +1,6 @@
 #include "Experimental.hpp"
 #include "Experimentals/SuppressPlayerLoginInfo.hpp"
+#include "Experimentals/AdjustReputationFix.hpp"
 
 #include "Services/Config/Config.hpp"
 
@@ -23,6 +24,12 @@ Experimental::Experimental(Services::ProxyServiceList* services)
     {
         LOG_INFO("EXPERIMENTAL: Suppressing playerlist and player login/logout messages for non DMs.");
         m_SuppressPlayerLoginInfo = std::make_unique<SuppressPlayerLoginInfo>(GetServices()->m_hooks.get());
+    }
+
+    if (GetServices()->m_config->Get<bool>("ADJUST_REPUTATION_FIX", false))
+    {
+        LOG_INFO("EXPERIMENTAL: Attempting to resolve faction/reputation crash.");
+        m_AdjustReputationFix = std::make_unique<AdjustReputationFix>(GetServices()->m_hooks.get());
     }
 }
 

--- a/Plugins/Experimental/Experimental.hpp
+++ b/Plugins/Experimental/Experimental.hpp
@@ -5,6 +5,7 @@
 namespace Experimental {
 
 class SuppressPlayerLoginInfo;
+class AdjustReputationFix;
 
 class Experimental : public NWNXLib::Plugin
 {
@@ -14,6 +15,7 @@ public:
 
 private:
     std::unique_ptr<SuppressPlayerLoginInfo> m_SuppressPlayerLoginInfo;
+    std::unique_ptr<AdjustReputationFix> m_AdjustReputationFix;
 };
 
 }

--- a/Plugins/Experimental/Experimentals/AdjustReputationFix.cpp
+++ b/Plugins/Experimental/Experimentals/AdjustReputationFix.cpp
@@ -1,0 +1,52 @@
+#include "Experimentals/AdjustReputationFix.hpp"
+
+#include "Services/Hooks/Hooks.hpp"
+
+#include "API/CAppManager.hpp"
+#include "API/CFactionManager.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/CNWSCreatureStats.hpp"
+#include "API/CServerExoApp.hpp"
+#include "API/CServerExoAppInternal.hpp"
+#include "API/Functions.hpp"
+#include "API/Globals.hpp"
+
+namespace Experimental {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+AdjustReputationFix::AdjustReputationFix(Services::HooksProxy* hooker)
+{
+    hooker->RequestExclusiveHook<API::Functions::_ZN12CNWSCreature16AdjustReputationEii, void>(&CNWSCreature__AdjustReputation_Hook);
+}
+
+void AdjustReputationFix::CNWSCreature__AdjustReputation_Hook(CNWSCreature *pThis, int32_t nFactionId, int32_t nAdjustment)
+{
+    auto* pFactionManager = Globals::AppManager()->m_pServerExoApp->m_pcExoAppInternal->m_pFactionManager;
+
+    if (!pFactionManager->GetIsNPCFaction(nFactionId))
+        return;
+
+    if (pThis->m_bPlayerCharacter || pThis->GetIsPossessedFamiliar())
+    {
+        if (pThis->m_pReputation)
+        {
+            int32_t index = nFactionId - 1;
+            if (index >= 0 && index < pThis->m_pReputation->num)
+            {
+                pThis->m_pReputation->element[index] += nAdjustment;
+                pThis->m_pReputation->element[index] = std::clamp(pThis->m_pReputation->element[index], 0, 100);
+            }
+        }
+    }
+    else
+    {
+        if (pThis->m_pStats->m_nFactionId != nFactionId)
+        {
+            int32_t rep = pFactionManager->GetNPCFactionReputation(pThis->m_pStats->m_nFactionId, nFactionId);
+            pFactionManager->SetNPCFactionReputation(pThis->m_pStats->m_nFactionId, nFactionId, (rep + nAdjustment));
+        }
+    }
+}
+}

--- a/Plugins/Experimental/Experimentals/AdjustReputationFix.hpp
+++ b/Plugins/Experimental/Experimentals/AdjustReputationFix.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "Common.hpp"
+
+namespace Experimental {
+
+class AdjustReputationFix
+{
+public:
+    AdjustReputationFix(NWNXLib::Services::HooksProxy* hooker);
+
+private:
+    static void CNWSCreature__AdjustReputation_Hook(CNWSCreature*, int32_t, int32_t);
+};
+
+}

--- a/Plugins/Experimental/README.md
+++ b/Plugins/Experimental/README.md
@@ -15,3 +15,4 @@ The following environmental variable is required to load the plugin:
 | Variable Name | Value | Notes |
 | -------------   | :----: | ------------------------------------ |
 | `NWNX_EXPERIMENTAL_SUPPRESS_PLAYER_LOGIN_INFO` | true/false | Suppresses the playerlist and player login/logout messages for all players except DMs. This functionality is not compatible with NWNX_Rename. |
+| `NWNX_EXPERIMENTAL_ADJUST_REPUTATION_FIX` | true/false | Attempts to correct a crash involving faction/reputations. |


### PR DESCRIPTION
This may be related to #920 and #1106 

Users should enable the `NWNX_Experimental` plugin first with the following environment variables:
`NWNX_CORE_LOAD_EXPERIMENTAL_PLUGIN=y` 
`NWNX_EXPERIMENTAL_SKIP=n`
and then set the environment variable for this experimental tweak
`NWNX_EXPERIMENTAL_ADJUST_REPUTATION_FIX=y`