### PR TITLE
Data: properly return INVALID_INDEX when we find no record in Array_Find_Str

### DIFF
--- a/Plugins/Data/NWScript/inc_array.nss
+++ b/Plugins/Data/NWScript/inc_array.nss
@@ -302,13 +302,12 @@ void Array_Erase(string tag, int index, object obj=OBJECT_INVALID)
 // if not found, return INVALID_INDEX
 int Array_Find_Str(string tag, string element, object obj=OBJECT_INVALID)
 {
-    int tmp = -1;
-    string stmt = "SELECT MIN(ind) FROM "+GetTableName(tag, obj)+" WHERE value = @element";
+    string stmt = "SELECT IFNULL(MIN(ind),@invalid_index) FROM "+GetTableName(tag, obj)+" WHERE value = @element";
     sqlquery sqlQuery = SqlPrepareQueryObject(GetModule(), stmt);
+    SqlBindInt(sqlQuery, "@invalid_index", INVALID_INDEX);
     SqlBindString(sqlQuery, "@element", element);
     if ( SqlStep(sqlQuery) ) {
-        tmp = SqlGetInt(sqlQuery, 0);
-        return tmp;
+        return SqlGetInt(sqlQuery, 0);
     }
     return INVALID_INDEX;
 }


### PR DESCRIPTION
Closes #1214 - thanks for the report @ud4ever

I'm going to use `IFNULL` instead of first doing a locate just to save a query