### PR TITLE
Initialize CNWCCMessageData using new CNWCCMessageData()

### DIFF
--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -1447,12 +1447,12 @@ ArgumentStack Player::FloatingTextStringOnCreature(ArgumentStack&& args)
         {
             if (auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage()))
             {
-                CNWCCMessageData messageData;
-                messageData.SetObjectID(0, pCreature->m_idSelf);
-                messageData.SetInteger(9, 94);
-                messageData.SetString(0, text);
+                auto *messageData = new CNWCCMessageData();
+                messageData->SetObjectID(0, pCreature->m_idSelf);
+                messageData->SetInteger(9, 94);
+                messageData->SetString(0, text);
 
-                pMessage->SendServerToPlayerCCMessage(pPlayer->m_nPlayerID, Constants::MessageClientSideMsgMinor::Feedback, &messageData, nullptr);
+                pMessage->SendServerToPlayerCCMessage(pPlayer->m_nPlayerID, Constants::MessageClientSideMsgMinor::Feedback, messageData, nullptr);
             }
         }
     }

--- a/Plugins/Race/Race.cpp
+++ b/Plugins/Race/Race.cpp
@@ -607,7 +607,7 @@ void Race::ResolveInitiativeHook(CNWSCreature *pCreature)
         auto *pPlayer = Globals::AppManager()->m_pServerExoApp->GetClientObjectByObjectId(pCreature->m_idSelf);
         if (pPlayer)
         {
-            auto *pData = new CNWCCMessageData;
+            auto *pData = new CNWCCMessageData();
             pData->SetInteger(0, diceRoll);
             pData->SetInteger(1, mod);
             pData->SetObjectID(0, pCreature->m_idSelf);

--- a/Plugins/Tweaks/Tweaks/FixDispelEffectLevels.cpp
+++ b/Plugins/Tweaks/Tweaks/FixDispelEffectLevels.cpp
@@ -45,8 +45,8 @@ int32_t FixDispelEffectLevels::CNWSEffectListHandler__OnApplyDispelAllMagic(CNWS
     }
 
     std::vector<uint64_t> nIgnoreEffectIDs;
-    CNWCCMessageData messageData;
-    messageData.SetObjectID(0, pObject->m_idSelf);
+    auto *messageData = new CNWCCMessageData();
+    messageData->SetObjectID(0, pObject->m_idSelf);
 
     for (auto* effect : pObject->m_appliedEffects)
     {
@@ -75,23 +75,23 @@ int32_t FixDispelEffectLevels::CNWSEffectListHandler__OnApplyDispelAllMagic(CNWS
             auto* pAIMaster = Globals::AppManager()->m_pServerExoApp->GetServerAIMaster();
             pAIMaster->AddEventDeltaTime(0, 0, pEffect->m_oidCreator, pObject->m_idSelf, Constants::Event::RemoveEffect, effect);
             if (effect->m_nSpellId != ~0u)
-                messageData.SetInteger(++nDispelledEffects, effect->m_nSpellId);
+                messageData->SetInteger(++nDispelledEffects, effect->m_nSpellId);
         }
 
         nIgnoreEffectIDs.push_back(effect->m_nID);
     }
 
-    messageData.SetInteger(0, nDispelledEffects);
+    messageData->SetInteger(0, nDispelledEffects);
     if (nDispelledEffects > 0)
     {
         if (auto* pPlayer = Globals::AppManager()->m_pServerExoApp->GetClientObjectByObjectId(pObject->m_idSelf))
             if (auto* pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage()))
-                pMessage->SendServerToPlayerCCMessage(pPlayer->m_nPlayerID, Constants::MessageClientSideMsgMinor::DispelMagic, &messageData, nullptr);
+                pMessage->SendServerToPlayerCCMessage(pPlayer->m_nPlayerID, Constants::MessageClientSideMsgMinor::DispelMagic, messageData, nullptr);
 
         if (pCreatorObject && pCreatorObject->m_idSelf != pObject->m_idSelf)
             if (auto* pPlayer = Globals::AppManager()->m_pServerExoApp->GetClientObjectByObjectId(pCreatorObject->m_idSelf))
                 if (auto* pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage()))
-                    pMessage->SendServerToPlayerCCMessage(pPlayer->m_nPlayerID, Constants::MessageClientSideMsgMinor::DispelMagic, &messageData, nullptr);
+                    pMessage->SendServerToPlayerCCMessage(pPlayer->m_nPlayerID, Constants::MessageClientSideMsgMinor::DispelMagic, messageData, nullptr);
     }
 
     return 1;
@@ -141,13 +141,13 @@ int32_t FixDispelEffectLevels::CNWSEffectListHandler__OnApplyDispelBestMagic(CNW
         {
             if (effect->m_nSpellId != ~0u)
             {
-                CNWCCMessageData messageData;
-                messageData.SetObjectID(0, pObject->m_idSelf);
-                messageData.SetInteger(0, 1);
-                messageData.SetInteger(1, effect->m_nSpellId);
+                auto *messageData = new CNWCCMessageData();
+                messageData->SetObjectID(0, pObject->m_idSelf);
+                messageData->SetInteger(0, 1);
+                messageData->SetInteger(1, effect->m_nSpellId);
                 if (auto* pPlayer = Globals::AppManager()->m_pServerExoApp->GetClientObjectByObjectId(pObject->m_idSelf))
                     if (auto* pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage()))
-                        pMessage->SendServerToPlayerCCMessage(pPlayer->m_nPlayerID, Constants::MessageClientSideMsgMinor::DispelMagic, &messageData, nullptr);
+                        pMessage->SendServerToPlayerCCMessage(pPlayer->m_nPlayerID, Constants::MessageClientSideMsgMinor::DispelMagic, messageData, nullptr);
             }
 
             auto* pAIMaster = Globals::AppManager()->m_pServerExoApp->GetServerAIMaster();

--- a/Plugins/Tweaks/Tweaks/SneakAttackCritImmunity.cpp
+++ b/Plugins/Tweaks/Tweaks/SneakAttackCritImmunity.cpp
@@ -154,7 +154,7 @@ void SneakAttackCritImmunity::CNWSCreature__ResolveSneakAttack_hook(CNWSCreature
     {
         if (pTarget->m_pStats->GetEffectImmunity(Constants::ImmunityType::SneakAttack, pThis, true))
         {
-            CNWCCMessageData* pData = new CNWCCMessageData;
+            auto *pData = new CNWCCMessageData();
             pData->SetObjectID(0, pTarget->m_idSelf);
             pData->SetInteger(0, 134);
             pAttackData->m_alstPendingFeedback.Add(pData);
@@ -271,7 +271,7 @@ void SneakAttackCritImmunity::CNWSCreature__ResolveDeathAttack_hook(CNWSCreature
     {
         if (pTarget->m_pStats->GetEffectImmunity(Constants::ImmunityType::SneakAttack, pThis, true))
         {
-            CNWCCMessageData* pData = new CNWCCMessageData;
+            auto *pData = new CNWCCMessageData();
             pData->SetObjectID(0, pTarget->m_idSelf);
             pData->SetInteger(0, 134);
             pAttackData->m_alstPendingFeedback.Add(pData);


### PR DESCRIPTION
I think this may have caused crashes

The constructor performs the following:
```c
  thisPtr->m_nParamInteger.num = 0;
  thisPtr->m_nParamInteger.array_size = 0;
  thisPtr->m_nParamInteger.element = 0;
  thisPtr->m_nParamFloat.num = 0;
  thisPtr->m_nParamFloat.array_size = 0;
  thisPtr->m_nParamFloat.element = 0;
  thisPtr->m_sParamString.num = 0;
  thisPtr->m_sParamString.array_size = 0;
  thisPtr->m_sParamString.element = 0;
  thisPtr->m_oidParamObjectID.num = 0;
  thisPtr->m_oidParamObjectID.array_size = 0;
  thisPtr->m_oidParamObjectID.element = 0;
  thisPtr->m_nType = 0;
```
The destructor attempts to access `v1 = thisPtr->m_sParamString.element;`

If we never set a single string element then wouldn't the destructor die on this nullptr ref? This would not have been an issue in say `NWNXPlayer::FloatingTextStringOnCreature` because there is a string set but in our two tweaks we never set even one string value.