### PR TITLE
Plugins: update hooks - part 3

### DIFF
--- a/Plugins/Feat/Feat.cpp
+++ b/Plugins/Feat/Feat.cpp
@@ -337,7 +337,7 @@ void Feat::ApplyFeatEffects(CNWSCreature *pCreature, uint16_t nFeat)
                             }
                         }
                         return iMods + pCalculateSpellSaveDC_hook->CallOriginal<int32_t>(pThis, nSpellID);
-                    });
+                    }, Hooking::Order::Late);
         }
     }
 

--- a/Plugins/Profiler/Profiler.cpp
+++ b/Plugins/Profiler/Profiler.cpp
@@ -42,6 +42,8 @@ static std::chrono::milliseconds g_recalibrationPeriod;
 static bool g_recalibrate = false;
 static bool g_tickrate = false;
 
+static Hooking::FunctionHook *s_MainLoopHook;
+
 Profiler::Profiler(Services::ProxyServiceList* services)
     : Plugin(services)
 {
@@ -126,7 +128,8 @@ Profiler::Profiler(Services::ProxyServiceList* services)
 
     if (g_recalibrate || g_tickrate)
     {
-        GetServices()->m_hooks->RequestSharedHook<API::Functions::_ZN21CServerExoAppInternal8MainLoopEv, int32_t>(&MainLoopUpdate);
+        s_MainLoopHook = GetServices()->m_hooks->Hook(API::Functions::_ZN21CServerExoAppInternal8MainLoopEv,
+                                                      (void*)&MainLoopUpdate, Hooking::Order::Earliest);
     }
 
     // Resamples all of the automated timing data.
@@ -247,13 +250,8 @@ void Profiler::HandleRecalibration(const std::chrono::time_point<std::chrono::hi
     }
 }
 
-void Profiler::MainLoopUpdate(bool before, CServerExoAppInternal*)
+int32_t Profiler::MainLoopUpdate(CServerExoAppInternal *thisPtr)
 {
-    if (!before)
-    {
-        return;
-    }
-
     auto now = std::chrono::high_resolution_clock::now();
 
     if (g_recalibrate)
@@ -265,6 +263,8 @@ void Profiler::MainLoopUpdate(bool before, CServerExoAppInternal*)
     {
         HandleTickrateReporting(now);
     }
+
+    return s_MainLoopHook->CallOriginal<int32_t>(thisPtr);
 }
 
 }

--- a/Plugins/Profiler/Profiler.hpp
+++ b/Plugins/Profiler/Profiler.hpp
@@ -36,7 +36,7 @@ private:
     static void HandleTickrateReporting(const std::chrono::time_point<std::chrono::high_resolution_clock>& now);
     static void HandleRecalibration(const std::chrono::time_point<std::chrono::high_resolution_clock>& now);
 
-    static void MainLoopUpdate(bool, CServerExoAppInternal* thisPtr);
+    static int32_t MainLoopUpdate(CServerExoAppInternal*);
 
     void SetPerfScopeResampler(const std::string& name);
     void PushPerfScope(std::string&& name, NWNXLib::Services::MetricData::Tags&& tags);

--- a/Plugins/Profiler/Targets/AIMasterUpdates.cpp
+++ b/Plugins/Profiler/Targets/AIMasterUpdates.cpp
@@ -17,6 +17,7 @@ using namespace NWNXLib;
 using namespace NWNXLib::Services;
 
 static MetricsProxy* g_metrics;
+static Hooking::FunctionHook *s_UpdateStateHook;
 
 DECLARE_PROFILE_TARGET_SIMPLE(*g_metrics, AIMasterUpdateState, void, CServerAIMaster*)
 DECLARE_PROFILE_TARGET_FAST_SIMPLE(*g_metrics, EventPending, int32_t, CServerAIMaster*, uint32_t, uint32_t)
@@ -30,7 +31,7 @@ AIMasterUpdates::AIMasterUpdates(const bool overkill,
 {
     g_metrics = metrics;
 
-    hooker->RequestSharedHook<API::Functions::_ZN15CServerAIMaster11UpdateStateEv, void>(&AIMasterUpdate);
+    s_UpdateStateHook = hooker->Hook(API::Functions::_ZN15CServerAIMaster11UpdateStateEv, (void*)&AIMasterUpdate, Hooking::Order::Earliest);
 
     Resamplers::ResamplerFuncPtr resampler = &Resamplers::template Mean<uint32_t>;
     metrics->SetResampler("AIQueuedEvents", resampler, std::chrono::seconds(1));
@@ -38,17 +39,17 @@ AIMasterUpdates::AIMasterUpdates(const bool overkill,
 
     DEFINE_PROFILER_TARGET(hooker,
         AIMasterUpdateState, API::Functions::_ZN15CServerAIMaster11UpdateStateEv,
-        void, CServerAIMaster*);
+        void, CServerAIMaster*)
 
     if (overkill)
     {
         DEFINE_PROFILER_TARGET_FAST(hooker,
             EventPending, API::Functions::_ZN15CServerAIMaster12EventPendingEjj,
-            int32_t, CServerAIMaster*, uint32_t, uint32_t);
+            int32_t, CServerAIMaster*, uint32_t, uint32_t)
 
         DEFINE_PROFILER_TARGET_FAST(hooker,
             GetNextObject, API::Functions::_ZN13CServerAIList13GetNextObjectEv,
-            CNWSObject*, CServerAIList*);
+            CNWSObject*, CServerAIList*)
 
         DEFINE_PROFILER_TARGET_FAST(hooker,
             GetPendingEvent, API::Functions::_ZN15CServerAIMaster15GetPendingEventEPjS0_S0_S0_S0_PPv,
@@ -56,17 +57,12 @@ AIMasterUpdates::AIMasterUpdates(const bool overkill,
 
         DEFINE_PROFILER_TARGET_FAST(hooker,
             UpdateDialog, API::Functions::_ZN10CNWSObject12UpdateDialogEv,
-            int32_t, CNWSObject*);
+            int32_t, CNWSObject*)
     }
 }
 
-void AIMasterUpdates::AIMasterUpdate(bool before, CServerAIMaster* thisPtr)
+void AIMasterUpdates::AIMasterUpdate(CServerAIMaster* thisPtr)
 {
-    if (!before)
-    {
-        return;
-    }
-
     g_metrics->Push("AIQueuedEvents", { { "Count", std::to_string(thisPtr->m_lEventQueue.m_pcExoLinkedListInternal->m_nCount) } });
 
     using namespace API::Constants;
@@ -76,6 +72,8 @@ void AIMasterUpdates::AIMasterUpdate(bool before, CServerAIMaster* thisPtr)
             { { "Count", std::to_string(thisPtr->m_apGameAIList[i].m_aoGameObjects.num) } },
             { { "Level", AIPriority::ToString(i) } });
     }
+
+    s_UpdateStateHook->CallOriginal<void>(thisPtr);
 }
 
 }

--- a/Plugins/Profiler/Targets/AIMasterUpdates.hpp
+++ b/Plugins/Profiler/Targets/AIMasterUpdates.hpp
@@ -13,7 +13,7 @@ public:
         NWNXLib::Services::MetricsProxy* metrics);
 
 private:
-    static void AIMasterUpdate(bool, CServerAIMaster* thisPtr);
+    static void AIMasterUpdate(CServerAIMaster*);
 };
 
 }

--- a/Plugins/Profiler/Targets/NetMessages.cpp
+++ b/Plugins/Profiler/Targets/NetMessages.cpp
@@ -10,111 +10,90 @@ using namespace NWNXLib;
 using namespace API;
 
 static Services::MetricsProxy* g_metrics;
+static Hooking::FunctionHook *s_ComputeGameObjectUpdateForCategoryHook;
+static Hooking::FunctionHook *s_SendServerToPlayerMessageHook;
+static Hooking::FunctionHook *s_HandlePlayerToServerMessageHook;
 
 NetMessages::NetMessages(Services::HooksProxy* hooker,
     Services::MetricsProxy* metrics)
 {
     g_metrics = metrics;
 
-    hooker->RequestSharedHook<Functions::_ZN11CNWSMessage34ComputeGameObjectUpdateForCategoryEjjP10CNWSPlayerP10CNWSObjectP16CGameObjectArrayP29CNWSPlayerLUOSortedObjectListi, int32_t,
-        CNWSMessage*, uint32_t, uint32_t, CNWSPlayer*, CNWSObject*, CGameObjectArray*, CNWSPlayerLUOSortedObjectList*, int32_t>
-        (&ComputeGameObjectUpdateForCategory);
+    s_ComputeGameObjectUpdateForCategoryHook = hooker->Hook(
+            Functions::_ZN11CNWSMessage34ComputeGameObjectUpdateForCategoryEjjP10CNWSPlayerP10CNWSObjectP16CGameObjectArrayP29CNWSPlayerLUOSortedObjectListi,
+            (void*)&ComputeGameObjectUpdateForCategoryHook, Hooking::Order::Earliest);
 
-    hooker->RequestSharedHook<Functions::_ZN11CNWSMessage25SendServerToPlayerMessageEjhhPhj, int32_t,
-        CNWSMessage*, PlayerID, uint8_t, uint8_t, uint8_t*, uint32_t>
-        (&SendServerToPlayerMessageHook);
+    s_SendServerToPlayerMessageHook = hooker->Hook(Functions::_ZN11CNWSMessage25SendServerToPlayerMessageEjhhPhj,
+                                                   (void*)&SendServerToPlayerMessageHook, Hooking::Order::Earliest);
 
-    hooker->RequestSharedHook<Functions::_ZN11CNWSMessage27HandlePlayerToServerMessageEjPhj, int32_t,
-        CNWSMessage*, PlayerID, uint8_t*, uint32_t>
-        (&HandlePlayerToServerMessageHook);
+    s_HandlePlayerToServerMessageHook = hooker->Hook(Functions::_ZN11CNWSMessage27HandlePlayerToServerMessageEjPhj,
+                                                     (void*)&HandlePlayerToServerMessageHook, Hooking::Order::Earliest);
 
     Services::Resamplers::ResamplerFuncPtr sumResampler = &Services::Resamplers::template Sum<uint32_t>;
     metrics->SetResampler("GameObjectUpdate", sumResampler, std::chrono::seconds(1));
     metrics->SetResampler("NetworkMessage", sumResampler, std::chrono::seconds(1));
 }
 
-void NetMessages::ComputeGameObjectUpdateForCategory(bool before,
-    CNWSMessage*,
-    uint32_t category,
-    uint32_t,
-    CNWSPlayer* player,
-    CNWSObject*,
-    CGameObjectArray*,
-    CNWSPlayerLUOSortedObjectList*,
-    int32_t)
+int32_t NetMessages::ComputeGameObjectUpdateForCategoryHook(CNWSMessage *thisPtr, uint32_t nCategory, uint32_t nMessageLimit,
+                                                            CNWSPlayer* pPlayer, CNWSObject *pPlayerGameObject, CGameObjectArray *pGameObjectArray,
+                                                            CNWSPlayerLUOSortedObjectList *pSortedList, int32_t nSortedListSize)
 {
-    if (!before)
-    {
-        return;
-    }
-
     g_metrics->Push(
         "GameObjectUpdate",
         {
             { "Count", "1" }
         },
         {
-            { "Category", std::to_string(category) },
-            { "PlayerID", std::to_string(player->m_nPlayerID) }
+            { "Category", std::to_string(nCategory) },
+            { "PlayerID", std::to_string(pPlayer->m_nPlayerID) }
         });
+
+    return s_ComputeGameObjectUpdateForCategoryHook->CallOriginal<int32_t>(thisPtr, nCategory, nMessageLimit, pPlayer,
+                                                                           pPlayerGameObject, pGameObjectArray, pSortedList,
+                                                                           nSortedListSize);
 }
 
-void NetMessages::SendServerToPlayerMessageHook(bool before,
-    CNWSMessage*,
-    PlayerID pid,
-    uint8_t major,
-    uint8_t minor,
-    uint8_t*,
-    uint32_t bufferLen)
+int32_t NetMessages::SendServerToPlayerMessageHook(CNWSMessage *thisPtr, PlayerID nPlayerId, uint8_t nMajor, uint8_t nMinor,
+                                                uint8_t *pBuffer, uint32_t nBufferSize)
 {
-    if (!before)
-    {
-        return;
-    }
-
     g_metrics->Push(
         "NetworkMessage",
         {
             { "Count", "1" },
-            { "Size", std::to_string(bufferLen) }
+            { "Size", std::to_string(nBufferSize) }
         },
         {
             { "Type", "C" },
-            { "Major", std::to_string(major) },
-            { "Minor", std::to_string(minor) },
-            { "PlayerID", std::to_string(pid) },
+            { "Major", std::to_string(nMajor) },
+            { "Minor", std::to_string(nMinor) },
+            { "PlayerID", std::to_string(nPlayerId) },
         });
+
+    return s_SendServerToPlayerMessageHook->CallOriginal<int32_t>(thisPtr, nPlayerId, nMajor, nMinor, pBuffer, nBufferSize);
 }
 
-void NetMessages::HandlePlayerToServerMessageHook(bool before,
-    CNWSMessage*,
-    PlayerID pid,
-    uint8_t* buffer,
-    uint32_t bufferLen)
+int32_t NetMessages::HandlePlayerToServerMessageHook(CNWSMessage *thisPtr, PlayerID nPlayerId, uint8_t* pBuffer, uint32_t nBufferSize)
 {
-    if (!before)
-    {
-        return;
-    }
-
-    if (bufferLen < 3)
+    if (nBufferSize < 3)
     {
         // Somebody might be doing bad things with packets.
-        return;
+        return s_HandlePlayerToServerMessageHook->CallOriginal<int32_t>(thisPtr, nPlayerId, pBuffer, nBufferSize);
     }
 
     g_metrics->Push(
         "NetworkMessage",
         {
             { "Count", "1" },
-            { "Size", std::to_string(bufferLen) }
+            { "Size", std::to_string(nBufferSize) }
         },
         {
             { "Type", "S" },
-            { "Major", std::to_string(buffer[1]) },
-            { "Minor", std::to_string(buffer[2]) },
-            { "PlayerID", std::to_string(pid) }
+            { "Major", std::to_string(pBuffer[1]) },
+            { "Minor", std::to_string(pBuffer[2]) },
+            { "PlayerID", std::to_string(nPlayerId) }
         });
+
+    return s_HandlePlayerToServerMessageHook->CallOriginal<int32_t>(thisPtr, nPlayerId, pBuffer, nBufferSize);
 }
 
 }

--- a/Plugins/Profiler/Targets/NetMessages.hpp
+++ b/Plugins/Profiler/Targets/NetMessages.hpp
@@ -11,9 +11,10 @@ public:
     NetMessages(NWNXLib::Services::HooksProxy* hooker, NWNXLib::Services::MetricsProxy* metrics);
 
 private:
-    static void ComputeGameObjectUpdateForCategory(bool, CNWSMessage*, uint32_t, uint32_t, CNWSPlayer*, CNWSObject*, CGameObjectArray*, CNWSPlayerLUOSortedObjectList*, int32_t);
-    static void SendServerToPlayerMessageHook(bool, CNWSMessage*, PlayerID, uint8_t, uint8_t, uint8_t*, uint32_t);
-    static void HandlePlayerToServerMessageHook(bool, CNWSMessage*, PlayerID, uint8_t*, uint32_t);
+    static int32_t ComputeGameObjectUpdateForCategoryHook(CNWSMessage*, uint32_t, uint32_t, CNWSPlayer*, CNWSObject*,
+                                                          CGameObjectArray*, CNWSPlayerLUOSortedObjectList*, int32_t);
+    static int32_t SendServerToPlayerMessageHook(CNWSMessage*, PlayerID, uint8_t, uint8_t, uint8_t*, uint32_t);
+    static int32_t HandlePlayerToServerMessageHook(CNWSMessage*, PlayerID, uint8_t*, uint32_t);
 };
 
 }

--- a/Plugins/Profiler/Timing.cpp
+++ b/Plugins/Profiler/Timing.cpp
@@ -26,6 +26,8 @@ std::chrono::nanoseconds FastTimer::s_hookOverhead = std::chrono::nanoseconds(0)
 
 MetricsProxy* FastTimer::g_metricsForCalibration;
 
+static Hooking::FunctionHook *s_CheckForCDHook;
+
 void FastTimer::Start()
 {
     m_startTime = std::chrono::high_resolution_clock::now();
@@ -79,7 +81,8 @@ void FastTimer::Calibrate(const size_t runs, HooksProxy* hooks, MetricsProxy* me
         unhookedResults.emplace_back(runTest(10));
     }
 
-    hooks->RequestSharedHook<Functions::_ZN16CExoBaseInternal10CheckForCDEj, int32_t>(&ProfilerCalibrateHookFuncWithScope);
+    s_CheckForCDHook = hooks->Hook(Functions::_ZN16CExoBaseInternal10CheckForCDEj,
+                                   (void*)&ProfilerCalibrateHookFuncWithScope, Hooking::Order::Earliest);
     for (size_t i = 0; i < runs; ++i)
     {
         hookedResults.emplace_back(runTest(10));
@@ -141,18 +144,15 @@ std::chrono::nanoseconds FastTimer::ConstructTimestampAndPop()
     return time;
 }
 
-void FastTimer::ProfilerCalibrateHookFuncWithScope(bool before, CExoBase*, uint32_t)
+int32_t FastTimer::ProfilerCalibrateHookFuncWithScope(CExoBase *thisPtr, uint32_t nLanguage)
 {
     static FastTimer timer;
 
-    if (before)
-    {
-        timer.Start();
-    }
-    else
-    {
-        timer.Stop(*g_metricsForCalibration, "FAST_TIMER_OVERHEAD_CALIBRATION");
-    }
+    timer.Start();
+    auto retVal = s_CheckForCDHook->CallOriginal<int32_t>(thisPtr, nLanguage);
+    timer.Stop(*g_metricsForCalibration, "FAST_TIMER_OVERHEAD_CALIBRATION");
+
+    return retVal;
 }
 
 FastTimerScope::FastTimerScope(MetricsProxy& metrics, std::string&& eventName, MetricData::Tags&& tags)

--- a/Plugins/Profiler/Timing.hpp
+++ b/Plugins/Profiler/Timing.hpp
@@ -38,7 +38,7 @@ private:
 
 private: // Calibration
     static NWNXLib::Services::MetricsProxy* g_metricsForCalibration;
-    static void ProfilerCalibrateHookFuncWithScope(bool, CExoBase*, uint32_t);
+    static int32_t ProfilerCalibrateHookFuncWithScope(CExoBase*, uint32_t);
 };
 
 class FastTimerScope


### PR DESCRIPTION
Resolves #1237

Last one, this fully eradicates any `Request{Exclusive|Shared}Hook` calls. 

My mangling of `Profiler/ProfilerMacros.hpp` could use a look. It could probably be rewritten, since there's only 1 hook type now, but I didn't want to change it too much since most of it goes over my head.