### PR TITLE
optimizations: ReconcileAutoMapData()

### DIFF
--- a/Plugins/Optimizations/CMakeLists.txt
+++ b/Plugins/Optimizations/CMakeLists.txt
@@ -3,4 +3,5 @@ add_plugin(Optimizations
         "GameObjectLookup.cpp"
         "LuoLookup.cpp"
         "PlayerLookup.cpp"
+        "ReconcileAutoMap.cpp"
 )

--- a/Plugins/Optimizations/README.md
+++ b/Plugins/Optimizations/README.md
@@ -13,3 +13,4 @@ Game optimizations. Improves performance of various game elements.
 | `NWNX_OPTIMIZATIONS_PLAYER_LOOKUP` | true/false | Optimizes Player client lookup from object IDs, improving performance |
 | `NWNX_OPTIMIZATIONS_LUO_LOOKUP` | true/false | Optimizes LastUpdateObject lookup code, improving performance |
 | `NWNX_OPTIMIZATIONS_ALTERNATE_GAME_OBJECT_UPDATE` | true/false | Uses an experimental alternative update mechanism. Requires `LUO_LOOKUP`. |
+| `NWNX_OPTIMIZATIONS_RECONCILE_AUTOMAP_DATA` | true/false | Reduces the number of checks for mismatches between players' and module's area list |

--- a/Plugins/Optimizations/ReconcileAutoMap.cpp
+++ b/Plugins/Optimizations/ReconcileAutoMap.cpp
@@ -1,0 +1,59 @@
+#include "nwnx.hpp"
+#include "HashTable32.hpp"
+
+#include "API/CNWSPlayer.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/CNWSCreatureStats.hpp"
+
+namespace Optimizations {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+static HashTable32<CNWSPlayer> s_playerobjects;
+
+static Hooks::Hook s_VMAreaManagement;
+static Hooks::Hook s_ReconcileAutoMapData;
+
+static void ReconcileAutoMapData(CNWSCreature*);
+static int32_t ExecuteCommandAreaManagement(CNWVirtualMachineCommands*, int32_t, int32_t);
+
+static uint64_t s_AreaListSeq = 1;
+static HashTable32<void, 64 * 1024> s_SeqTable;
+
+void ReconcileAutoMap() __attribute__((constructor));
+void ReconcileAutoMap()
+{
+    if (Config::Get<bool>("RECONCILE_AUTOMAP_DATA", false))
+    {
+        LOG_INFO("AutoMap data fixup optimization enabled");
+
+        s_ReconcileAutoMapData = Hooks::HookFunction(Functions::_ZN12CNWSCreature20ReconcileAutoMapDataEv, (void*)ReconcileAutoMapData, Hooks::Order::Early);
+        s_VMAreaManagement     = Hooks::HookFunction(Functions::_ZN25CNWVirtualMachineCommands28ExecuteCommandAreaManagementEii, (void*)ExecuteCommandAreaManagement, Hooks::Order::Early);
+        s_SeqTable.Initialize();
+    }
+}
+
+static int32_t ExecuteCommandAreaManagement(CNWVirtualMachineCommands* pThis, int32_t nCommandId, int32_t nParameters)
+{
+    if (nCommandId == Constants::VMCommand::CreateArea  ||
+        nCommandId == Constants::VMCommand::DestroyArea ||
+        nCommandId == Constants::VMCommand::CopyArea)
+    {
+        s_AreaListSeq++;
+    }
+
+    return s_VMAreaManagement->CallOriginal<int32_t>(pThis, nCommandId, nParameters);
+}
+
+static void ReconcileAutoMapData(CNWSCreature* pThis)
+{
+    uint64_t seq = (uint64_t)s_SeqTable.Get(pThis->m_idSelf);
+    if (seq != s_AreaListSeq)
+    {
+        s_ReconcileAutoMapData->CallOriginal<void>(pThis);
+        s_SeqTable.Add(pThis->m_idSelf, (void*) s_AreaListSeq);
+    }
+}
+
+}


### PR DESCRIPTION
Whenever areas are added or removed from the module the players' minimap information needs to be reshuffled to make room. The issue is that the game will do a somewhat costly check for if this needs to be done - cost scaling with the number of areas in the module.