### PR TITLE
Tweaks: add NWNX_TWEAKS_TURD_BY_CDKEY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ https://github.com/nwnxee/unified/compare/build8193.20...HEAD
 - Experimental: Added `NWNX_EXPERIMENTAL_UNHARDCODE_RANGER_DUALWIELD` to remove the hardcoded effects of the Ranger's Dual-wield feat. This functionality is not compatible with the NWNX_ON_HAS_FEAT_* event.
 - Tweaks: Added `NWNX_TWEAKS_ALWAYS_RETURN_FULL_DEX_STAT` to have GetDEXStat() always return a creature's full dexterity stat.
 - Tweaks: added `NWNX_TWEAKS_DISPLAY_NUM_ATTACKS_OVERRIDE_IN_CHARACTER_SHEET` to display the correct amount of attacks per round on the character sheet when overridden with SetBaseAttackBonus()
+- Tweaks: added `NWNX_TWEAKS_TURD_BY_CDKEY` to associate TURDs by CDKey/CharacterName instead of PlayerName/CharacterName. Note: pass the CDKey instead of PlayerName when calling NWNX_Administration_DeleteTURD().
 - DotNET: Added native function hook support.
 - Optimizations: Added `LuoLookup` optimization that speeds up per-player object updates.
 - Optimizations: Added `PlayerLookup` optimization that speeds up some player related functions on highly populated servers.

--- a/Plugins/Administration/Administration.cpp
+++ b/Plugins/Administration/Administration.cpp
@@ -156,7 +156,7 @@ NWNX_EXPORT Events::ArgumentStack DeletePlayerCharacter(Events::ArgumentStack&& 
     }
 
     Tasks::QueueOnMainThread(
-        [filename, playerId, bPreserveBackup, playerName, characterName, characterLastName, kickMessage]
+        [filename, playerId, bPreserveBackup, playerName, characterName, characterLastName, kickMessage, playerdir]
         {
             // Will show "Delete Character" message to PC. Best match from dialog.tlk
             Globals::AppManager()->m_pServerExoApp->GetNetLayer()->DisconnectPlayer(playerId, 10392, 1, kickMessage);
@@ -182,6 +182,8 @@ NWNX_EXPORT Events::ArgumentStack DeletePlayerCharacter(Events::ArgumentStack&& 
             }
 
             CExoLinkedListNode *foundNode = FindTURD(playerName, chararacterFullName);
+            if (!foundNode)
+                foundNode = FindTURD(playerdir, chararacterFullName);
 
             if (foundNode)
             {

--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -23,4 +23,5 @@ add_plugin(Tweaks
     "PreserveDepletedItems.cpp"
     "SneakAttackCritImmunity.cpp"
     "StringToIntBaseToAuto.cpp"
+    "TURDByCDKey.cpp"
     "UnhardcodeShields.cpp")

--- a/Plugins/Tweaks/README.md
+++ b/Plugins/Tweaks/README.md
@@ -35,7 +35,9 @@ Tweaks stuff. See below.
 * `NWNX_TWEAKS_CLEAR_SPELL_EFFECTS_ON_TURDS`: true or false
 * `NWNX_TWEAKS_ALWAYS_RETURN_FULL_DEX_STAT`: true or false
 * `NWNX_TWEAKS_DISPLAY_NUM_ATTACKS_OVERRIDE_IN_CHARACTER_SHEET`: true or false
-
+* `NWNX_TWEAKS_TURD_BY_CDKEY`: true or false
+  - Note: pass the CDKey instead of PlayerName when calling NWNX_Administration_DeleteTURD().
+  
 ## Environment variable values
 
 ### NWNX_TWEAKS_HIDE_PLAYERS_ON_CHAR_LIST

--- a/Plugins/Tweaks/TURDByCDKey.cpp
+++ b/Plugins/Tweaks/TURDByCDKey.cpp
@@ -1,0 +1,68 @@
+#include "nwnx.hpp"
+
+#include "API/CAppManager.hpp"
+#include "API/CServerExoApp.hpp"
+#include "API/CNetLayer.hpp"
+#include "API/CNetLayerPlayerInfo.hpp"
+#include "API/CNWSModule.hpp"
+#include "API/CNWSPlayer.hpp"
+
+
+namespace Tweaks {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+static bool s_GetCDKeyInsteadOfPlayerName;
+
+void TURDByCDKey() __attribute__((constructor));
+void TURDByCDKey()
+{
+    if (!Config::Get<bool>("TURD_BY_CDKEY", false))
+        return;
+
+    LOG_INFO("TURDs are associated by CDKey/CharacterName instead of PlayerName/CharacterName.");
+
+    static Hooks::Hook s_GetPlayerNameHook = Hooks::HookFunction(Functions::_ZN10CNWSPlayer13GetPlayerNameEv,
+        (void*)+[](CNWSPlayer *pPlayer) -> CExoString
+        {
+            if (s_GetCDKeyInsteadOfPlayerName)
+            {
+                if (auto *pPlayerInfo = Globals::AppManager()->m_pServerExoApp->GetNetLayer()->GetPlayerInfo(pPlayer->m_nPlayerID))
+                {
+                    return pPlayerInfo->m_lstKeys[0].sPublic;
+                }
+
+                return CExoString("");
+            }
+            else
+                return s_GetPlayerNameHook->CallOriginal<CExoString>(pPlayer);
+        }, Hooks::Order::Late);
+
+    static Hooks::Hook s_DropTURDHook = Hooks::HookFunction(Functions::_ZN10CNWSPlayer8DropTURDEv,
+        (void*)+[](CNWSPlayer *pPlayer) -> void
+        {
+            s_GetCDKeyInsteadOfPlayerName = true;
+            s_DropTURDHook->CallOriginal<void>(pPlayer);
+            s_GetCDKeyInsteadOfPlayerName = false;
+        }, Hooks::Order::Early);
+
+    static Hooks::Hook s_RemoveFromTURDListHook = Hooks::HookFunction(Functions::_ZN10CNWSModule18RemoveFromTURDListEP10CNWSPlayer,
+        (void*)+[](CNWSModule *pModule, CNWSPlayer *pPlayer) -> void
+        {
+            s_GetCDKeyInsteadOfPlayerName = true;
+            s_RemoveFromTURDListHook->CallOriginal<void>(pModule, pPlayer);
+            s_GetCDKeyInsteadOfPlayerName = false;
+        }, Hooks::Order::Early);
+
+    static Hooks::Hook s_GetPlayerTURDFromListHook = Hooks::HookFunction(Functions::_ZN10CNWSModule21GetPlayerTURDFromListEP10CNWSPlayer,
+        (void*)+[](CNWSModule *pModule, CNWSPlayer *pPlayer) -> CNWSPlayerTURD*
+        {
+            s_GetCDKeyInsteadOfPlayerName = true;
+            auto retVal = s_GetPlayerTURDFromListHook->CallOriginal<CNWSPlayerTURD*>(pModule, pPlayer);
+            s_GetCDKeyInsteadOfPlayerName = false;
+            return retVal;
+        }, Hooks::Order::Early);
+}
+
+}


### PR DESCRIPTION
Associates TURDs by CDKey/CharacterName instead of PlayerName/CharacterName.