### PR TITLE
Extend Crit range/modifiers with BaseItem parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ https://github.com/nwnxee/unified/compare/build8193.20...HEAD
 - Util: {Get|Set}InstructionsExecuted();
 
 ### Changed
-- Creature: Functions for CriticalMultipler and CriticalRange extended to allow declaration of nBaseItem. Order of Overrides is Specified Baseitem > Specified Hand > non-Specified. Modifiers now apply in addition to overrides (rather than only in the absence of overrides)
+- Creature: Functions for CriticalMultipler and CriticalRange extended to allow declaration of nBaseItem. Order of Overrides is Specified Baseitem > Specified Hand > non-Specified. Modifiers now apply in addition to overrides (rather than only in the absence of overrides). _**ABI breaking:** You will need to update nwnx_creature.nss if you are using these functions_.
 
 ### Deprecated
 - Data: The NWNX_Data array implementation is deprecated. SQLite implementation available.  Shim include file provided for compatibility.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ https://github.com/nwnxee/unified/compare/build8193.20...HEAD
 - Util: {Get|Set}InstructionsExecuted();
 
 ### Changed
-- N/A
+- Creature: Functions for CriticalMultipler and CriticalRange extended to allow declaration of nBaseItem. Order of Overrides is Specified Baseitem > Specified Hand > non-Specified. Modifiers now apply in addition to overrides (rather than only in the absence of overrides)
 
 ### Deprecated
 - Data: The NWNX_Data array implementation is deprecated. SQLite implementation available.  Shim include file provided for compatibility.

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -2251,15 +2251,15 @@ void Creature::InitCriticalMultiplierHook()
                 if (!bOffHand) //mainhand
                 {
                     auto pItem = pThis->m_pBaseCreature->m_pInventory->GetItemInSlot(Constants::EquipmentSlot::RightHand);
-                    std::string nBaseItemID;
+                    std::string BaseItemID;
                     if (!pItem)
-                        nBaseItemID = "-1";
+                        BaseItemID = std::to_string(Constants::BaseItem::Gloves);
                     else
-                        nBaseItemID = std::to_string(pItem->m_nBaseItem);
+                        BaseItemID = std::to_string(pItem->m_nBaseItem);
 
-                    if (auto critMultOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_OVERRIDE!1!BI" + nBaseItemID))
+                    if (auto critMultOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_OVERRIDE!1!BI" + BaseItemID))
                         retVal = critMultOvr.value();
-                    else if (auto critMultOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_OVERRIDE!0!BI" + nBaseItemID))
+                    else if (auto critMultOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_OVERRIDE!0!BI" + BaseItemID))
                         retVal = critMultOvr.value();
                     else if (auto critMultOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_OVERRIDE!1"))
                         retVal = critMultOvr.value();
@@ -2269,9 +2269,9 @@ void Creature::InitCriticalMultiplierHook()
                         retVal = pGetCriticalHitMultiplier_hook->CallOriginal<int32_t>(pThis, bOffHand);
 
                     //Override-Modifier gap
-                    if (auto critMultMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_MODIFIER!1!BI" + nBaseItemID))
+                    if (auto critMultMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_MODIFIER!1!BI" + BaseItemID))
                         retVal = retVal + critMultMod.value();
-                    if (auto critMultMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_MODIFIER!0!BI" + nBaseItemID))
+                    if (auto critMultMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_MODIFIER!0!BI" + BaseItemID))
                         retVal = retVal + critMultMod.value();
                     if (auto critMultMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_MODIFIER!1"))
                         retVal = retVal + critMultMod.value();
@@ -2284,15 +2284,15 @@ void Creature::InitCriticalMultiplierHook()
                     if (!pItem) // Could be a double-sided weapon
                         pItem = pThis->m_pBaseCreature->m_pInventory->GetItemInSlot(Constants::EquipmentSlot::RightHand);
 
-                    std::string nBaseItemID;
+                    std::string BaseItemID;
                     if (!pItem)
-                        nBaseItemID = "-1";
+                        BaseItemID = std::to_string(Constants::BaseItem::Gloves);
                     else
-                        nBaseItemID = std::to_string(pItem->m_nBaseItem);
+                        BaseItemID = std::to_string(pItem->m_nBaseItem);
 
-                    if (auto critMultOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_OVERRIDE!2!BI" + nBaseItemID))
+                    if (auto critMultOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_OVERRIDE!2!BI" + BaseItemID))
                         retVal = critMultOvr.value();
-                    else if (auto critMultOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_OVERRIDE!0!BI" + nBaseItemID))
+                    else if (auto critMultOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_OVERRIDE!0!BI" + BaseItemID))
                         retVal = critMultOvr.value();
                     else if (auto critMultOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_OVERRIDE!2"))
                         retVal = critMultOvr.value();
@@ -2302,9 +2302,9 @@ void Creature::InitCriticalMultiplierHook()
                         retVal = pGetCriticalHitMultiplier_hook->CallOriginal<int32_t>(pThis, bOffHand);
 
                     //Override-Modifier gap
-                    if (auto critMultMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_MODIFIER!2!BI" + nBaseItemID))
+                    if (auto critMultMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_MODIFIER!2!BI" + BaseItemID))
                         retVal = retVal + critMultMod.value();
-                    if (auto critMultMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_MODIFIER!0!BI" + nBaseItemID))
+                    if (auto critMultMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_MODIFIER!0!BI" + BaseItemID))
                         retVal = retVal + critMultMod.value();
                     if (auto critMultMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_MULTIPLIER_MODIFIER!2"))
                         retVal = retVal + critMultMod.value();
@@ -2326,24 +2326,24 @@ ArgumentStack Creature::SetCriticalMultiplierModifier(ArgumentStack&& args)
 
     if (auto* pCreature = creature(args))
     {
-        const auto nModifier = Services::Events::ExtractArgument<int32_t>(args);
-        auto nHand = Services::Events::ExtractArgument<int32_t>(args);
+        const auto Modifier = Services::Events::ExtractArgument<int32_t>(args);
+        auto Hand = Services::Events::ExtractArgument<int32_t>(args);
         const bool persist = !!Services::Events::ExtractArgument<int32_t>(args);
-        auto nBaseItemID = Services::Events::ExtractArgument<int32_t>(args);
+        auto BaseItemID = Services::Events::ExtractArgument<int32_t>(args);
 
-        if (nHand < 0 || 2 < nHand)
-            nHand = 0;
-        if (nBaseItemID < -2)
-            nBaseItemID = -2;
+        if (Hand < 0 || 2 < Hand)
+            Hand = 0;
+        if (BaseItemID < -1)
+            BaseItemID = -1;
 
-        auto sPOSVar = "CRITICAL_MULTIPLIER_MODIFIER!" + std::to_string(nHand);
-        if (nBaseItemID != -2)
-            sPOSVar = sPOSVar + "!BI" + std::to_string(nBaseItemID);
+        auto POSVar = "CRITICAL_MULTIPLIER_MODIFIER!" + std::to_string(Hand);
+        if (BaseItemID != -1)
+            POSVar = POSVar + "!BI" + std::to_string(BaseItemID);
 
-        if (nModifier)
-            g_plugin->GetServices()->m_perObjectStorage->Set(pCreature, sPOSVar, nModifier, persist);
+        if (Modifier)
+            g_plugin->GetServices()->m_perObjectStorage->Set(pCreature, POSVar, Modifier, persist);
         else
-            g_plugin->GetServices()->m_perObjectStorage->Remove(pCreature, sPOSVar);
+            g_plugin->GetServices()->m_perObjectStorage->Remove(pCreature, POSVar);
     }
     return Services::Events::Arguments();
 }
@@ -2354,21 +2354,21 @@ ArgumentStack Creature::GetCriticalMultiplierModifier(ArgumentStack&& args)
 
     if (auto* pCreature = creature(args))
     {
-        auto nHand = Services::Events::ExtractArgument<int32_t>(args);
-        auto nBaseItemID = Services::Events::ExtractArgument<int32_t>(args);
+        auto Hand = Services::Events::ExtractArgument<int32_t>(args);
+        auto BaseItemID = Services::Events::ExtractArgument<int32_t>(args);
 
-        if (nHand < 0 || 2 < nHand)
-            nHand = 0;
-        if (nBaseItemID < -2)
-            nBaseItemID = -2;
+        if (Hand < 0 || 2 < Hand)
+            Hand = 0;
+        if (BaseItemID < -1)
+            BaseItemID = -1;
 
-        auto sPOSVar = "CRITICAL_MULTIPLIER_MODIFIER!" + std::to_string(nHand);
-        if (nBaseItemID != -2)
-            sPOSVar = sPOSVar + "!BI" + std::to_string(nBaseItemID);
+        auto POSVar = "CRITICAL_MULTIPLIER_MODIFIER!" + std::to_string(Hand);
+        if (BaseItemID != -1)
+            POSVar = POSVar + "!BI" + std::to_string(BaseItemID);
 
-        auto nModifier = GetServices()->m_perObjectStorage->Get<int32_t>(pCreature, sPOSVar);
-        if (nModifier)
-            retVal = nModifier.value();
+        auto Modifier = GetServices()->m_perObjectStorage->Get<int32_t>(pCreature, POSVar);
+        if (Modifier)
+            retVal = Modifier.value();
     }
     return Services::Events::Arguments(retVal);
 }
@@ -2380,24 +2380,24 @@ ArgumentStack Creature::SetCriticalMultiplierOverride(ArgumentStack&& args)
 
     if (auto* pCreature = creature(args))
     {
-        const auto nOverride = Services::Events::ExtractArgument<int32_t>(args);
-        auto nHand = Services::Events::ExtractArgument<int32_t>(args);
+        const auto Override = Services::Events::ExtractArgument<int32_t>(args);
+        auto Hand = Services::Events::ExtractArgument<int32_t>(args);
         const bool persist = !!Services::Events::ExtractArgument<int32_t>(args);
-        auto nBaseItemID = Services::Events::ExtractArgument<int32_t>(args);
+        auto BaseItemID = Services::Events::ExtractArgument<int32_t>(args);
 
-        if (nHand < 0 || 2 < nHand)
-            nHand = 0;
-        if (nBaseItemID < -2)
-            nBaseItemID = -2;
+        if (Hand < 0 || 2 < Hand)
+            Hand = 0;
+        if (BaseItemID < -1)
+            BaseItemID = -1;
 
-        auto sPOSVar = "CRITICAL_MULTIPLIER_OVERRIDE!" + std::to_string(nHand);
-        if (nBaseItemID != -2)
-            sPOSVar = sPOSVar + "!BI" + std::to_string(nBaseItemID);
+        auto POSVar = "CRITICAL_MULTIPLIER_OVERRIDE!" + std::to_string(Hand);
+        if (BaseItemID != -1)
+            POSVar = POSVar + "!BI" + std::to_string(BaseItemID);
 
-        if (nOverride >= 0)
-            g_plugin->GetServices()->m_perObjectStorage->Set(pCreature, sPOSVar, nOverride, persist);
+        if (Override >= 0)
+            g_plugin->GetServices()->m_perObjectStorage->Set(pCreature, POSVar, Override, persist);
         else
-            g_plugin->GetServices()->m_perObjectStorage->Remove(pCreature, sPOSVar);
+            g_plugin->GetServices()->m_perObjectStorage->Remove(pCreature, POSVar);
     }
     return Services::Events::Arguments();
 }
@@ -2408,21 +2408,21 @@ ArgumentStack Creature::GetCriticalMultiplierOverride(ArgumentStack&& args)
 
     if (auto* pCreature = creature(args))
     {
-        auto nHand = Services::Events::ExtractArgument<int32_t>(args);
-        auto nBaseItemID = Services::Events::ExtractArgument<int32_t>(args);
+        auto Hand = Services::Events::ExtractArgument<int32_t>(args);
+        auto BaseItemID = Services::Events::ExtractArgument<int32_t>(args);
 
-        if (nHand < 0 || 2 < nHand)
-            nHand = 0;
-        if (nBaseItemID < -2)
-            nBaseItemID = -2;
+        if (Hand < 0 || 2 < Hand)
+            Hand = 0;
+        if (BaseItemID < -1)
+            BaseItemID = -1;
 
-        auto sPOSVar = "CRITICAL_MULTIPLIER_OVERRIDE!" + std::to_string(nHand);
-        if (nBaseItemID != -2)
-            sPOSVar = sPOSVar + "!BI" + std::to_string(nBaseItemID);
+        auto POSVar = "CRITICAL_MULTIPLIER_OVERRIDE!" + std::to_string(Hand);
+        if (BaseItemID != -1)
+            POSVar = POSVar + "!BI" + std::to_string(BaseItemID);
 
-        auto nOverride = GetServices()->m_perObjectStorage->Get<int32_t>(pCreature, sPOSVar);
-        if (nOverride)
-            retVal = nOverride.value();
+        auto Override = GetServices()->m_perObjectStorage->Get<int32_t>(pCreature, POSVar);
+        if (Override)
+            retVal = Override.value();
     }
     return Services::Events::Arguments(retVal);
 }
@@ -2439,15 +2439,15 @@ void Creature::InitCriticalRangeHook()
                 if (!bOffHand) //mainhand
                 {
                     auto pItem = pThis->m_pBaseCreature->m_pInventory->GetItemInSlot(Constants::EquipmentSlot::RightHand);
-                    std::string nBaseItemID;
+                    std::string BaseItemID;
                     if (!pItem)
-                        nBaseItemID = "-1";
+                        BaseItemID = std::to_string(Constants::BaseItem::Gloves);
                     else
-                        nBaseItemID = std::to_string(pItem->m_nBaseItem);
+                        BaseItemID = std::to_string(pItem->m_nBaseItem);
 
-                    if (auto critRngOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_OVERRIDE!1!BI" + nBaseItemID))
+                    if (auto critRngOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_OVERRIDE!1!BI" + BaseItemID))
                         retVal = critRngOvr.value();
-                    else if (auto critRngOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_OVERRIDE!0!BI" + nBaseItemID))
+                    else if (auto critRngOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_OVERRIDE!0!BI" + BaseItemID))
                         retVal = critRngOvr.value();
                     else if (auto critRngOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_OVERRIDE!1"))
                         retVal = critRngOvr.value();
@@ -2457,9 +2457,9 @@ void Creature::InitCriticalRangeHook()
                         retVal = pGetCriticalHitRoll_hook->CallOriginal<int32_t>(pThis, bOffHand);
 
                     //Override-Modifier gap
-                    if (auto critRngMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_MODIFIER!1!BI" + nBaseItemID))
+                    if (auto critRngMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_MODIFIER!1!BI" + BaseItemID))
                         retVal = retVal + critRngMod.value();
-                    if (auto critRngMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_MODIFIER!0!BI" + nBaseItemID))
+                    if (auto critRngMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_MODIFIER!0!BI" + BaseItemID))
                         retVal = retVal + critRngMod.value();
                     if (auto critRngMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_MODIFIER!1"))
                         retVal = retVal + critRngMod.value();
@@ -2472,15 +2472,15 @@ void Creature::InitCriticalRangeHook()
                     if (!pItem) // Could be a double-sided weapon
                         pItem = pThis->m_pBaseCreature->m_pInventory->GetItemInSlot(Constants::EquipmentSlot::RightHand);
 
-                    std::string nBaseItemID;
+                    std::string BaseItemID;
                     if (!pItem)
-                        nBaseItemID = "-1";
+                        BaseItemID = std::to_string(Constants::BaseItem::Gloves);
                     else
-                        nBaseItemID = std::to_string(pItem->m_nBaseItem);
+                        BaseItemID = std::to_string(pItem->m_nBaseItem);
 
-                    if (auto critRngOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_OVERRIDE!2!BI" + nBaseItemID))
+                    if (auto critRngOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_OVERRIDE!2!BI" + BaseItemID))
                         retVal = critRngOvr.value();
-                    else if (auto critRngOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_OVERRIDE!0!BI" + nBaseItemID))
+                    else if (auto critRngOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_OVERRIDE!0!BI" + BaseItemID))
                         retVal = critRngOvr.value();
                     else if (auto critRngOvr = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_OVERRIDE!2"))
                         retVal = critRngOvr.value();
@@ -2490,9 +2490,9 @@ void Creature::InitCriticalRangeHook()
                         retVal = pGetCriticalHitRoll_hook->CallOriginal<int32_t>(pThis, bOffHand);
 
                     //Override-Modifier gap
-                    if (auto critRngMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_MODIFIER!2!BI" + nBaseItemID))
+                    if (auto critRngMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_MODIFIER!2!BI" + BaseItemID))
                         retVal = retVal + critRngMod.value();
-                    if (auto critRngMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_MODIFIER!0!BI" + nBaseItemID))
+                    if (auto critRngMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_MODIFIER!0!BI" + BaseItemID))
                         retVal = retVal + critRngMod.value();
                     if (auto critRngMod = g_plugin->GetServices()->m_perObjectStorage->Get<int32_t>(pThis->m_pBaseCreature->m_idSelf, "CRITICAL_RANGE_MODIFIER!2"))
                         retVal = retVal + critRngMod.value();
@@ -2513,24 +2513,24 @@ ArgumentStack Creature::SetCriticalRangeModifier(ArgumentStack&& args)
 
     if (auto* pCreature = creature(args))
     {
-        const auto nModifier = Services::Events::ExtractArgument<int32_t>(args);
-        auto nHand = Services::Events::ExtractArgument<int32_t>(args);
+        const auto Modifier = Services::Events::ExtractArgument<int32_t>(args);
+        auto Hand = Services::Events::ExtractArgument<int32_t>(args);
         const bool persist = !!Services::Events::ExtractArgument<int32_t>(args);
-        auto nBaseItemID = Services::Events::ExtractArgument<int32_t>(args);
+        auto BaseItemID = Services::Events::ExtractArgument<int32_t>(args);
 
-        if (nHand < 0 || 2 < nHand)
-            nHand = 0;
-        if (nBaseItemID < -2)
-            nBaseItemID = -2;
+        if (Hand < 0 || 2 < Hand)
+            Hand = 0;
+        if (BaseItemID < -1)
+            BaseItemID = -1;
 
-        auto sPOSVar = "CRITICAL_RANGE_MODIFIER!" + std::to_string(nHand);
-        if (nBaseItemID != -2)
-            sPOSVar = sPOSVar + "!BI" + std::to_string(nBaseItemID);
+        auto POSVar = "CRITICAL_RANGE_MODIFIER!" + std::to_string(Hand);
+        if (BaseItemID != -1)
+            POSVar = POSVar + "!BI" + std::to_string(BaseItemID);
 
-        if (nModifier)
-            g_plugin->GetServices()->m_perObjectStorage->Set(pCreature, sPOSVar, nModifier, persist);
+        if (Modifier)
+            g_plugin->GetServices()->m_perObjectStorage->Set(pCreature, POSVar, Modifier, persist);
         else
-            g_plugin->GetServices()->m_perObjectStorage->Remove(pCreature, sPOSVar);
+            g_plugin->GetServices()->m_perObjectStorage->Remove(pCreature, POSVar);
     }
     return Services::Events::Arguments();
 }
@@ -2541,21 +2541,21 @@ ArgumentStack Creature::GetCriticalRangeModifier(ArgumentStack&& args)
 
     if (auto* pCreature = creature(args))
     {
-        auto nHand = Services::Events::ExtractArgument<int32_t>(args);
-        auto nBaseItemID = Services::Events::ExtractArgument<int32_t>(args);
+        auto Hand = Services::Events::ExtractArgument<int32_t>(args);
+        auto BaseItemID = Services::Events::ExtractArgument<int32_t>(args);
 
-        if (nHand < 0 || 2 < nHand)
-            nHand = 0;
-        if (nBaseItemID < -2)
-            nBaseItemID = -2;
+        if (Hand < 0 || 2 < Hand)
+            Hand = 0;
+        if (BaseItemID < -1)
+            BaseItemID = -1;
 
-        auto sPOSVar = "CRITICAL_RANGE_MODIFIER!" + std::to_string(nHand);
-        if (nBaseItemID != -2)
-            sPOSVar = sPOSVar + "!BI" + std::to_string(nBaseItemID);
+        auto POSVar = "CRITICAL_RANGE_MODIFIER!" + std::to_string(Hand);
+        if (BaseItemID != -1)
+            POSVar = POSVar + "!BI" + std::to_string(BaseItemID);
 
-        auto nModifier = GetServices()->m_perObjectStorage->Get<int32_t>(pCreature, sPOSVar);
-        if (nModifier)
-            retVal = nModifier.value();
+        auto Modifier = GetServices()->m_perObjectStorage->Get<int32_t>(pCreature, POSVar);
+        if (Modifier)
+            retVal = Modifier.value();
     }
     return Services::Events::Arguments(retVal);
 }
@@ -2567,24 +2567,24 @@ ArgumentStack Creature::SetCriticalRangeOverride(ArgumentStack&& args)
 
     if (auto* pCreature = creature(args))
     {
-        const auto nOverride = Services::Events::ExtractArgument<int32_t>(args);
-        auto nHand = Services::Events::ExtractArgument<int32_t>(args);
+        const auto Override = Services::Events::ExtractArgument<int32_t>(args);
+        auto Hand = Services::Events::ExtractArgument<int32_t>(args);
         const bool persist = !!Services::Events::ExtractArgument<int32_t>(args);
-        auto nBaseItemID = Services::Events::ExtractArgument<int32_t>(args);
+        auto BaseItemID = Services::Events::ExtractArgument<int32_t>(args);
 
-        if (nHand < 0 || 2 < nHand)
-            nHand = 0;
-        if (nBaseItemID < -2)
-            nBaseItemID = -2;
+        if (Hand < 0 || 2 < Hand)
+            Hand = 0;
+        if (BaseItemID < -1)
+            BaseItemID = -1;
 
-        auto sPOSVar = "CRITICAL_RANGE_OVERRIDE!" + std::to_string(nHand);
-        if (nBaseItemID != -2)
-            sPOSVar = sPOSVar + "!BI" + std::to_string(nBaseItemID);
+        auto POSVar = "CRITICAL_RANGE_OVERRIDE!" + std::to_string(Hand);
+        if (BaseItemID != -1)
+            POSVar = POSVar + "!BI" + std::to_string(BaseItemID);
 
-        if (nOverride >= 0)
-            g_plugin->GetServices()->m_perObjectStorage->Set(pCreature, sPOSVar, nOverride, persist);
+        if (Override >= 0)
+            g_plugin->GetServices()->m_perObjectStorage->Set(pCreature, POSVar, Override, persist);
         else
-            g_plugin->GetServices()->m_perObjectStorage->Remove(pCreature, sPOSVar);
+            g_plugin->GetServices()->m_perObjectStorage->Remove(pCreature, POSVar);
     }
     return Services::Events::Arguments();
 }
@@ -2595,21 +2595,21 @@ ArgumentStack Creature::GetCriticalRangeOverride(ArgumentStack&& args)
 
     if (auto* pCreature = creature(args))
     {
-        auto nHand = Services::Events::ExtractArgument<int32_t>(args);
-        auto nBaseItemID = Services::Events::ExtractArgument<int32_t>(args);
+        auto Hand = Services::Events::ExtractArgument<int32_t>(args);
+        auto BaseItemID = Services::Events::ExtractArgument<int32_t>(args);
 
-        if (nHand < 0 || 2 < nHand)
-            nHand = 0;
-        if (nBaseItemID < -2)
-            nBaseItemID = -2;
+        if (Hand < 0 || 2 < Hand)
+            Hand = 0;
+        if (BaseItemID < -1)
+            BaseItemID = -1;
 
-        auto sPOSVar = "CRITICAL_RANGE_OVERRIDE!" + std::to_string(nHand);
-        if (nBaseItemID != -2)
-            sPOSVar = sPOSVar + "!BI" + std::to_string(nBaseItemID);
+        auto POSVar = "CRITICAL_RANGE_OVERRIDE!" + std::to_string(Hand);
+        if (BaseItemID != -1)
+            POSVar = POSVar + "!BI" + std::to_string(BaseItemID);
 
-        auto nOverride = GetServices()->m_perObjectStorage->Get<int32_t>(pCreature, sPOSVar);
-        if (nOverride)
-            retVal = nOverride.value();
+        auto Override = GetServices()->m_perObjectStorage->Get<int32_t>(pCreature, POSVar);
+        if (Override)
+            retVal = Override.value();
     }
     return Services::Events::Arguments(retVal);
 }

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -685,61 +685,69 @@ int NWNX_Creature_GetCasterLevelOverride(object oCreature, int nClass);
 /// @param oCreature The creature object.
 void NWNX_Creature_JumpToLimbo(object oCreature);
 
-/// @brief Sets the critical hit multiplier modifier for the creature
+/// @brief Sets the critical hit multiplier modifier for the Creature
 /// @param oCreature The target creature
 /// @param nModifier The modifier to apply
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
 /// @param bPersist Whether the modifier should persist to .bic file if applicable
-/// @note Persistence is activated each server reset by first use of either 'SetCriticalMultiplier*' functions. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
-void NWNX_Creature_SetCriticalMultiplierModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE);
+/// @param nBaseItem Applies the.modifier only when the attack used this baseitem. -1 for 'Unarmed', '-2' for 'all'
+/// @note Persistence is activated each server reset by the first use of either 'SetCriticalMultiplier*' functions. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
+void NWNX_Creature_SetCriticalMultiplierModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2);
 
 /// @brief Gets the critical hit multiplier modifier for the Creature
 /// @param oCreature The target creature
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
+/// @param nBaseItem The baseitem modifer to retrieve. -1 for 'Unarmed', '-2' for 'all'
 /// @return the current critical hit multiplier modifier for the creature
-int NWNX_Creature_GetCriticalMultiplierModifier(object oCreature, int nHand = 0);
+int NWNX_Creature_GetCriticalMultiplierModifier(object oCreature, int nHand = 0, int nBaseItem = -2);
 
-/// @brief Sets the critical hit multiplier override for the creature.
+/// @brief Sets the critical hit multiplier override for the Creature.
 /// @param oCreature The target creature
 /// @param nOverride The override value to apply. -1 to clear override.
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
-/// @param bPersist whether the modifier should be persisted to the .bic file if applicable
-/// @note Persistence is activated each server reset by first use of either 'SetCriticalMultiplier*' functions. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
-void NWNX_Creature_SetCriticalMultiplierOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE);
+/// @param bPersist Whether the modifier should persist to .bic file if applicable
+/// @param nBaseItem Applies the.Override only when the attack used this baseitem. -1 for 'Unarmed', '-2' for 'all'
+/// @note Persistence is activated each server reset by the first use of either 'SetCriticalMultiplier*' functions. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
+void NWNX_Creature_SetCriticalMultiplierOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2);
 
 /// @brief Gets the critical hit multiplier override for the Creature
 /// @param oCreature The target creature
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
+/// @param nBaseItem The baseitem Override to retrieve. -1 for 'Unarmed', '-2' for 'all'
 /// @return the current critical hit multiplier override for the creature. No override == -1
-int NWNX_Creature_GetCriticalMultiplierOverride(object oCreature, int nHand = 0);
+int NWNX_Creature_GetCriticalMultiplierOverride(object oCreature, int nHand = 0, int nBaseItem = -2);
 
 /// @brief Sets the critical hit range modifier for the creature.
 /// @param oCreature The target creature
 /// @param nModifier The modifier to apply. Positive modifiers reduce critical chance. (I.e. From 18-20, a +1 results in crit range of 19-20)
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
-/// @param bPersist whether the modifier should be persisted to the .bic file if applicable
-/// @note Persistence is activated each server reset by first use of either 'SetCriticalRange*' functions. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
-void NWNX_Creature_SetCriticalRangeModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE);
+/// @param bPersist Whether the modifier should persist to .bic file if applicable
+/// @param nBaseItem Applies the.modifier only when the attack used this baseitem. -1 for 'Unarmed', '-2' for 'all'
+/// @note Persistence is activated each server reset by the first use of either 'SetCriticalRange*' functions. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
+void NWNX_Creature_SetCriticalRangeModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2);
 
 /// @brief Gets the critical hit range modifier for the creature.
 /// @param oCreature The target creature
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
+/// @param nBaseItem The baseitem modifer to retrieve. -1 for 'Unarmed', '-2' for 'all'
 /// @return the current critical hit range modifier for the creature
-int NWNX_Creature_GetCriticalRangeModifier(object oCreature, int nHand = 0);
+int NWNX_Creature_GetCriticalRangeModifier(object oCreature, int nHand = 0, int nBaseItem = -2);
 
 /// @brief Sets the critical hit range Override for the creature.
 /// @param oCreature The target creature
 /// @param nOverride The new minimum roll to crit. i.e nOverride of 15 results in crit range of 15-20. -1 to clear override.
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
-/// @param bPersist whether the modifier should be persisted to the .bic file if applicable
-/// @note Persistence is activated each server reset by first use of either 'SetCriticalRange*' functions. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
-void NWNX_Creature_SetCriticalRangeOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE);
+/// @param bPersist Whether the modifier should persist to .bic file if applicable
+/// @param nBaseItem Applies the.Override only when the attack used this baseitem. -1 for 'Unarmed', '-2' for 'all'
+/// @note Persistence is activated each server reset by the first use of either 'SetCriticalRange*' functions. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
+void NWNX_Creature_SetCriticalRangeOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2);
 
 /// @brief Sets the critical hit range Override for the creature.
 /// @param oCreature The target creature
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
-/// @return the current critical hit range override for the creature. No override == -1.
-int NWNX_Creature_GetCriticalRangeOverride(object oCreature, int nHand = 0);
+/// @param nBaseItem The baseitem Override to retrieve. -1 for 'Unarmed', '-2' for 'all'
+/// @return the current critical hit range override for the creature. No override == -1
+int NWNX_Creature_GetCriticalRangeOverride(object oCreature, int nHand = 0, int nBaseItem = -2);
 
 /// @brief Add oAssociate as nAssociateType to oCreature
 /// @warning Only basic checks are done so care must be taken when using this function
@@ -1866,10 +1874,11 @@ void NWNX_Creature_JumpToLimbo(object oCreature)
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
 
-void NWNX_Creature_SetCriticalMultiplierModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE)
+void NWNX_Creature_SetCriticalMultiplierModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2)
 {
     string sFunc = "SetCriticalMultiplierModifier";
 
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, nBaseItem);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, bPersist);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, nHand);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, nModifier);
@@ -1878,10 +1887,11 @@ void NWNX_Creature_SetCriticalMultiplierModifier(object oCreature, int nModifier
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
 
-int NWNX_Creature_GetCriticalMultiplierModifier(object oCreature, int nHand = 0)
+int NWNX_Creature_GetCriticalMultiplierModifier(object oCreature, int nHand = 0, int nBaseItem = -2)
 {
     string sFunc = "GetCriticalMultiplierModifier";
 
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, nBaseItem);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, nHand);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
 
@@ -1889,10 +1899,11 @@ int NWNX_Creature_GetCriticalMultiplierModifier(object oCreature, int nHand = 0)
     return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
 }
 
-void NWNX_Creature_SetCriticalMultiplierOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE)
+void NWNX_Creature_SetCriticalMultiplierOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2)
 {
     string sFunc = "SetCriticalMultiplierOverride";
 
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, nBaseItem);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, bPersist);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, nHand);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, nOverride);
@@ -1901,10 +1912,11 @@ void NWNX_Creature_SetCriticalMultiplierOverride(object oCreature, int nOverride
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
 
-int NWNX_Creature_GetCriticalMultiplierOverride(object oCreature, int nHand = 0)
+int NWNX_Creature_GetCriticalMultiplierOverride(object oCreature, int nHand = 0, int nBaseItem = -2)
 {
     string sFunc = "GetCriticalMultiplierOverride";
 
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, nBaseItem);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, nHand);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
 
@@ -1912,10 +1924,11 @@ int NWNX_Creature_GetCriticalMultiplierOverride(object oCreature, int nHand = 0)
     return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
 }
 
-void NWNX_Creature_SetCriticalRangeModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE)
+void NWNX_Creature_SetCriticalRangeModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2)
 {
     string sFunc = "SetCriticalRangeModifier";
 
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, nBaseItem);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, bPersist);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, nHand);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, nModifier);
@@ -1924,10 +1937,11 @@ void NWNX_Creature_SetCriticalRangeModifier(object oCreature, int nModifier, int
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
 
-int NWNX_Creature_GetCriticalRangeModifier(object oCreature, int nHand = 0)
+int NWNX_Creature_GetCriticalRangeModifier(object oCreature, int nHand = 0, int nBaseItem = -2)
 {
     string sFunc = "GetCriticalRangeModifier";
 
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, nBaseItem);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, nHand);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
 
@@ -1935,10 +1949,11 @@ int NWNX_Creature_GetCriticalRangeModifier(object oCreature, int nHand = 0)
     return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
 }
 
-void NWNX_Creature_SetCriticalRangeOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE)
+void NWNX_Creature_SetCriticalRangeOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2)
 {
     string sFunc = "SetCriticalRangeOverride";
 
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, nBaseItem);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, bPersist);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, nHand);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, nOverride);
@@ -1947,10 +1962,11 @@ void NWNX_Creature_SetCriticalRangeOverride(object oCreature, int nOverride, int
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
 
-int NWNX_Creature_GetCriticalRangeOverride(object oCreature, int nHand = 0)
+int NWNX_Creature_GetCriticalRangeOverride(object oCreature, int nHand = 0, int nBaseItem = -2)
 {
     string sFunc = "GetCriticalRangeOverride";
 
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, nBaseItem);
     NWNX_PushArgumentInt(NWNX_Creature, sFunc, nHand);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
 

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -690,64 +690,64 @@ void NWNX_Creature_JumpToLimbo(object oCreature);
 /// @param nModifier The modifier to apply
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
 /// @param bPersist Whether the modifier should persist to .bic file if applicable
-/// @param nBaseItem Applies the.modifier only when the attack used this baseitem. -1 for 'Unarmed', '-2' for 'all'
+/// @param nBaseItem Applies the.modifier only when the attack used this baseitem. BASE_ITEM_GLOVES for Unarmed, '-1' for all
 /// @note Persistence is activated each server reset by the first use of either 'SetCriticalMultiplier*' functions. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
-void NWNX_Creature_SetCriticalMultiplierModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2);
+void NWNX_Creature_SetCriticalMultiplierModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE, int nBaseItem = -1);
 
 /// @brief Gets the critical hit multiplier modifier for the Creature
 /// @param oCreature The target creature
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
-/// @param nBaseItem The baseitem modifer to retrieve. -1 for 'Unarmed', '-2' for 'all'
+/// @param nBaseItem The baseitem modifer to retrieve. BASE_ITEM_GLOVES for Unarmed, '-1' for all
 /// @return the current critical hit multiplier modifier for the creature
-int NWNX_Creature_GetCriticalMultiplierModifier(object oCreature, int nHand = 0, int nBaseItem = -2);
+int NWNX_Creature_GetCriticalMultiplierModifier(object oCreature, int nHand = 0, int nBaseItem = -1);
 
 /// @brief Sets the critical hit multiplier override for the Creature.
 /// @param oCreature The target creature
 /// @param nOverride The override value to apply. -1 to clear override.
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
 /// @param bPersist Whether the modifier should persist to .bic file if applicable
-/// @param nBaseItem Applies the.Override only when the attack used this baseitem. -1 for 'Unarmed', '-2' for 'all'
+/// @param nBaseItem Applies the.Override only when the attack used this baseitem. BASE_ITEM_GLOVES for Unarmed, '-1' for all
 /// @note Persistence is activated each server reset by the first use of either 'SetCriticalMultiplier*' functions. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
-void NWNX_Creature_SetCriticalMultiplierOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2);
+void NWNX_Creature_SetCriticalMultiplierOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE, int nBaseItem = -1);
 
 /// @brief Gets the critical hit multiplier override for the Creature
 /// @param oCreature The target creature
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
-/// @param nBaseItem The baseitem Override to retrieve. -1 for 'Unarmed', '-2' for 'all'
+/// @param nBaseItem The baseitem Override to retrieve. BASE_ITEM_GLOVES for Unarmed, '-1' for all
 /// @return the current critical hit multiplier override for the creature. No override == -1
-int NWNX_Creature_GetCriticalMultiplierOverride(object oCreature, int nHand = 0, int nBaseItem = -2);
+int NWNX_Creature_GetCriticalMultiplierOverride(object oCreature, int nHand = 0, int nBaseItem = -1);
 
 /// @brief Sets the critical hit range modifier for the creature.
 /// @param oCreature The target creature
 /// @param nModifier The modifier to apply. Positive modifiers reduce critical chance. (I.e. From 18-20, a +1 results in crit range of 19-20)
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
 /// @param bPersist Whether the modifier should persist to .bic file if applicable
-/// @param nBaseItem Applies the.modifier only when the attack used this baseitem. -1 for 'Unarmed', '-2' for 'all'
+/// @param nBaseItem Applies the.modifier only when the attack used this baseitem. BASE_ITEM_GLOVES for Unarmed, '-1' for all
 /// @note Persistence is activated each server reset by the first use of either 'SetCriticalRange*' functions. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
-void NWNX_Creature_SetCriticalRangeModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2);
+void NWNX_Creature_SetCriticalRangeModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE, int nBaseItem = -1);
 
 /// @brief Gets the critical hit range modifier for the creature.
 /// @param oCreature The target creature
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
-/// @param nBaseItem The baseitem modifer to retrieve. -1 for 'Unarmed', '-2' for 'all'
+/// @param nBaseItem The baseitem modifer to retrieve. BASE_ITEM_GLOVES for Unarmed, '-1' for all
 /// @return the current critical hit range modifier for the creature
-int NWNX_Creature_GetCriticalRangeModifier(object oCreature, int nHand = 0, int nBaseItem = -2);
+int NWNX_Creature_GetCriticalRangeModifier(object oCreature, int nHand = 0, int nBaseItem = -1);
 
 /// @brief Sets the critical hit range Override for the creature.
 /// @param oCreature The target creature
 /// @param nOverride The new minimum roll to crit. i.e nOverride of 15 results in crit range of 15-20. -1 to clear override.
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
 /// @param bPersist Whether the modifier should persist to .bic file if applicable
-/// @param nBaseItem Applies the.Override only when the attack used this baseitem. -1 for 'Unarmed', '-2' for 'all'
+/// @param nBaseItem Applies the.Override only when the attack used this baseitem. BASE_ITEM_GLOVES for Unarmed, '-1' for all
 /// @note Persistence is activated each server reset by the first use of either 'SetCriticalRange*' functions. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
-void NWNX_Creature_SetCriticalRangeOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2);
+void NWNX_Creature_SetCriticalRangeOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE, int nBaseItem = -1);
 
 /// @brief Sets the critical hit range Override for the creature.
 /// @param oCreature The target creature
 /// @param nHand 0 for all attacks, 1 for Mainhand, 2 for Offhand
-/// @param nBaseItem The baseitem Override to retrieve. -1 for 'Unarmed', '-2' for 'all'
+/// @param nBaseItem The baseitem Override to retrieve. BASE_ITEM_GLOVES for Unarmed, '-1' for all
 /// @return the current critical hit range override for the creature. No override == -1
-int NWNX_Creature_GetCriticalRangeOverride(object oCreature, int nHand = 0, int nBaseItem = -2);
+int NWNX_Creature_GetCriticalRangeOverride(object oCreature, int nHand = 0, int nBaseItem = -1);
 
 /// @brief Add oAssociate as nAssociateType to oCreature
 /// @warning Only basic checks are done so care must be taken when using this function
@@ -1874,7 +1874,7 @@ void NWNX_Creature_JumpToLimbo(object oCreature)
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
 
-void NWNX_Creature_SetCriticalMultiplierModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2)
+void NWNX_Creature_SetCriticalMultiplierModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE, int nBaseItem = -1)
 {
     string sFunc = "SetCriticalMultiplierModifier";
 
@@ -1887,7 +1887,7 @@ void NWNX_Creature_SetCriticalMultiplierModifier(object oCreature, int nModifier
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
 
-int NWNX_Creature_GetCriticalMultiplierModifier(object oCreature, int nHand = 0, int nBaseItem = -2)
+int NWNX_Creature_GetCriticalMultiplierModifier(object oCreature, int nHand = 0, int nBaseItem = -1)
 {
     string sFunc = "GetCriticalMultiplierModifier";
 
@@ -1899,7 +1899,7 @@ int NWNX_Creature_GetCriticalMultiplierModifier(object oCreature, int nHand = 0,
     return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
 }
 
-void NWNX_Creature_SetCriticalMultiplierOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2)
+void NWNX_Creature_SetCriticalMultiplierOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE, int nBaseItem = -1)
 {
     string sFunc = "SetCriticalMultiplierOverride";
 
@@ -1912,7 +1912,7 @@ void NWNX_Creature_SetCriticalMultiplierOverride(object oCreature, int nOverride
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
 
-int NWNX_Creature_GetCriticalMultiplierOverride(object oCreature, int nHand = 0, int nBaseItem = -2)
+int NWNX_Creature_GetCriticalMultiplierOverride(object oCreature, int nHand = 0, int nBaseItem = -1)
 {
     string sFunc = "GetCriticalMultiplierOverride";
 
@@ -1924,7 +1924,7 @@ int NWNX_Creature_GetCriticalMultiplierOverride(object oCreature, int nHand = 0,
     return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
 }
 
-void NWNX_Creature_SetCriticalRangeModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2)
+void NWNX_Creature_SetCriticalRangeModifier(object oCreature, int nModifier, int nHand = 0, int bPersist = FALSE, int nBaseItem = -1)
 {
     string sFunc = "SetCriticalRangeModifier";
 
@@ -1937,7 +1937,7 @@ void NWNX_Creature_SetCriticalRangeModifier(object oCreature, int nModifier, int
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
 
-int NWNX_Creature_GetCriticalRangeModifier(object oCreature, int nHand = 0, int nBaseItem = -2)
+int NWNX_Creature_GetCriticalRangeModifier(object oCreature, int nHand = 0, int nBaseItem = -1)
 {
     string sFunc = "GetCriticalRangeModifier";
 
@@ -1949,7 +1949,7 @@ int NWNX_Creature_GetCriticalRangeModifier(object oCreature, int nHand = 0, int 
     return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
 }
 
-void NWNX_Creature_SetCriticalRangeOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE, int nBaseItem = -2)
+void NWNX_Creature_SetCriticalRangeOverride(object oCreature, int nOverride, int nHand = 0, int bPersist = FALSE, int nBaseItem = -1)
 {
     string sFunc = "SetCriticalRangeOverride";
 
@@ -1962,7 +1962,7 @@ void NWNX_Creature_SetCriticalRangeOverride(object oCreature, int nOverride, int
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
 
-int NWNX_Creature_GetCriticalRangeOverride(object oCreature, int nHand = 0, int nBaseItem = -2)
+int NWNX_Creature_GetCriticalRangeOverride(object oCreature, int nHand = 0, int nBaseItem = -1)
 {
     string sFunc = "GetCriticalRangeOverride";
 


### PR DESCRIPTION
Updates and extends the functions Get/Set pairs for CriticalMultiplier and CriticalRange, both modifiers and overrides, as follows:

* Now allows optional declaration of a BASE_TYPE_*. If specified, modifier/override applies only to attacks made with the specified weapon. Can apply to Unarmed (`nBaseItem == -1`). Weapon declaration takes priority in Overrides. That is, the order goes:
  1. Baseitem and specified hand
  2. Baseitem and non-specified hand
  3. No Baseitem and specified hand
  4. No Baseitem and non-specified hand

* Order of parameters maintained for compatibility, although I would've liked it earlier.

* Modifiers now apply in addition to Overrides, and multiple modifiers take effect if relevant. I.E Overriding Main-hand Longsword with multiplier of 3, and Modifier of any Off-Hand of -1, and a Modifier of any Longsword of +2 will result in (3-1+2 =) 4, rather than previously where it would simply stop at the Override and return 3.



