### PR TITLE
Get and set servers min and max level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ https://github.com/nwnxee/unified/compare/build8193.20...HEAD
 - Util: {Get|Set}InstructionsExecuted()
 - Area: NWNX_Area_GetAmbientSound{Day/Night}()
 - Area: NWNX_Area_GetAmbientSound{Day/Night}Volume
+- Admin: {Get/Set}MinLevel()
+- Admin: {Get/Set}MaxLevel()
 - Object: {Get|Set}AILevel()
 
 ### Changed

--- a/Plugins/Administration/Administration.cpp
+++ b/Plugins/Administration/Administration.cpp
@@ -68,6 +68,10 @@ Administration::Administration(Services::ProxyServiceList* services)
     REGISTER(GetDebugValue);
     REGISTER(SetDebugValue);
     REGISTER(ReloadRules);
+    REGISTER(GetMinLevel);
+    REGISTER(SetMinLevel);
+    REGISTER(GetMaxLevel);
+    REGISTER(SetMaxLevel);
 
 #undef REGISTER
 }
@@ -670,6 +674,40 @@ Events::ArgumentStack Administration::ReloadRules(Events::ArgumentStack&&)
 {
     LOG_NOTICE("Reloading rules!");
     Globals::Rules()->ReloadAll();
+    return Events::Arguments();
+}
+
+Events::ArgumentStack Administration::GetMinLevel(Events::ArgumentStack&&)
+{
+    auto *pServerInfo = Globals::AppManager()->m_pServerExoApp->GetServerInfo();
+    return Events::Arguments(pServerInfo->m_JoiningRestrictions.nMinLevel);
+}
+
+Events::ArgumentStack Administration::SetMinLevel(Events::ArgumentStack&& args)
+{
+    const auto nLevel = Events::ExtractArgument<int32_t>(args);
+    ASSERT_OR_THROW(nLevel >= 1);
+    ASSERT_OR_THROW(nLevel <= 255);
+    LOG_NOTICE("Set minimum level to %d.", nLevel);
+    auto *pServerInfo = Globals::AppManager()->m_pServerExoApp->GetServerInfo();
+    pServerInfo->m_JoiningRestrictions.nMinLevel = nLevel;
+    return Events::Arguments();
+}
+
+Events::ArgumentStack Administration::GetMaxLevel(Events::ArgumentStack&&)
+{
+    auto *pServerInfo = Globals::AppManager()->m_pServerExoApp->GetServerInfo();
+    return Events::Arguments(pServerInfo->m_JoiningRestrictions.nMaxLevel);
+}
+
+Events::ArgumentStack Administration::SetMaxLevel(Events::ArgumentStack&& args)
+{
+    const auto nLevel = Events::ExtractArgument<int32_t>(args);
+    ASSERT_OR_THROW(nLevel >= 1);
+    ASSERT_OR_THROW(nLevel <= 255);
+    LOG_NOTICE("Set maximum level to %d.", nLevel);
+    auto *pServerInfo = Globals::AppManager()->m_pServerExoApp->GetServerInfo();
+    pServerInfo->m_JoiningRestrictions.nMaxLevel = nLevel;
     return Events::Arguments();
 }
 

--- a/Plugins/Administration/Administration.hpp
+++ b/Plugins/Administration/Administration.hpp
@@ -37,6 +37,10 @@ public:
     ArgumentStack GetDebugValue             (ArgumentStack&& args);
     ArgumentStack SetDebugValue             (ArgumentStack&& args);
     ArgumentStack ReloadRules               (ArgumentStack&& args);
+    ArgumentStack GetMinLevel               (ArgumentStack&& args);
+    ArgumentStack SetMinLevel               (ArgumentStack&& args);
+    ArgumentStack GetMaxLevel               (ArgumentStack&& args);
+    ArgumentStack SetMaxLevel               (ArgumentStack&& args);
 };
 
 }

--- a/Plugins/Administration/NWScript/nwnx_admin.nss
+++ b/Plugins/Administration/NWScript/nwnx_admin.nss
@@ -156,6 +156,23 @@ void NWNX_Administration_SetDebugValue(int type, int state);
 /// @warning DANGER, DRAGONS. Bad things may or may not happen.
 void NWNX_Administration_ReloadRules();
 
+/// @brief Get the servers minimum level.
+/// @return The minimum level for the server.
+int NWNX_Administration_GetMinLevel();
+
+/// @brief Set the servers minimum level.
+/// @param nLevel The minimum level for the server.
+void NWNX_Administration_SetMinLevel(int nLevel);
+
+/// @brief Get the servers maximum level.
+/// @return The maximum level for the server.
+int NWNX_Administration_GetMaxLevel();
+
+/// @brief Set the servers maximum level.
+/// @note Attention when using this and the MaxLevel plugin. They both change the same value.
+/// @param nLevel The maximum level for the server.
+void NWNX_Administration_SetMaxLevel(int nLevel);
+
 /// @}
 
 string NWNX_Administration_GetPlayerPassword()
@@ -340,5 +357,33 @@ void NWNX_Administration_ReloadRules()
 {
     string sFunc = "ReloadRules";
 
+    NWNX_CallFunction(NWNX_Administration, sFunc);
+}
+
+int NWNX_Administration_GetMinLevel()
+{
+    string sFunc = "GetMinLevel";
+    NWNX_CallFunction(NWNX_Administration, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Administration, sFunc);
+}
+
+void NWNX_Administration_SetMinLevel(int nLevel)
+{
+    string sFunc = "SetMinLevel";
+    NWNX_PushArgumentInt(NWNX_Administration, sFunc, nLevel);
+    NWNX_CallFunction(NWNX_Administration, sFunc);
+}
+
+int NWNX_Administration_GetMaxLevel()
+{
+    string sFunc = "GetMaxLevel";
+    NWNX_CallFunction(NWNX_Administration, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Administration, sFunc);
+}
+
+void NWNX_Administration_SetMaxLevel(int nLevel)
+{
+    string sFunc = "SetMaxLevel";
+    NWNX_PushArgumentInt(NWNX_Administration, sFunc, nLevel);
     NWNX_CallFunction(NWNX_Administration, sFunc);
 }

--- a/Plugins/Administration/NWScript/nwnx_admin_t.nss
+++ b/Plugins/Administration/NWScript/nwnx_admin_t.nss
@@ -22,5 +22,13 @@ void main()
     NWNX_Administration_SetDebugValue(NWNX_ADMINISTRATION_DEBUG_MOVEMENT_SPEED, TRUE);
     NWNX_Tests_Report("NWNX_Administration", "{Set/Get}DebugValue", NWNX_Administration_GetDebugValue(NWNX_ADMINISTRATION_DEBUG_MOVEMENT_SPEED));
 
+    NWNX_Administration_SetMinLevel(6);
+    NWNX_Tests_Report("NWNX_Administration", "{Set/Get}MinLevel", NWNX_Administration_GetMinLevel() == 6);
+    NWNX_Administration_SetMinLevel(1);
+
+    NWNX_Administration_SetMaxLevel(20);
+    NWNX_Tests_Report("NWNX_Administration", "{Set/Get}MaxLevel", NWNX_Administration_GetMaxLevel() == 20);
+    NWNX_Administration_SetMaxLevel(40);
+
     WriteTimestampedLogEntry("NWNX_Administration unit test end.");
 }


### PR DESCRIPTION
Resolves #1226.

Looks good after brief testing. The server info is updated and characters are denied login based on the set level range. Characters already on the server are not affected.

I limited the level value to >= 1 and <= 255 because in the clients server info display it seems to be a byte, the display overflowed at 256.