### PR TITLE
Tweaks: add NWNX_TWEAKS_DISPLAY_NUM_ATTACKS_OVERRIDE_IN_CHARACTER_SHEET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ https://github.com/nwnxee/unified/compare/build8193.20...HEAD
 - Experimental: Added `NWNX_EXPERIMENTAL_DISABLE_LEVELUP_VALIDATION` to disable levelup validation.
 - Experimental: Added `NWNX_EXPERIMENTAL_UNHARDCODE_RANGER_DUALWIELD` to remove the hardcoded effects of the Ranger's Dual-wield feat. This functionality is not compatible with the NWNX_ON_HAS_FEAT_* event.
 - Tweaks: Added `NWNX_TWEAKS_ALWAYS_RETURN_FULL_DEX_STAT` to have GetDEXStat() always return a creature's full dexterity stat.
+- Tweaks: added `NWNX_TWEAKS_DISPLAY_NUM_ATTACKS_OVERRIDE_IN_CHARACTER_SHEET` to display the correct amount of attacks per round on the character sheet when overridden with SetBaseAttackBonus()
 
 ##### New Plugins
 - N/A

--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -24,4 +24,5 @@ add_plugin(Tweaks
     "Tweaks/FixItemNullptrInCItemRepository.cpp"
     "Tweaks/ClearSpellEffectsOnTURDs.cpp"
     "Tweaks/AlwaysReturnFullDEXStat.cpp"
+    "Tweaks/DisplayNumAttacksOverrideInCharacterSheet.cpp"
 )

--- a/Plugins/Tweaks/README.md
+++ b/Plugins/Tweaks/README.md
@@ -34,6 +34,7 @@ Tweaks stuff. See below.
 * `NWNX_TWEAKS_FIX_ITEM_NULLPTR_IN_CITEMREPOSITORY`: true or false
 * `NWNX_TWEAKS_CLEAR_SPELL_EFFECTS_ON_TURDS`: true or false
 * `NWNX_TWEAKS_ALWAYS_RETURN_FULL_DEX_STAT`: true or false
+* `NWNX_TWEAKS_DISPLAY_NUM_ATTACKS_OVERRIDE_IN_CHARACTER_SHEET`: true or false
 
 ## Environment variable values
 

--- a/Plugins/Tweaks/Tweaks.cpp
+++ b/Plugins/Tweaks/Tweaks.cpp
@@ -23,6 +23,7 @@
 #include "Tweaks/FixItemNullptrInCItemRepository.hpp"
 #include "Tweaks/ClearSpellEffectsOnTURDs.hpp"
 #include "Tweaks/AlwaysReturnFullDEXStat.hpp"
+#include "Tweaks/DisplayNumAttacksOverrideInCharacterSheet.hpp"
 
 #include "Services/Config/Config.hpp"
 
@@ -196,6 +197,12 @@ Tweaks::Tweaks(Services::ProxyServiceList* services)
     {
         LOG_INFO("GetDEXStat() is always returning a creature's full Dexterity Stat.");
         m_AlwaysReturnFullDEXStat = std::make_unique<AlwaysReturnFullDEXStat>(GetServices()->m_hooks.get());
+    }
+
+    if (GetServices()->m_config->Get<bool>("DISPLAY_NUM_ATTACKS_OVERRIDE_IN_CHARACTER_SHEET", false))
+    {
+        LOG_INFO("Number of attacks per round overridden by SetBaseAttackBonus() will show on the character sheet.");
+        m_DisplayNumAttacksOverrideInCharacterSheet = std::make_unique<DisplayNumAttacksOverrideInCharacterSheet>(GetServices()->m_hooks.get());
     }
 }
 

--- a/Plugins/Tweaks/Tweaks.hpp
+++ b/Plugins/Tweaks/Tweaks.hpp
@@ -29,6 +29,7 @@ class FixArmorDexBonusUnderOne;
 class FixItemNullptrInCItemRepository;
 class ClearSpellEffectsOnTURDs;
 class AlwaysReturnFullDEXStat;
+class DisplayNumAttacksOverrideInCharacterSheet;
 
 class Tweaks : public NWNXLib::Plugin
 {
@@ -61,6 +62,7 @@ private:
     std::unique_ptr<FixItemNullptrInCItemRepository> m_FixItemNullptrInCItemRepository;
     std::unique_ptr<ClearSpellEffectsOnTURDs> m_ClearSpellEffectsOnTURDs;
     std::unique_ptr<AlwaysReturnFullDEXStat> m_AlwaysReturnFullDEXStat;
+    std::unique_ptr<DisplayNumAttacksOverrideInCharacterSheet> m_DisplayNumAttacksOverrideInCharacterSheet;
 };
 
 }

--- a/Plugins/Tweaks/Tweaks/DisplayNumAttacksOverrideInCharacterSheet.cpp
+++ b/Plugins/Tweaks/Tweaks/DisplayNumAttacksOverrideInCharacterSheet.cpp
@@ -1,0 +1,26 @@
+#include "Tweaks/DisplayNumAttacksOverrideInCharacterSheet.hpp"
+#include "API/CNWSCreatureStats.hpp"
+#include "Utils.hpp"
+
+
+namespace Tweaks {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+NWNXLib::Hooking::FunctionHook* s_GetAttacksPerRoundHook;
+
+DisplayNumAttacksOverrideInCharacterSheet::DisplayNumAttacksOverrideInCharacterSheet(Services::HooksProxy* hooker)
+{
+    s_GetAttacksPerRoundHook = hooker->RequestExclusiveHook<Functions::_ZN17CNWSCreatureStats18GetAttacksPerRoundEv>(&GetAttacksPerRoundHook);
+}
+
+uint8_t DisplayNumAttacksOverrideInCharacterSheet::GetAttacksPerRoundHook(CNWSCreatureStats *pCreatureStats)
+{
+    if (pCreatureStats->m_nOverrideBaseAttackBonus)
+        return pCreatureStats->m_nOverrideBaseAttackBonus;
+    else
+        return s_GetAttacksPerRoundHook->CallOriginal<uint8_t>(pCreatureStats);
+}
+
+}

--- a/Plugins/Tweaks/Tweaks/DisplayNumAttacksOverrideInCharacterSheet.hpp
+++ b/Plugins/Tweaks/Tweaks/DisplayNumAttacksOverrideInCharacterSheet.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Common.hpp"
+#include "Services/Hooks/Hooks.hpp"
+
+namespace Tweaks {
+
+class DisplayNumAttacksOverrideInCharacterSheet
+{
+public:
+    DisplayNumAttacksOverrideInCharacterSheet(NWNXLib::Services::HooksProxy* hooker);
+
+private:
+    static uint8_t GetAttacksPerRoundHook(CNWSCreatureStats*);
+};
+
+}


### PR DESCRIPTION
Overriding a creature's number of attacks per round with SetBaseAttackBonus() doesn't show up on the character sheet, but have no fear, with this small tweak it will. Magic.