### PR TITLE
Time sqlite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ https://github.com/nwnxee/unified/compare/build8193.20...HEAD
 - Encounter: SetGeometry()
 - Util: GetInstructionLimit()
 - Util: {Get|Set}InstructionsExecuted()
+- Util: NWNX_Util_GetHighResTimeStamp() (in preparation for removing the now deprecated NWNX_Time)
 - Area: NWNX_Area_GetAmbientSound{Day/Night}()
 - Area: NWNX_Area_GetAmbientSound{Day/Night}Volume
 
@@ -32,6 +33,7 @@ https://github.com/nwnxee/unified/compare/build8193.20...HEAD
 
 ### Deprecated
 - Data: The NWNX_Data array implementation is deprecated. SQLite implementation available.  Shim include file provided for compatibility.
+- Time: The NWNX_Time implementation is deprecated. A SQLite implementation is now in use. The include file inc_sqlite_time is provided.
 
 ### Removed
 - N/A

--- a/Plugins/Time/NWScript/inc_sqlite_time.nss
+++ b/Plugins/Time/NWScript/inc_sqlite_time.nss
@@ -1,0 +1,68 @@
+/// @addtogroup time Time
+/// @brief Provides various time related functions.
+/// @{
+/// @file inc_sqlite_time.nss
+
+/// @brief Returns the current time formatted according to the provided sqlite date time format string.
+/// @param format Format string as used by sqlites STRFTIME().
+/// @return The current time in the requested format. Empty string on error.
+string SQLite_GetFormattedSystemTime(string format);
+
+/// @return Returns the number of seconds since midnight on January 1, 1970.
+int SQLite_GetTimeStamp();
+
+/// @brief A millisecond timestamp
+struct SQLite_MillisecondTimeStamp
+{
+    int seconds; ///< Seconds since epoch
+    int milliseconds; ///< Milliseconds
+};
+
+/// @remark For mircosecond timestamps use NWNX_Utility_GetHighResTimeStamp().
+/// @return Returns the number of milliseconds since midnight on January 1, 1970.
+struct SQLite_MillisecondTimeStamp SQLite_GetMillisecondTimeStamp();
+
+/// @brief Returns the current date.
+/// @return The date in the format (mm/dd/yyyy).
+string SQLite_GetSystemDate();
+
+/// @brief Returns current time.
+/// @return The current time in the format (24:mm:ss).
+string SQLite_GetSystemTime();
+
+/// @}
+
+string SQLite_GetFormattedSystemTime(string format)
+{
+    sqlquery query = SqlPrepareQueryObject(GetModule(), "SELECT STRFTIME(@format, 'now', 'localtime')");
+    SqlBindString(query, "@format", format);
+    SqlStep(query); // sqlite returns NULL for invalid format in STRFTIME()
+    return SqlGetString(query, 0);
+}
+
+int SQLite_GetTimeStamp()
+{
+    sqlquery query = SqlPrepareQueryObject(GetModule(), "SELECT STRFTIME('%s', 'now')");
+    SqlStep(query);
+    return SqlGetInt(query, 0);
+}
+
+struct SQLite_MillisecondTimeStamp SQLite_GetMillisecondTimeStamp()
+{
+    sqlquery query = SqlPrepareQueryObject(GetModule(), "SELECT STRFTIME('%s', 'now'), SUBSTR(STRFTIME('%f', 'now'), 4)");
+    SqlStep(query);
+    struct SQLite_MillisecondTimeStamp t;
+    t.seconds = SqlGetInt(query, 0);
+    t.milliseconds = SqlGetInt(query, 1);
+    return t;
+}
+
+string SQLite_GetSystemDate()
+{
+    return SQLite_GetFormattedSystemTime("%m/%d/%Y");
+}
+
+string SQLite_GetSystemTime()
+{
+    return SQLite_GetFormattedSystemTime("%H:%M:%S");
+}

--- a/Plugins/Time/NWScript/nwnx_time.nss
+++ b/Plugins/Time/NWScript/nwnx_time.nss
@@ -3,17 +3,22 @@
 /// @{
 /// @file nwnx_time.nss
 #include "nwnx"
+#include "nwnx_util"
+#include "inc_sqlite_time"
 
 const string NWNX_Time = "NWNX_Time"; ///< @private
 
 /// @brief Returns the current date.
+/// @deprecated Use SQLite functions (see inc_sqlite_time). This will be removed in future NWNX releases.
 /// @return The date in the format (mm/dd/yyyy).
 string NWNX_Time_GetSystemDate();
 
 /// @brief Returns current time.
+/// @deprecated Use SQLite functions (see inc_sqlite_time). This will be removed in future NWNX releases.
 /// @return The current time in the format (24:mm:ss).
 string NWNX_Time_GetSystemTime();
 
+/// @deprecated Use SQLite functions (see inc_sqlite_time). This will be removed in future NWNX releases.
 /// @return Returns the number of seconds since midnight on January 1, 1970.
 int NWNX_Time_GetTimeStamp();
 
@@ -24,6 +29,7 @@ struct NWNX_Time_HighResTimestamp
     int microseconds; ///< Microseconds
 };
 
+/// @deprecated Use NWNX_Util_GetHighResTimeStamp(). This will be removed in future NWNX releases.
 /// @return Returns the number of microseconds since midnight on January 1, 1970.
 struct NWNX_Time_HighResTimestamp NWNX_Time_GetHighResTimeStamp();
 
@@ -31,33 +37,28 @@ struct NWNX_Time_HighResTimestamp NWNX_Time_GetHighResTimeStamp();
 
 string NWNX_Time_GetSystemDate()
 {
-    string sFunc = "GetSystemDate";
-    NWNX_CallFunction(NWNX_Time, sFunc);
-    return NWNX_GetReturnValueString(NWNX_Time, sFunc);
+    WriteTimestampedLogEntry("WARNING:  NWNX_Time is deprecated.  You should migrate to SQLite based functions (see inc_sqlite_time).");
+    return SQLite_GetSystemDate();
 }
 
 string NWNX_Time_GetSystemTime()
 {
-    string sFunc = "GetSystemTime";
-    NWNX_CallFunction(NWNX_Time, sFunc);
-    return NWNX_GetReturnValueString(NWNX_Time, sFunc);
+    WriteTimestampedLogEntry("WARNING:  NWNX_Time is deprecated.  You should migrate to SQLite based functions (see inc_sqlite_time).");
+    return SQLite_GetSystemTime();
 }
 
 int NWNX_Time_GetTimeStamp()
 {
-    string sFunc = "GetTimeStamp";
-
-    NWNX_CallFunction(NWNX_Time, sFunc);
-    return NWNX_GetReturnValueInt(NWNX_Time, sFunc);
+    WriteTimestampedLogEntry("WARNING:  NWNX_Time is deprecated.  You should migrate to SQLite based functions (see inc_sqlite_time).");
+    return SQLite_GetTimeStamp();
 }
 
 struct NWNX_Time_HighResTimestamp NWNX_Time_GetHighResTimeStamp()
 {
+    WriteTimestampedLogEntry("WARNING:  NWNX_Time is deprecated.  NWNX_Time_GetHighResTimeStamp is moving to NWNX_Util.");
+    struct NWNX_Util_HighResTimestamp u = NWNX_Util_GetHighResTimeStamp();
     struct NWNX_Time_HighResTimestamp t;
-    string sFunc = "GetHighResTimeStamp";
-
-    NWNX_CallFunction(NWNX_Time, sFunc);
-    t.microseconds = NWNX_GetReturnValueInt(NWNX_Time, sFunc);
-    t.seconds = NWNX_GetReturnValueInt(NWNX_Time, sFunc);
+    t.seconds = u.seconds;
+    t.microseconds = u.microseconds;
     return t;
 }

--- a/Plugins/Time/Time.cpp
+++ b/Plugins/Time/Time.cpp
@@ -13,6 +13,7 @@ static Time::Time* g_plugin;
 
 NWNX_PLUGIN_ENTRY Plugin* PluginLoad(Services::ProxyServiceList* services)
 {
+    LOG_WARNING("Time plugin is deprecated.  Please migrate to inc_sqlite_time.");
     g_plugin = new Time::Time(services);
     return g_plugin;
 }

--- a/Plugins/Util/NWScript/nwnx_util.nss
+++ b/Plugins/Util/NWScript/nwnx_util.nss
@@ -35,6 +35,13 @@ struct NWNX_Util_WorldTime
     int nTimeOfDay; ///< The time of day
 };
 
+/// @brief A high resolution timestamp
+struct NWNX_Util_HighResTimestamp
+{
+    int seconds; ///< Seconds since epoch
+    int microseconds; ///< Microseconds
+};
+
 /// @brief Gets the name of the currently executing script.
 /// @note If depth is > 0, it will return the name of the script that called this one via ExecuteScript().
 /// @param depth to seek the executing script.
@@ -240,6 +247,9 @@ void NWNX_Util_SetDawnHour(int nDawnHour);
 /// @brief Set the module dusk hour.
 /// @param nDuskHour The new dusk hour
 void NWNX_Util_SetDuskHour(int nDuskHour);
+
+/// @return Returns the number of microseconds since midnight on January 1, 1970.
+struct NWNX_Util_HighResTimestamp NWNX_Util_GetHighResTimeStamp();
 
 /// @}
 
@@ -599,4 +609,15 @@ void NWNX_Util_SetDuskHour(int nDuskHour)
 
     NWNX_PushArgumentInt(NWNX_Util, sFunc, nDuskHour);
     NWNX_CallFunction(NWNX_Util, sFunc);
+}
+
+struct NWNX_Util_HighResTimestamp NWNX_Util_GetHighResTimeStamp()
+{
+    struct NWNX_Util_HighResTimestamp t;
+    string sFunc = "GetHighResTimeStamp";
+
+    NWNX_CallFunction(NWNX_Util, sFunc);
+    t.microseconds = NWNX_GetReturnValueInt(NWNX_Util, sFunc);
+    t.seconds = NWNX_GetReturnValueInt(NWNX_Util, sFunc);
+    return t;
 }

--- a/Plugins/Util/NWScript/nwnx_util_t.nss
+++ b/Plugins/Util/NWScript/nwnx_util_t.nss
@@ -57,5 +57,18 @@ void main()
 
     NWNX_Tests_Report("NWNX_Util", "GetLastCreatedObject", GetIsObjectValid(NWNX_Util_GetLastCreatedObject(4/*OBJECT_TYPE_AREA*/, 1)));
 
+    struct NWNX_Util_HighResTimestamp t1 = NWNX_Util_GetHighResTimeStamp();
+    // waste some time..
+    DestroyObject(CreateObject(OBJECT_TYPE_CREATURE, "nw_chicken", GetStartingLocation()));
+    DestroyObject(CreateObject(OBJECT_TYPE_CREATURE, "nw_chicken", GetStartingLocation()));
+    DestroyObject(CreateObject(OBJECT_TYPE_CREATURE, "nw_chicken", GetStartingLocation()));
+    DestroyObject(CreateObject(OBJECT_TYPE_CREATURE, "nw_chicken", GetStartingLocation()));
+    struct NWNX_Util_HighResTimestamp t2 = NWNX_Util_GetHighResTimeStamp();
+    WriteTimestampedLogEntry("t1.seconds: " + IntToString(t1.seconds) + "; " +
+                             "t1.microseconds: " + IntToString(t1.microseconds) + "; " +
+                             "t2.seconds: " + IntToString(t2.seconds) + "; " +
+                             "t2.microseconds: " + IntToString(t2.microseconds) + "; ");
+    NWNX_Tests_Report("NWNX_Util", "GetHighResTimeStamp", t1.microseconds != t2.microseconds);
+
     WriteTimestampedLogEntry("NWNX_Util unit test end.");
 }

--- a/Plugins/Util/Util.cpp
+++ b/Plugins/Util/Util.cpp
@@ -35,6 +35,7 @@
 #include <cstdio>
 #include <regex>
 #include <cmath>
+#include <chrono>
 
 
 using namespace NWNXLib;
@@ -96,6 +97,7 @@ Util::Util(Services::ProxyServiceList* services)
     REGISTER(GetScriptParamIsSet);
     REGISTER(SetDawnHour);
     REGISTER(SetDuskHour);
+    REGISTER(GetHighResTimeStamp);
 
 #undef REGISTER
 
@@ -843,6 +845,16 @@ ArgumentStack Util::SetDuskHour(ArgumentStack &&args)
       ASSERT_OR_THROW(duskHour <= 23);
     Utils::GetModule()->m_nDuskHour = duskHour;
     return Services::Events::Arguments();
+}
+
+ArgumentStack Util::GetHighResTimeStamp(ArgumentStack&&)
+{
+    auto now = std::chrono::system_clock::now();
+    auto dur = now.time_since_epoch();
+
+    auto count = std::chrono::duration_cast<std::chrono::microseconds>(dur).count();
+
+    return Services::Events::Arguments((int32_t)(count / 1000000), (int32_t)(count % 1000000));
 }
 
 }

--- a/Plugins/Util/Util.hpp
+++ b/Plugins/Util/Util.hpp
@@ -52,6 +52,7 @@ private:
     ArgumentStack GetScriptParamIsSet           (ArgumentStack&& args);
     ArgumentStack SetDawnHour                   (ArgumentStack&& args);
     ArgumentStack SetDuskHour                   (ArgumentStack&& args);
+    ArgumentStack GetHighResTimeStamp           (ArgumentStack&& args);
 
     size_t m_resRefIndex;
     std::vector<std::string> m_listResRefs;


### PR DESCRIPTION
Giving this a try so there is at least some code to talk about. Thanks for the comments to get started @plenarius. I have a few questions.

I did not add an optional format string argument to GetSystemDate and GetSystemDate. Nor did I add those functions specifically in the nwscript include. I figure when you can pass a format string you could make either of those functions return any format and that seemed weird.
So instead in the new include I added SQLite_GetFormattedSystemTime(string format) where you pass in a format string. That is also the function that is now used in nwnx_time.nss in NWNX_Time_GetSystemDate and NWNX_Time_GetSystemTime. Let me know what you think, please.

Should I add GetSystemDate, GetSystemTime and a new GetSystemDateTime to the include for convenience or are we going to stop providing this include file at some point and people are supposed to write their own anyway?

I'm not familiar with the DoxyGen comments. In the include should this `/// @file inc_sqlite_time.nss` match the file name or point to nwnx_time.nss (I saw that in inc_array)? Generally I'm not sure I used all the doc comments correctly.

Is it too spammy to write to the log on every call of a NWNX_Time_* function?

Is my NWNX_Time_GetHighResTimeStamp implementation correct, the bit where I just multiply the milliseconds by 1000?

Once this is on the right track I'll try to move NWNX_Time_GetHighResTimeStamp to NWNX_Util_GetHighResTimeStamp with the original implementation so there is still microsecond resolution available. I don't know any C++ so I did not start on that yet.

(Resolves #1218)