### PR TITLE
{Get/Set}AILevel for objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ https://github.com/nwnxee/unified/compare/build8193.20...HEAD
 - Util: {Get|Set}InstructionsExecuted()
 - Area: NWNX_Area_GetAmbientSound{Day/Night}()
 - Area: NWNX_Area_GetAmbientSound{Day/Night}Volume
+- Object: {Get|Set}AILevel()
 
 ### Changed
 - Creature: Functions for CriticalMultipler and CriticalRange extended to allow declaration of nBaseItem. Order of Overrides is Specified Baseitem > Specified Hand > non-Specified. Modifiers now apply in addition to overrides (rather than only in the absence of overrides). _**ABI breaking:** You will need to update nwnx_creature.nss if you are using these functions_.

--- a/Plugins/Object/NWScript/nwnx_object.nss
+++ b/Plugins/Object/NWScript/nwnx_object.nss
@@ -339,6 +339,16 @@ void NWNX_Object_SetHasInventory(object obj, int bHasInventory);
 /// @return -1 on error or the engine animation constant
 int NWNX_Object_GetCurrentAnimation(object oObject);
 
+/// @brief Gets the AI level of an object.
+/// @param oObject The object.
+/// @return The AI level (AI_LEVEL_* -1 to 4).
+int NWNX_Object_GetAILevel(object oObject);
+
+/// @brief Sets the AI level of an object.
+/// @param oObject The object.
+/// @param nLevel The level to set (AI_LEVEL_* -1 to 4).
+void NWNX_Object_SetAILevel(object oObject, int nLevel);
+
 /// @}
 
 int NWNX_Object_GetLocalVariableCount(object obj)
@@ -831,4 +841,24 @@ int NWNX_Object_GetCurrentAnimation(object oObject)
     NWNX_CallFunction(NWNX_Object, sFunc);
 
     return NWNX_GetReturnValueInt(NWNX_Object, sFunc);
+}
+
+int NWNX_Object_GetAILevel(object oObject)
+{
+    string sFunc = "GetAILevel";
+
+    NWNX_PushArgumentObject(NWNX_Object, sFunc, oObject);
+    NWNX_CallFunction(NWNX_Object, sFunc);
+
+    return NWNX_GetReturnValueInt(NWNX_Object, sFunc);
+}
+
+void NWNX_Object_SetAILevel(object oObject, int nLevel)
+{
+    string sFunc = "SetAILevel";
+
+    NWNX_PushArgumentInt(NWNX_Object, sFunc, nLevel);
+    NWNX_PushArgumentObject(NWNX_Object, sFunc, oObject);
+
+    NWNX_CallFunction(NWNX_Object, sFunc);
 }

--- a/Plugins/Object/NWScript/nwnx_object_t.nss
+++ b/Plugins/Object/NWScript/nwnx_object_t.nss
@@ -117,6 +117,11 @@ void main()
     NWNX_Tests_Report("NWNX_Object", "SetHasInventory", GetHasInventory(oPlc) == !bHasInventory);
     DestroyObject(oPlc);
 
+    oPlc = CreateObject(OBJECT_TYPE_PLACEABLE, "nw_plc_driftwd1", GetStartingLocation());
+    NWNX_Object_SetAILevel(oPlc, AI_LEVEL_VERY_HIGH);
+    NWNX_Tests_Report("NWNX_Object", "{Get/Set}AILevel", NWNX_Object_GetAILevel(oPlc) == AI_LEVEL_VERY_HIGH);
+    DestroyObject(oPlc);
+
     DestroyObject(o);
     DestroyObject(oDeserialized);
     WriteTimestampedLogEntry("NWNX_Object unit test end.");

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -1,6 +1,7 @@
 #include "Object.hpp"
 
 #include "API/CAppManager.hpp"
+#include "API/CServerAIMaster.hpp"
 #include "API/CServerExoApp.hpp"
 #include "API/CNWSObject.hpp"
 #include "API/CNWSScriptVar.hpp"
@@ -100,6 +101,8 @@ Object::Object(Services::ProxyServiceList* services)
     REGISTER(DoSpellLevelAbsorption);
     REGISTER(SetHasInventory);
     REGISTER(GetCurrentAnimation);
+    REGISTER(GetAILevel);
+    REGISTER(SetAILevel);
 
 #undef REGISTER
 }
@@ -1001,6 +1004,32 @@ ArgumentStack Object::GetCurrentAnimation(ArgumentStack&& args)
     }
 
     return Services::Events::Arguments(retVal);
+}
+
+ArgumentStack Object::GetAILevel(ArgumentStack&& args)
+{
+    int32_t retVal = -1;
+
+    if (auto *pObject = object(args))
+    {
+        retVal = pObject->m_nAILevel;
+    }
+
+    return Services::Events::Arguments(retVal);
+}
+
+ArgumentStack Object::SetAILevel(ArgumentStack&& args)
+{
+    if (auto *pObject = object(args))
+    {
+        const auto nLevel = Services::Events::ExtractArgument<int32_t>(args);
+        ASSERT_OR_THROW(nLevel >= -1);
+        ASSERT_OR_THROW(nLevel <= 4);
+        auto *ai = Globals::AppManager()->m_pServerExoApp->GetServerAIMaster();
+        ai->SetAILevel(pObject, nLevel);
+    }
+
+    return Services::Events::Arguments();
 }
 
 }

--- a/Plugins/Object/Object.hpp
+++ b/Plugins/Object/Object.hpp
@@ -62,6 +62,8 @@ private:
     ArgumentStack DoSpellLevelAbsorption    (ArgumentStack&& args);
     ArgumentStack SetHasInventory           (ArgumentStack&& args);
     ArgumentStack GetCurrentAnimation       (ArgumentStack&& args);
+    ArgumentStack GetAILevel                (ArgumentStack&& args);
+    ArgumentStack SetAILevel                (ArgumentStack&& args);
 
     CNWSObject *object(ArgumentStack& args);
 };


### PR DESCRIPTION
Functions as requested in #960.

In my tests it "worked fine" insofar as levels between -1 and 4 could be read and set for all types of objects. Items, placeables, creatures, doors and even a PC.

Should this be limited to certain object types, like placeable, anyway?

Is setting of AI level 4 ok? It seemed to work but in the nwnlexicon it says that 4 (AI_LEVEL_VERY_HIGH) can not be set manually on creatures with the base game function and that level is reserved to creatures in combat.