### PR TITLE
DotNET: Add getter for exported globals.

### DIFF
--- a/Plugins/DotNET/DotNET.cpp
+++ b/Plugins/DotNET/DotNET.cpp
@@ -219,6 +219,7 @@ DotNET::DotNET(Services::ProxyServiceList* services) : Plugin(services)
         args.push_back((void*)&nwnxPopEffect);
         args.push_back((void*)&nwnxPopItemProperty);
         args.push_back((void*)&nwnxCallFunction);
+        args.push_back((void*)&GetNWNXExportedGlobals);
     rc = bootstrap(args.data(), args.size()*sizeof(void*));
     if (rc != 0)
         LOG_FATAL("Failed to execute bootstrap function; rc=0x%x", rc);

--- a/Plugins/DotNET/DotNET.hpp
+++ b/Plugins/DotNET/DotNET.hpp
@@ -2,6 +2,7 @@
 
 #include "Plugin.hpp"
 #include "API/ALL_CLASSES.hpp"
+#include "API/Globals.hpp"
 
 namespace DotNET {
 
@@ -71,6 +72,7 @@ private:
     static CGameEffect* nwnxPopEffect();
     static CGameEffect* nwnxPopItemProperty();
     static void nwnxCallFunction();
+    static NWNXLib::API::Globals::NWNXExportedGlobals GetNWNXExportedGlobals();
 };
 
 

--- a/Plugins/DotNET/DotNETExports.cpp
+++ b/Plugins/DotNET/DotNETExports.cpp
@@ -369,5 +369,9 @@ void DotNET::nwnxCallFunction()
     auto events = Instance->GetServices()->m_events->GetProxyBase();
     events->Call(nwnxActivePlugin, nwnxActiveFunction);
 }
+NWNXLib::API::Globals::NWNXExportedGlobals DotNET::GetNWNXExportedGlobals()
+{
+    return NWNXLib::API::Globals::ExportedGlobals;
+}
 
 }

--- a/Plugins/DotNET/NWN/Internal/Bootstrap.cs
+++ b/Plugins/DotNET/NWN/Internal/Bootstrap.cs
@@ -21,6 +21,30 @@ namespace NWN
             public SignalHandlerDelegate    Signal;
         }
 
+        [SuppressUnmanagedCodeSecurity]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate NWNXExportedGlobals GetNWNXExportedGlobalsDelegate();
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct NWNXExportedGlobals
+        {
+            public IntPtr PSBuildNumber;
+            public IntPtr PSBuildRevision;
+            public IntPtr PPExoBase;
+            public IntPtr PPExoResMan;
+            public IntPtr PPVirtualMachine;
+            public IntPtr PPScriptCompiler;
+            public IntPtr PPAppManager;
+            public IntPtr PPTlkTable;
+            public IntPtr PPRules;
+            public IntPtr PPExoTaskManager;
+            public IntPtr PBEnableCombatDebugging;
+            public IntPtr PBEnableSavingThrowDebugging;
+            public IntPtr PBEnableMovementSpeedDebugging;
+            public IntPtr PBEnableHitDieDebugging;
+            public IntPtr PBExitProgram;
+        }
+
         [SuppressUnmanagedCodeSecurity][UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate IntPtr GetFunctionPointerDelegate(string name);
         [SuppressUnmanagedCodeSecurity][UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -146,6 +170,7 @@ namespace NWN
             public readonly nwnxPopEffectDelegate                 nwnxPopEffect;
             public readonly nwnxPopItemPropertyDelegate           nwnxPopItemProperty;
             public readonly nwnxCallFunctionDelegate              nwnxCallFunction;
+            public readonly GetNWNXExportedGlobalsDelegate        GetNWNXExportedGlobals;
         }
         public static BootstrapArgs NativeFunctions;
         private static AllHandlers _handlers;


### PR DESCRIPTION
Provides needed access for Native/Managed interop: https://github.com/nwn-dotnet/NWN.Core.Native