### PR TITLE
SWIG: Fix undefined base classes

### DIFF
--- a/Plugins/SWIG/CMakeLists.txt
+++ b/Plugins/SWIG/CMakeLists.txt
@@ -8,6 +8,7 @@ function(add_swig_plugin target)
         OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${interopFile}
         DEPENDS Core
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${interfaceFile}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/generate.sh
         COMMAND chmod a+x ./generate.sh && mkdir -p ./${target} && ./generate.sh -v -c++ -fcompact -o ${interopFile} -outdir ./${target} -I../../NWNXLib/API ${ARGN} ${interfaceFile}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )

--- a/Plugins/SWIG/generate.sh
+++ b/Plugins/SWIG/generate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 NWNXLIB_SWG="${NWNXLIB_SWG:-NWNXLib.i}"
-INCLUDES=(${INCLUDES[@]:-"API/CExoPackedFile.hpp" "API/CCallbackHandlerBase.hpp" "API/CGameObject.hpp" "API/CRes.hpp" "API/CResStruct.hpp" "API/CResGFF.hpp" "API/CNWSObject.hpp" "API/CNWTile.hpp" "API/CNWTileSet.hpp" "API/CVirtualMachineCmdImplementer.hpp" "API/STR_RES_HEADER_OLD.hpp" "API/CAurObjectVisualTransformData.hpp" "API/CNWSClient.hpp" "API/CNWMessage.hpp" "API/CExoFile.hpp" "API/CNWSClient.hpp" "API/CExoFile.hpp" "API/CGameEffectApplierRemover.hpp" "API/CNWItem.hpp"})
+INCLUDES=(${INCLUDES[@]:-"API/CExoPackedFile.hpp" "API/CCallbackHandlerBase.hpp" "API/CGameObject.hpp" "API/CRes.hpp" "API/CResStruct.hpp" "API/CResGFF.hpp" "API/CNWSObject.hpp" "API/CNWTile.hpp" "API/CNWTileSet.hpp" "API/CVirtualMachineCmdImplementer.hpp" "API/STR_RES_HEADER_OLD.hpp" "API/CAurObjectVisualTransformData.hpp" "API/CNWSClient.hpp" "API/CNWMessage.hpp" "API/CExoFile.hpp" "API/CNWSClient.hpp" "API/CExoFile.hpp" "API/CGameEffectApplierRemover.hpp" "API/CNWItem.hpp" "API/CBaseExoApp.hpp" "API/CNWArea.hpp"})
 EXCLUDES=(${EXCLUDES[@]:-"Functions.hpp" "FunctionsLinux.hpp" "nwn_api.hpp"})
 
 FIND_ARGS=()


### PR DESCRIPTION
Resolves the following warning/skipped bindings:
```
../../NWNXLib/API/API/CServerExoApp.hpp:44: Warning 401: Base class 'CBaseExoApp' undefined.
../../NWNXLib/API/API/CBaseExoApp.hpp:19: Warning 401: 'CBaseExoApp' must be defined before it is used as a base class.
../../NWNXLib/API/API/CNWSArea.hpp:45: Warning 401: Base class 'CNWArea' undefined.
../../NWNXLib/API/API/CNWArea.hpp:21: Warning 401: 'CNWArea' must be defined before it is used as a base class.
```