### PR TITLE
Core: hook VM::RunScriptChunk instead of ExecuteScriptChunk for the NWNX Functions check in script chunks

### DIFF
--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -218,8 +218,8 @@ void NWNXCore::InitialSetupHooks()
 
     if (!m_coreServices->m_config->Get<bool>("ALLOW_NWNX_FUNCTIONS_IN_EXECUTE_SCRIPT_CHUNK", false))
     {
-        m_services->m_hooks->RequestSharedHook<API::Functions::_ZN25CNWVirtualMachineCommands32ExecuteCommandExecuteScriptChunkEii, int32_t>(
-                +[](bool before, CNWVirtualMachineCommands*, int32_t, int32_t)
+        m_services->m_hooks->RequestSharedHook<API::Functions::_ZN15CVirtualMachine14RunScriptChunkERK10CExoStringjii, int32_t>(
+                +[](bool before, CVirtualMachine*, const CExoString&, ObjectID, int32_t, int32_t)
                 {
                     g_core->m_ScriptChunkRecursion += before ? +1 : -1;
                 });


### PR DESCRIPTION
This broke when DMs got the ability to run script chunks through the debug menu. 