### PR TITLE
SWIG: Expose CNWArea, CNWItem and default constructors

### DIFF
--- a/Plugins/SWIG/CMakeLists.txt
+++ b/Plugins/SWIG/CMakeLists.txt
@@ -22,5 +22,5 @@ function(add_swig_plugin target)
 endfunction()
 
 if(SWIG_FOUND)
-    add_swig_plugin(SWIG_DotNET -csharp -dllimport "${PLUGIN_PREFIX}SWIG_DotNET" -namespace "NWN.Native.API")
+    add_swig_plugin(SWIG_DotNET -DSWIGWORDSIZE64 -csharp -dllimport "${PLUGIN_PREFIX}SWIG_DotNET" -namespace "NWN.Native.API")
 endif(SWIG_FOUND)

--- a/Plugins/SWIG/SWIG_DotNET.i
+++ b/Plugins/SWIG/SWIG_DotNET.i
@@ -1,6 +1,7 @@
 %module NWNXLib
 
 %include <stdint.i>
+%include <swiginterface.i>
 
 #pragma SWIG nowarn=317
 #define NWNXLIB_FUNCTION_NO_VERSION_CHECK
@@ -85,9 +86,6 @@
   }
 %}
 
-%nodefaultctor;
-%nodefaultdtor;
-
 // Expose Managed Constructor
 SWIG_CSBODY_PROXY(public, internal, SWIGTYPE)
 
@@ -107,7 +105,7 @@ SWIG_CSBODY_PROXY(public, internal, SWIGTYPE)
         System.IntPtr cPtr = $imcall;$excode 
         return cPtr; 
     } 
-%} 
+%}
 
 // Rename constants to unique classes.
 %rename("%(regex:/(?:NWNXLib::API::Constants)::\s*(\w+)(?:.+)$/\\1/)s", regextarget=1, fullname=1, %$isenum) "NWNXLib::API::Constants::*";
@@ -129,6 +127,18 @@ SWIG_CSBODY_PROXY(public, internal, SWIGTYPE)
 %rename(_OpIndex) operator[];
 %ignore CExoString::operator std::string;
 
+// Exclude default constructors for undefined references.
+%nodefaultctor CVirtualMachineCmdImplementer;
+%nodefaultctor CGameEffectApplierRemover;
+%nodefaultctor CBaseExoApp;
+%nodefaultctor CItemPropertyApplierRemover;
+%nodefaultctor CNWAmbientSound;
+%nodefaultctor CNWSEffectListHandler;
+%nodefaultctor CNWVirtualMachineCommands;
+%nodefaultctor CVirtualMachineDebugLoader;
+%nodefaultctor CResARE;
+%nodefaultctor CResIFO;
+
 // Ignore ambigious types.
 %ignore MIN;
 %ignore MAX;
@@ -136,10 +146,12 @@ SWIG_CSBODY_PROXY(public, internal, SWIGTYPE)
 %ignore ToString;
 %ignore NWSync::CNWSync;
 
-// Ignore multi-inheritance types.
+// Interfaces for multi-inheritance types.
+%interface_custom("CGameObject", "ICGameObject", CGameObject);
+%interface_custom("CNWItem", "ICNWItem", CNWItem);
+
+// Ignored multi-inheritance types.
 %ignore CCallbackHandlerBase;
-%ignore CNWArea;
-%ignore CNWItem;
 %ignore CResHelper<CRes2DA,2017>;
 %ignore CResHelper<CResDWK,2052>;
 %ignore CResHelper<CResLTR,2036>;


### PR DESCRIPTION
This PR restores the generation of default ctors/dtors, and implements interfaces for some useful API types.

The following default constructors have undefined reference issues and I was not sure if these should be fixed in the API. I have excluded them for now:

```
CVirtualMachineCmdImplementer
CGameEffectApplierRemover
CBaseExoApp
CItemPropertyApplierRemover
CNWAmbientSound
CNWSEffectListHandler
CNWVirtualMachineCommands
CVirtualMachineDebugLoader
CResARE
CResIFO
```

```
/usr/bin/ld: warning: type and size of dynamic symbol `_ZN7CResGFF15OnResourceFreedEv' are not defined
/usr/bin/ld: warning: type and size of dynamic symbol `_ZN4CRes26GetFixedResourceDataOffsetEv' are not defined
/usr/bin/ld: warning: type and size of dynamic symbol `_ZN4CRes20GetFixedResourceSizeEv' are not defined
/usr/bin/ld: warning: type and size of dynamic symbol `_ZN7CResGFF18OnResourceServicedEv' are not defined
/usr/bin/ld: CMakeFiles/SWIG_DotNET.dir/SWIG_DotNETInterop.cpp.o: in function `CVirtualMachineCmdImplementer::CVirtualMachineCmdImplementer()':
/unified/NWNXLib/API/API/CVirtualMachineCmdImplementer.hpp:19: undefined reference to `vtable for CVirtualMachineCmdImplementer'
/usr/bin/ld: CMakeFiles/SWIG_DotNET.dir/SWIG_DotNETInterop.cpp.o: in function `CGameEffectApplierRemover::CGameEffectApplierRemover()':
/unified/NWNXLib/API/API/CGameEffectApplierRemover.hpp:17: undefined reference to `vtable for CGameEffectApplierRemover'
/usr/bin/ld: CMakeFiles/SWIG_DotNET.dir/SWIG_DotNETInterop.cpp.o: in function `CBaseExoApp::CBaseExoApp()':
/unified/NWNXLib/API/API/CBaseExoApp.hpp:18: undefined reference to `vtable for CBaseExoApp'
/usr/bin/ld: CMakeFiles/SWIG_DotNET.dir/SWIG_DotNETInterop.cpp.o: in function `CItemPropertyApplierRemover::CItemPropertyApplierRemover()':
/unified/NWNXLib/API/API/CItemPropertyApplierRemover.hpp:18: undefined reference to `vtable for CItemPropertyApplierRemover'
/usr/bin/ld: CMakeFiles/SWIG_DotNET.dir/SWIG_DotNETInterop.cpp.o: in function `CNWAmbientSound::CNWAmbientSound()':
/unified/NWNXLib/API/API/CNWAmbientSound.hpp:15: undefined reference to `vtable for CNWAmbientSound'
/usr/bin/ld: CMakeFiles/SWIG_DotNET.dir/SWIG_DotNETInterop.cpp.o: in function `CNWSEffectListHandler::CNWSEffectListHandler()':
/unified/NWNXLib/API/API/CNWSEffectListHandler.hpp:21: undefined reference to `vtable for CNWSEffectListHandler'
/usr/bin/ld: CMakeFiles/SWIG_DotNET.dir/SWIG_DotNETInterop.cpp.o: in function `CNWVirtualMachineCommands::CNWVirtualMachineCommands()':
/unified/NWNXLib/API/API/CNWVirtualMachineCommands.hpp:22: undefined reference to `vtable for CNWVirtualMachineCommands'
/usr/bin/ld: CMakeFiles/SWIG_DotNET.dir/SWIG_DotNETInterop.cpp.o: in function `CVirtualMachineDebugLoader::CVirtualMachineDebugLoader()':
/unified/NWNXLib/API/API/CVirtualMachineDebugLoader.hpp:18: undefined reference to `CResHelper<CResNDB, (unsigned short)2064>::CResHelper()'
/usr/bin/ld: CMakeFiles/SWIG_DotNET.dir/SWIG_DotNETInterop.cpp.o:(.data.rel.ro._ZTI7CResARE[_ZTI7CResARE]+0x10): undefined reference to `typeinfo for CResGFF'
/usr/bin/ld: CMakeFiles/SWIG_DotNET.dir/SWIG_DotNETInterop.cpp.o:(.data.rel.ro._ZTI7CResIFO[_ZTI7CResIFO]+0x10): undefined reference to `typeinfo for CResGFF'
```