### PR TITLE
core: add hard exit option

### DIFF
--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -483,6 +483,8 @@ void NWNXCore::Shutdown()
         UnloadServices();
         Tasks::StopAsyncWorkers();
         g_core = nullptr;
+        if (Config::Get<bool>("HARD_EXIT", false))
+            exit(0);
     }
 }
 

--- a/Core/README.md
+++ b/Core/README.md
@@ -26,6 +26,7 @@ The core of NWNX:EE that does all the things.
 | `NWNX_CORE_LOG_COLOR` | 0-1 | 1 | Set whether to show logs printed by NWNX in color (only when printing to a TTY).
 | `NWNX_CORE_LOG_FORCE_COLOR` | 0-1| 0 | Sets whether to force color output.
 | `NWNX_CORE_LOG_ASYNC` | 0-1| 0 | Sets whether to flush the log to disk in an async thread.
+| `NWNX_CORE_HARD_EXIT` | 0-1| 0 | If set, NWNX will hard kill the process after it unloads.
 
 ## Console Commands
 


### PR DESCRIPTION
Works around the GOA lookup hang in WSL