### PR TITLE
Docker: fix unquoted arguments in run-server.sh

### DIFF
--- a/Scripts/Docker/run-server.patch
+++ b/Scripts/Docker/run-server.patch
@@ -47,6 +47,10 @@
 > exec ./nwserver-linux \
 84d113
 <   -module "${NWN_MODULE:-DockerDemo}" \
+102c131
+<   ${args[@]}
+---
+>   "${args[@]}"
 103,114d131
 < RET=$?
 < set -e

--- a/Scripts/Docker/run-server.sh.new
+++ b/Scripts/Docker/run-server.sh.new
@@ -128,4 +128,4 @@ exec ./nwserver-linux \
   -dmpassword "${NWN_DMPASSWORD}" \
   -adminpassword "${NWN_ADMINPASSWORD}" \
   -reloadwhenempty "${NWN_RELOADWHENEMPTY:-0}" \
-  ${args[@]}
+  "${args[@]}"


### PR DESCRIPTION
I have drank deep from the well of Bash, and have come out enlightened. The fix for elements not being quoted, is simply to quote the array. So instead of `${args[@]}`, we instead write `"${args[@]}"`.

Now you may be thinking, surely that will just put the *entire* array in one argument? Not so, because the ways of Bash are strange and mysterious. Quoting this array expansion quotes each item in the array *individually*.

To confirm this, I slapped together a quick script (`cargs`) that would return the argument count and the first three arguments:

```bash
#!/bin/bash
echo $#
echo $1
echo $2
echo $3
```

Then at the command line:

```bash
$ bash
$ args=("-module" "foo bar")
$ exec ./cargs "${args[@]}"
2
-module
foo bar
```

I have tested this on my fork, and found it works.

It took longer than expected to find this, because on my fork GHA was building the docker image twice; once from my repository, and then a few minutes later from a base image from this repository. This produced some very intuitive behaviour, as the build would work, then not work a minute later. I mention this just in case someone runs across this issue in future while trying to make patches for Docker.