### PR TITLE
Get/Set perspace and related fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ https://github.com/nwnxee/unified/compare/build8193.20...HEAD
 - Creature: DoPerceptionUpdateOnCreature()
 - Creature: {Get/Set}PersonalSpace()
 - Creature: {Get/Set}CreaturePersonalSpace()
+- Creature: {Get/Set}Height()
 - Encounter: GetGeometry()
 - Encounter: SetGeometry()
 - Util: GetInstructionLimit()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ https://github.com/nwnxee/unified/compare/build8193.20...HEAD
 - Creature: {Get/Set}PersonalSpace()
 - Creature: {Get/Set}CreaturePersonalSpace()
 - Creature: {Get/Set}Height()
+- Creature: {Get/Set}HitDistance()
 - Encounter: GetGeometry()
 - Encounter: SetGeometry()
 - Util: GetInstructionLimit()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ https://github.com/nwnxee/unified/compare/build8193.20...HEAD
 ##### New NWScript Functions
 - Creature: ComputeSafeLocation()
 - Creature: DoPerceptionUpdateOnCreature()
+- Creature: {Get/Set}PersonalSpace()
 - Encounter: GetGeometry()
 - Encounter: SetGeometry()
 - Util: GetInstructionLimit()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ https://github.com/nwnxee/unified/compare/build8193.20...HEAD
 - Creature: ComputeSafeLocation()
 - Creature: DoPerceptionUpdateOnCreature()
 - Creature: {Get/Set}PersonalSpace()
+- Creature: {Get/Set}CreaturePersonalSpace()
 - Encounter: GetGeometry()
 - Encounter: SetGeometry()
 - Util: GetInstructionLimit()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ https://github.com/nwnxee/unified/compare/build8193.20...HEAD
 - Creature: {Get/Set}CreaturePersonalSpace()
 - Creature: {Get/Set}Height()
 - Creature: {Get/Set}HitDistance()
+- Creature: {Get/Set}PreferredAttackDistance()
 - Encounter: GetGeometry()
 - Encounter: SetGeometry()
 - Util: GetInstructionLimit()

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -190,6 +190,8 @@ Creature::Creature(Services::ProxyServiceList* services)
     REGISTER(SetCreaturePersonalSpace);
     REGISTER(GetHeight);
     REGISTER(SetHeight);
+    REGISTER(GetHitDistance);
+    REGISTER(SetHitDistance);
 
 #undef REGISTER
 }
@@ -3195,6 +3197,35 @@ ArgumentStack Creature::SetHeight(ArgumentStack&& args)
         if (pCreature->m_pcPathfindInformation)
         {
             pCreature->m_pcPathfindInformation->m_fHeight = fHeight;
+        }
+    }
+
+    return Services::Events::Arguments();
+}
+
+ArgumentStack Creature::GetHitDistance(ArgumentStack&& args)
+{
+    float retVal = 0;
+    if (auto *pCreature = creature(args))
+    {
+        if (pCreature->m_pcPathfindInformation)
+        {
+            retVal = pCreature->m_pcPathfindInformation->m_fHitDistance;
+        }
+    }
+
+    return Services::Events::Arguments(retVal);
+}
+
+ArgumentStack Creature::SetHitDistance(ArgumentStack&& args)
+{
+    if (auto *pCreature = creature(args))
+    {
+        const auto fHitDist = Services::Events::ExtractArgument<float>(args);
+        ASSERT_OR_THROW(fHitDist >= 0);
+        if (pCreature->m_pcPathfindInformation)
+        {
+            pCreature->m_pcPathfindInformation->m_fHitDistance = fHitDist;
         }
     }
 

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -192,6 +192,8 @@ Creature::Creature(Services::ProxyServiceList* services)
     REGISTER(SetHeight);
     REGISTER(GetHitDistance);
     REGISTER(SetHitDistance);
+    REGISTER(GetPreferredAttackDistance);
+    REGISTER(SetPreferredAttackDistance);
 
 #undef REGISTER
 }
@@ -3227,6 +3229,29 @@ ArgumentStack Creature::SetHitDistance(ArgumentStack&& args)
         {
             pCreature->m_pcPathfindInformation->m_fHitDistance = fHitDist;
         }
+    }
+
+    return Services::Events::Arguments();
+}
+
+ArgumentStack Creature::GetPreferredAttackDistance(ArgumentStack&& args)
+{
+    float retVal = 0;
+    if (auto *pCreature = creature(args))
+    {
+        retVal = pCreature->m_fPreferredAttackDistance;
+    }
+
+    return Services::Events::Arguments(retVal);
+}
+
+ArgumentStack Creature::SetPreferredAttackDistance(ArgumentStack&& args)
+{
+    if (auto *pCreature = creature(args))
+    {
+        const auto fPrefAtckDist = Services::Events::ExtractArgument<float>(args);
+        ASSERT_OR_THROW(fPrefAtckDist >= 0);
+        pCreature->m_fPreferredAttackDistance = fPrefAtckDist;
     }
 
     return Services::Events::Arguments();

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -26,6 +26,7 @@
 #include "API/CNWSCombatRound.hpp"
 #include "API/CEffectIconObject.hpp"
 #include "API/CNWSArea.hpp"
+#include "API/CPathfindInformation.hpp"
 #include "API/Constants.hpp"
 #include "API/Globals.hpp"
 #include "API/Functions.hpp"
@@ -183,6 +184,8 @@ Creature::Creature(Services::ProxyServiceList* services)
     REGISTER(SetNoPermanentDeath);
     REGISTER(ComputeSafeLocation);
     REGISTER(DoPerceptionUpdateOnCreature);
+    REGISTER(GetPersonalSpace);
+    REGISTER(SetPersonalSpace);
 
 #undef REGISTER
 }
@@ -3100,6 +3103,36 @@ ArgumentStack Creature::DoPerceptionUpdateOnCreature(ArgumentStack&& args)
         if (auto *pTargetCreature = creature(args))
         {
             pCreature->DoPerceptionUpdateOnCreature(pTargetCreature);
+        }
+    }
+
+    return Services::Events::Arguments();
+}
+
+ArgumentStack Creature::GetPersonalSpace(ArgumentStack&& args)
+{
+    float retVal = 0;
+    if (auto *pCreature = creature(args))
+    {
+        if (pCreature->m_pcPathfindInformation)
+        {
+            retVal = pCreature->m_pcPathfindInformation->m_fPersonalSpace;
+        }
+    }
+
+    return Services::Events::Arguments(retVal);
+}
+
+ArgumentStack Creature::SetPersonalSpace(ArgumentStack&& args)
+{
+    if (auto *pCreature = creature(args))
+    {
+        const auto fPerspace = Services::Events::ExtractArgument<float>(args);
+        ASSERT_OR_THROW(fPerspace >= 0);
+        if (pCreature->m_pcPathfindInformation)
+        {
+            pCreature->m_pcPathfindInformation->m_fPersonalSpace = fPerspace;
+            pCreature->m_pcPathfindInformation->ComputeStepTolerance();
         }
     }
 

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -188,6 +188,8 @@ Creature::Creature(Services::ProxyServiceList* services)
     REGISTER(SetPersonalSpace);
     REGISTER(GetCreaturePersonalSpace);
     REGISTER(SetCreaturePersonalSpace);
+    REGISTER(GetHeight);
+    REGISTER(SetHeight);
 
 #undef REGISTER
 }
@@ -3164,6 +3166,35 @@ ArgumentStack Creature::SetCreaturePersonalSpace(ArgumentStack&& args)
         if (pCreature->m_pcPathfindInformation)
         {
             pCreature->m_pcPathfindInformation->m_fCreaturePersonalSpace = fCrePerspace;
+        }
+    }
+
+    return Services::Events::Arguments();
+}
+
+ArgumentStack Creature::GetHeight(ArgumentStack&& args)
+{
+    float retVal = 0;
+    if (auto *pCreature = creature(args))
+    {
+        if (pCreature->m_pcPathfindInformation)
+        {
+            retVal = pCreature->m_pcPathfindInformation->m_fHeight;
+        }
+    }
+
+    return Services::Events::Arguments(retVal);
+}
+
+ArgumentStack Creature::SetHeight(ArgumentStack&& args)
+{
+    if (auto *pCreature = creature(args))
+    {
+        const auto fHeight = Services::Events::ExtractArgument<float>(args);
+        ASSERT_OR_THROW(fHeight >= 0);
+        if (pCreature->m_pcPathfindInformation)
+        {
+            pCreature->m_pcPathfindInformation->m_fHeight = fHeight;
         }
     }
 

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -186,6 +186,8 @@ Creature::Creature(Services::ProxyServiceList* services)
     REGISTER(DoPerceptionUpdateOnCreature);
     REGISTER(GetPersonalSpace);
     REGISTER(SetPersonalSpace);
+    REGISTER(GetCreaturePersonalSpace);
+    REGISTER(SetCreaturePersonalSpace);
 
 #undef REGISTER
 }
@@ -3133,6 +3135,35 @@ ArgumentStack Creature::SetPersonalSpace(ArgumentStack&& args)
         {
             pCreature->m_pcPathfindInformation->m_fPersonalSpace = fPerspace;
             pCreature->m_pcPathfindInformation->ComputeStepTolerance();
+        }
+    }
+
+    return Services::Events::Arguments();
+}
+
+ArgumentStack Creature::GetCreaturePersonalSpace(ArgumentStack&& args)
+{
+    float retVal = 0;
+    if (auto *pCreature = creature(args))
+    {
+        if (pCreature->m_pcPathfindInformation)
+        {
+            retVal = pCreature->m_pcPathfindInformation->m_fCreaturePersonalSpace;
+        }
+    }
+
+    return Services::Events::Arguments(retVal);
+}
+
+ArgumentStack Creature::SetCreaturePersonalSpace(ArgumentStack&& args)
+{
+    if (auto *pCreature = creature(args))
+    {
+        const auto fCrePerspace = Services::Events::ExtractArgument<float>(args);
+        ASSERT_OR_THROW(fCrePerspace >= 0);
+        if (pCreature->m_pcPathfindInformation)
+        {
+            pCreature->m_pcPathfindInformation->m_fCreaturePersonalSpace = fCrePerspace;
         }
     }
 

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -134,6 +134,8 @@ private:
     ArgumentStack SetNoPermanentDeath           (ArgumentStack&& args);
     ArgumentStack ComputeSafeLocation           (ArgumentStack&& args);
     ArgumentStack DoPerceptionUpdateOnCreature  (ArgumentStack&& args);
+    ArgumentStack GetPersonalSpace              (ArgumentStack&& args);
+    ArgumentStack SetPersonalSpace              (ArgumentStack&& args);
 
     CNWSCreature *creature(ArgumentStack& args);
     std::unordered_map<uint8_t, std::unordered_map<ObjectID, int16_t>> m_RollModifier;

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -140,6 +140,8 @@ private:
     ArgumentStack SetCreaturePersonalSpace      (ArgumentStack&& args);
     ArgumentStack GetHeight                     (ArgumentStack&& args);
     ArgumentStack SetHeight                     (ArgumentStack&& args);
+    ArgumentStack GetHitDistance                (ArgumentStack&& args);
+    ArgumentStack SetHitDistance                (ArgumentStack&& args);
 
     CNWSCreature *creature(ArgumentStack& args);
     std::unordered_map<uint8_t, std::unordered_map<ObjectID, int16_t>> m_RollModifier;

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -136,6 +136,8 @@ private:
     ArgumentStack DoPerceptionUpdateOnCreature  (ArgumentStack&& args);
     ArgumentStack GetPersonalSpace              (ArgumentStack&& args);
     ArgumentStack SetPersonalSpace              (ArgumentStack&& args);
+    ArgumentStack GetCreaturePersonalSpace      (ArgumentStack&& args);
+    ArgumentStack SetCreaturePersonalSpace      (ArgumentStack&& args);
 
     CNWSCreature *creature(ArgumentStack& args);
     std::unordered_map<uint8_t, std::unordered_map<ObjectID, int16_t>> m_RollModifier;

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -138,6 +138,8 @@ private:
     ArgumentStack SetPersonalSpace              (ArgumentStack&& args);
     ArgumentStack GetCreaturePersonalSpace      (ArgumentStack&& args);
     ArgumentStack SetCreaturePersonalSpace      (ArgumentStack&& args);
+    ArgumentStack GetHeight                     (ArgumentStack&& args);
+    ArgumentStack SetHeight                     (ArgumentStack&& args);
 
     CNWSCreature *creature(ArgumentStack& args);
     std::unordered_map<uint8_t, std::unordered_map<ObjectID, int16_t>> m_RollModifier;

--- a/Plugins/Creature/Creature.hpp
+++ b/Plugins/Creature/Creature.hpp
@@ -142,6 +142,8 @@ private:
     ArgumentStack SetHeight                     (ArgumentStack&& args);
     ArgumentStack GetHitDistance                (ArgumentStack&& args);
     ArgumentStack SetHitDistance                (ArgumentStack&& args);
+    ArgumentStack GetPreferredAttackDistance    (ArgumentStack&& args);
+    ArgumentStack SetPreferredAttackDistance    (ArgumentStack&& args);
 
     CNWSCreature *creature(ArgumentStack& args);
     std::unordered_map<uint8_t, std::unordered_map<ObjectID, int16_t>> m_RollModifier;

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -885,6 +885,16 @@ float NWNX_Creature_GetHitDistance(object oCreature);
 /// @param fHitDist The creatures hit distance.
 void NWNX_Creature_SetHitDistance(object oCreature, float fHitDist);
 
+/// @brief Get a creatures preferred attack distance.
+/// @param oCreature The creature.
+/// @return The creatures preferred attack distance.
+float NWNX_Creature_GetPreferredAttackDistance(object oCreature);
+
+/// @brief Set a creatures preferred attack distance.
+/// @param oCreature The creature.
+/// @param fPrefAtckDist The creatures preferred attack distance.
+void NWNX_Creature_SetPreferredAttackDistance(object oCreature, float fPrefAtckDist);
+
 /// @}
 
 void NWNX_Creature_AddFeat(object creature, int feat)
@@ -2261,6 +2271,25 @@ void NWNX_Creature_SetHitDistance(object oCreature, float fHitDist)
     string sFunc = "SetHitDistance";
 
     NWNX_PushArgumentFloat(NWNX_Creature, sFunc, fHitDist);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+float NWNX_Creature_GetPreferredAttackDistance(object oCreature)
+{
+    string sFunc = "GetPreferredAttackDistance";
+
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+
+    return NWNX_GetReturnValueFloat(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_SetPreferredAttackDistance(object oCreature, float fPrefAtckDist)
+{
+    string sFunc = "SetPreferredAttackDistance";
+
+    NWNX_PushArgumentFloat(NWNX_Creature, sFunc, fPrefAtckDist);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -845,6 +845,16 @@ vector NWNX_Creature_ComputeSafeLocation(object oCreature, vector vPosition, flo
 /// @param oTargetCreature The target creature.
 void NWNX_Creature_DoPerceptionUpdateOnCreature(object oCreature, object oTargetCreature);
 
+/// @brief Get a creatures personal space (meters from center to non-creature objects).
+/// @param oCreature The creature.
+/// @return The creatures personal space.
+float NWNX_Creature_GetPersonalSpace(object oCreature);
+
+/// @brief Set a creatures personal space (meters from center to non-creature objects).
+/// @param oCreature The creature.
+/// @param fPerspace The creatures personal space.
+void NWNX_Creature_SetPersonalSpace(object oCreature, float fPerspace);
+
 /// @}
 
 void NWNX_Creature_AddFeat(object creature, int feat)
@@ -2145,6 +2155,25 @@ void NWNX_Creature_DoPerceptionUpdateOnCreature(object oCreature, object oTarget
     string sFunc = "DoPerceptionUpdateOnCreature";
 
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, oTargetCreature);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+float NWNX_Creature_GetPersonalSpace(object oCreature)
+{
+    string sFunc = "GetPersonalSpace";
+
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+
+    return NWNX_GetReturnValueFloat(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_SetPersonalSpace(object oCreature, float fPerspace)
+{
+    string sFunc = "SetPersonalSpace";
+
+    NWNX_PushArgumentFloat(NWNX_Creature, sFunc, fPerspace);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -855,6 +855,16 @@ float NWNX_Creature_GetPersonalSpace(object oCreature);
 /// @param fPerspace The creatures personal space.
 void NWNX_Creature_SetPersonalSpace(object oCreature, float fPerspace);
 
+/// @brief Get a creatures creature personal space (meters from center to other creatures).
+/// @param oCreature The creature.
+/// @return The creatures creature personal space.
+float NWNX_Creature_GetCreaturePersonalSpace(object oCreature);
+
+/// @brief Set a creatures creature personal space (meters from center to other creatures).
+/// @param oCreature The creature.
+/// @param fCrePerspace The creatures creature personal space.
+void NWNX_Creature_SetCreaturePersonalSpace(object oCreature, float fCrePerspace);
+
 /// @}
 
 void NWNX_Creature_AddFeat(object creature, int feat)
@@ -2174,6 +2184,25 @@ void NWNX_Creature_SetPersonalSpace(object oCreature, float fPerspace)
     string sFunc = "SetPersonalSpace";
 
     NWNX_PushArgumentFloat(NWNX_Creature, sFunc, fPerspace);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+float NWNX_Creature_GetCreaturePersonalSpace(object oCreature)
+{
+    string sFunc = "GetCreaturePersonalSpace";
+
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+
+    return NWNX_GetReturnValueFloat(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_SetCreaturePersonalSpace(object oCreature, float fCrePerspace)
+{
+    string sFunc = "SetCreaturePersonalSpace";
+
+    NWNX_PushArgumentFloat(NWNX_Creature, sFunc, fCrePerspace);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -875,6 +875,16 @@ float NWNX_Creature_GetHeight(object oCreature);
 /// @param fHeight The creatures height.
 void NWNX_Creature_SetHeight(object oCreature, float fHeight);
 
+/// @brief Get a creatures hit distance.
+/// @param oCreature The creature.
+/// @return The creatures hit distance.
+float NWNX_Creature_GetHitDistance(object oCreature);
+
+/// @brief Set a creatures hit distance.
+/// @param oCreature The creature.
+/// @param fHitDist The creatures hit distance.
+void NWNX_Creature_SetHitDistance(object oCreature, float fHitDist);
+
 /// @}
 
 void NWNX_Creature_AddFeat(object creature, int feat)
@@ -2232,6 +2242,25 @@ void NWNX_Creature_SetHeight(object oCreature, float fHeight)
     string sFunc = "SetHeight";
 
     NWNX_PushArgumentFloat(NWNX_Creature, sFunc, fHeight);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+float NWNX_Creature_GetHitDistance(object oCreature)
+{
+    string sFunc = "GetHitDistance";
+
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+
+    return NWNX_GetReturnValueFloat(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_SetHitDistance(object oCreature, float fHitDist)
+{
+    string sFunc = "SetHitDistance";
+
+    NWNX_PushArgumentFloat(NWNX_Creature, sFunc, fHitDist);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -865,6 +865,16 @@ float NWNX_Creature_GetCreaturePersonalSpace(object oCreature);
 /// @param fCrePerspace The creatures creature personal space.
 void NWNX_Creature_SetCreaturePersonalSpace(object oCreature, float fCrePerspace);
 
+/// @brief Get a creatures height.
+/// @param oCreature The creature.
+/// @return The creatures height.
+float NWNX_Creature_GetHeight(object oCreature);
+
+/// @brief Set a creatures height.
+/// @param oCreature The creature.
+/// @param fHeight The creatures height.
+void NWNX_Creature_SetHeight(object oCreature, float fHeight);
+
 /// @}
 
 void NWNX_Creature_AddFeat(object creature, int feat)
@@ -2203,6 +2213,25 @@ void NWNX_Creature_SetCreaturePersonalSpace(object oCreature, float fCrePerspace
     string sFunc = "SetCreaturePersonalSpace";
 
     NWNX_PushArgumentFloat(NWNX_Creature, sFunc, fCrePerspace);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+float NWNX_Creature_GetHeight(object oCreature)
+{
+    string sFunc = "GetHeight";
+
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+
+    return NWNX_GetReturnValueFloat(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_SetHeight(object oCreature, float fHeight)
+{
+    string sFunc = "SetHeight";
+
+    NWNX_PushArgumentFloat(NWNX_Creature, sFunc, fHeight);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -24,6 +24,9 @@ void main()
     NWNX_Creature_SetCreaturePersonalSpace(oCreature, 0.25);
     NWNX_Tests_Report("NWNX_Creature", "{Set/Get}CreaturePersonalSpace", NWNX_Creature_GetCreaturePersonalSpace(oCreature) == 0.25);
 
+    NWNX_Creature_SetHeight(oCreature, 0.4);
+    NWNX_Tests_Report("NWNX_Creature", "{Set/Get}Height", NWNX_Creature_GetHeight(oCreature) == 0.4);
+
     //
     // FEAT related functions
     //

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -30,6 +30,9 @@ void main()
     NWNX_Creature_SetHitDistance(oCreature, 0.3);
     NWNX_Tests_Report("NWNX_Creature", "{Set/Get}HitDistance", NWNX_Creature_GetHitDistance(oCreature) == 0.3);
 
+    NWNX_Creature_SetPreferredAttackDistance(oCreature, 1.1);
+    NWNX_Tests_Report("NWNX_Creature", "{Set/Get}PreferredAttackDistance", NWNX_Creature_GetPreferredAttackDistance(oCreature) == 1.1);
+
     //
     // FEAT related functions
     //

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -14,6 +14,12 @@ void main()
         return;
     }
 
+    //
+    // Personal space related functions
+    //
+
+    NWNX_Creature_SetPersonalSpace(oCreature, 0.5);
+    NWNX_Tests_Report("NWNX_Creature", "{Set/Get}PersonalSpace", NWNX_Creature_GetPersonalSpace(oCreature) == 0.5);
 
     //
     // FEAT related functions

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -27,6 +27,9 @@ void main()
     NWNX_Creature_SetHeight(oCreature, 0.4);
     NWNX_Tests_Report("NWNX_Creature", "{Set/Get}Height", NWNX_Creature_GetHeight(oCreature) == 0.4);
 
+    NWNX_Creature_SetHitDistance(oCreature, 0.3);
+    NWNX_Tests_Report("NWNX_Creature", "{Set/Get}HitDistance", NWNX_Creature_GetHitDistance(oCreature) == 0.3);
+
     //
     // FEAT related functions
     //

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -21,6 +21,9 @@ void main()
     NWNX_Creature_SetPersonalSpace(oCreature, 0.5);
     NWNX_Tests_Report("NWNX_Creature", "{Set/Get}PersonalSpace", NWNX_Creature_GetPersonalSpace(oCreature) == 0.5);
 
+    NWNX_Creature_SetCreaturePersonalSpace(oCreature, 0.25);
+    NWNX_Tests_Report("NWNX_Creature", "{Set/Get}CreaturePersonalSpace", NWNX_Creature_GetCreaturePersonalSpace(oCreature) == 0.25);
+
     //
     // FEAT related functions
     //


### PR DESCRIPTION
Resolves #1194.

I don't know if ComputeStepTolerance() does what it is supposed to do and how to test that.

I think these functions can be used well together with SetObjectVisualTransform for OBJECT_VISUAL_TRANSFORM_SCALE.
Considering that, would it make sense to add getter and setter for `m_fPreferredAttackDistance`?

I scaled a dragon down with visual transform and reduced the perspace fields by the same factor.
It works for collision detection but the walk animation is off. Does this have to do with the fields `WALKDIST` and `RUNDIST` from appearance.2da? Can it be changed via the creature object?
I saw `float ComputeTotalWalkDistance()` but did not get further than that.

Edit: Daz told me walk animation can be changed with SetObjectVisualTransform() for OBJECT_VISUAL_TRANSFORM_ANIMATION_SPEED. So that seems to be sufficient.