### PR TITLE
Add Set/Get Map Note (AKA Map Pins)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ https://github.com/nwnxee/unified/compare/build8193.20...HEAD
 ### Added
 - Events: added `NWNX_ON_INPUT_EMOTE_*` events to InputEvents, this event fires when a player uses a radial menu emote.
 - Events: added `NWNX_ON_COMBAT_DR_BROKEN_*` events to CombatEvents, this event fires when a creature's limited Damage{Resistance|Reduction} gets broken.
-- Events: added `NWNX_ON_UNPOSSESS_FAMILIAR_*` events to AssociateEvents, this event fires when a player unpossesses a familiar . 
+- Events: added `NWNX_ON_UNPOSSESS_FAMILIAR_*` events to AssociateEvents, this event fires when a player unpossesses a familiar.
 - Experimental: Added `NWNX_EXPERIMENTAL_DISABLE_LEVELUP_VALIDATION` to disable levelup validation.
 - Experimental: Added `NWNX_EXPERIMENTAL_UNHARDCODE_RANGER_DUALWIELD` to remove the hardcoded effects of the Ranger's Dual-wield feat. This functionality is not compatible with the NWNX_ON_HAS_FEAT_* event.
 - Tweaks: Added `NWNX_TWEAKS_ALWAYS_RETURN_FULL_DEX_STAT` to have GetDEXStat() always return a creature's full dexterity stat.
@@ -38,6 +38,7 @@ https://github.com/nwnxee/unified/compare/build8193.20...HEAD
 - Encounter: SetGeometry()
 - Encounter: {Get/Set}CanReset()
 - Object: {Get|Set}AILevel()
+- Object: {Get|Set}MapNote()
 - Util: GetInstructionLimit()
 - Util: {Get|Set}InstructionsExecuted()
 - Util: NWNX_Util_GetHighResTimeStamp() (in preparation for removing the now deprecated NWNX_Time)

--- a/Plugins/Object/NWScript/nwnx_object.nss
+++ b/Plugins/Object/NWScript/nwnx_object.nss
@@ -349,6 +349,19 @@ int NWNX_Object_GetAILevel(object oObject);
 /// @param nLevel The level to set (AI_LEVEL_* -1 to 4).
 void NWNX_Object_SetAILevel(object oObject, int nLevel);
 
+/// @brief Retrieves the Map Note (AKA Map Pin) from a waypoint - Returns even if currently disabled.
+/// @param oObject The Waypoint object
+/// @param nID The Language ID (default English)
+/// @param nGender 0 = Male, 1 = Female
+string NWNX_Object_GetMapNote(object oObject, int nID = 0, int nGender = 0);
+
+/// @brief Sets a Map Note (AKA Map Pin) to any waypoint, even if no previous map note. Only updates for clients on area-load. Use SetMapPinEnabled() as required.
+/// @param oObject The Waypoint object
+/// @param sMapNote The contents to set as the Map Note.
+/// @param nID The Language ID (default English)
+/// @param nGender 0 = Male, 1 = Female
+void NWNX_Object_SetMapNote(object oObject, string sMapNote, int nID = 0, int nGender = 0);
+
 /// @}
 
 int NWNX_Object_GetLocalVariableCount(object obj)
@@ -860,5 +873,28 @@ void NWNX_Object_SetAILevel(object oObject, int nLevel)
     NWNX_PushArgumentInt(NWNX_Object, sFunc, nLevel);
     NWNX_PushArgumentObject(NWNX_Object, sFunc, oObject);
 
+    NWNX_CallFunction(NWNX_Object, sFunc);
+}
+
+string NWNX_Object_GetMapNote(object oObject, int nID = 0, int nGender = 0)
+{
+    string sFunc = "GetMapNote";
+
+    NWNX_PushArgumentInt(NWNX_Object, sFunc, nGender);
+    NWNX_PushArgumentInt(NWNX_Object, sFunc, nID);
+    NWNX_PushArgumentObject(NWNX_Object, sFunc, oObject);
+    NWNX_CallFunction(NWNX_Object, sFunc);
+
+    return NWNX_GetReturnValueString(NWNX_Object, sFunc);
+}
+
+void NWNX_Object_SetMapNote(object oObject, string sMapNote, int nID = 0, int nGender = 0)
+{
+    string sFunc = "SetMapNote";
+
+    NWNX_PushArgumentInt(NWNX_Object, sFunc, nGender);
+    NWNX_PushArgumentInt(NWNX_Object, sFunc, nID);
+    NWNX_PushArgumentString(NWNX_Object, sFunc, sMapNote);
+    NWNX_PushArgumentObject(NWNX_Object, sFunc, oObject);
     NWNX_CallFunction(NWNX_Object, sFunc);
 }

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -17,6 +17,7 @@
 #include "API/CNWSAreaOfEffectObject.hpp"
 #include "API/CNWSDoor.hpp"
 #include "API/CNWSItem.hpp"
+#include "API/CNWSWaypoint.hpp"
 #include "API/CNWRules.hpp"
 #include "API/CNWBaseItem.hpp"
 #include "API/CNWBaseItemArray.hpp"
@@ -863,6 +864,34 @@ NWNX_EXPORT ArgumentStack SetAILevel(ArgumentStack&& args)
         ASSERT_OR_THROW(nLevel <= 4);
         auto *ai = Globals::AppManager()->m_pServerExoApp->GetServerAIMaster();
         ai->SetAILevel(pObject, nLevel);
+    }
+
+    return {};
+}
+
+NWNX_EXPORT ArgumentStack GetMapNote(ArgumentStack&& args)
+{
+    if (auto *pWaypoint = Utils::AsNWSWaypoint(object(args)))
+    {
+        auto nGender = args.extract<int32_t>();
+        auto nID = args.extract<int32_t>();
+
+        return Utils::ExtractLocString(pWaypoint->m_szMapNote, nID, nGender);
+    }
+
+    return "";
+}
+
+NWNX_EXPORT ArgumentStack SetMapNote(ArgumentStack&& args)
+{
+    if (auto *pWaypoint = Utils::AsNWSWaypoint(object(args)))
+    {
+        auto sMapNote = args.extract<std::string>();
+        auto nGender = args.extract<int32_t>();
+        auto nID = args.extract<int32_t>();
+
+        pWaypoint->m_bMapNote = true;
+        pWaypoint->m_szMapNote = Utils::CreateLocString(sMapNote, nID, nGender);
     }
 
     return {};


### PR DESCRIPTION
Does what it says on the tin.

`Sets a Map Note (AKA Map Pin) to any waypoint, even if no previous map note. Only updates for clients on area-load. Use SetMapPinEnabled() as required.`

`Retrieves the Map Note (AKA Map Pin) from a waypoint - Returns even if currently disabled.`