### PR TITLE
GetSet Effect Immunity Bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ https://github.com/nwnxee/unified/compare/build8193.21...HEAD
 - N/A
 
 ##### New NWScript Functions
-- N/A
+- Creature: {Get/Set}BypassEffectImmunity()
 
 ### Changed
 - N/A
@@ -60,7 +60,6 @@ https://github.com/nwnxee/unified/compare/build8193.20...build8193.21
 - Creature: {Get/Set}Height()
 - Creature: {Get/Set}HitDistance()
 - Creature: {Get/Set}PreferredAttackDistance()
-- Creature: {Get/Set}BypassEffectImmunity()
 - Encounter: GetGeometry()
 - Encounter: SetGeometry()
 - Encounter: {Get/Set}CanReset()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ https://github.com/nwnxee/unified/compare/build8193.20...build8193.21
 - Creature: {Get/Set}Height()
 - Creature: {Get/Set}HitDistance()
 - Creature: {Get/Set}PreferredAttackDistance()
+- Creature: {Get/Set}BypassEffectImmunity()
 - Encounter: GetGeometry()
 - Encounter: SetGeometry()
 - Encounter: {Get/Set}CanReset()

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -895,6 +895,7 @@ float NWNX_Creature_GetPreferredAttackDistance(object oCreature);
 /// @param fPrefAtckDist The creatures preferred attack distance.
 void NWNX_Creature_SetPreferredAttackDistance(object oCreature, float fPrefAtckDist);
 
+
 /// @brief Get the skill penalty from wearing armor.
 /// @param oCreature The creature.
 int NWNX_Creature_GetArmorCheckPenalty(object oCreature);
@@ -902,6 +903,21 @@ int NWNX_Creature_GetArmorCheckPenalty(object oCreature);
 /// @brief Get the skill penalty from wearing a shield.
 /// @param oCreature The creature.
 int NWNX_Creature_GetShieldCheckPenalty(object oCreature);
+
+/// @brief Sets a chance for normal Effect Immunities to be bypassed
+/// @param oCreature The affected creature
+/// @param nImmunityType 'IMMUNITY_TYPE_*' to bypass. By default affects outgoing effects (oCreature -> another creature). Use a negative (-IMMUNITY_TYPE_*) to affect incoming effects instead (another creature -> oCreature) use 255/-255 to bypass ALL Immunities.
+/// @param nChance The chance (of 100%) to bypass the immunity check. A Positive chance results in NOT IMMUNE. A Negative chance results in IMMUNE.
+/// @param bPersist Whether the modifier should persist to .bic file (for PCs)
+/// @note Persistence is enabled after a server reset by the first use of this function. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
+/// @note Where an Outgoing and Incoming bypass both attempt opposing outcomes, both are ignored and the immunity status without bypass will apply.
+void NWNX_Creature_SetBypassEffectImmunity(object oCreature, int nImmunityType, int nChance = 100, int bPersist = FALSE);
+
+/// @brief Gets a chance for normal Effect Immunities to be bypassed
+/// @param oCreature The target creature
+/// @param nImmunityType 'IMMUNITY_TYPE_*' to retrive the current chance for bypass: Positive gets outgoing effects (oCreature -> another creature). Negative (-IMMUNITY_TYPE_*) gets incoming effects (another creature -> oCreature).
+/// @return the current critical hit multiplier modifier for the creature
+int NWNX_Creature_GetBypassEffectImmunity(object oCreature, int nImmunityType);
 
 /// @}
 
@@ -2315,6 +2331,27 @@ int NWNX_Creature_GetShieldCheckPenalty(object oCreature)
 {
     string sFunc = "GetShieldCheckPenalty";
 
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+    return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_SetBypassEffectImmunity(object oCreature, int nImmunityType, int nChance = 100, int bPersist = FALSE)
+{
+    string sFunc = "SetBypassEffectImmunity";
+
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, bPersist);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, nChance);
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, nImmunityType);
+    NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+int NWNX_Creature_GetBypassEffectImmunity(object oCreature, int nImmunityType)
+{
+    string sFunc = "GetBypassEffectImmunity";
+
+    NWNX_PushArgumentInt(NWNX_Creature, sFunc, nImmunityType);
     NWNX_PushArgumentObject(NWNX_Creature, sFunc, oCreature);
     NWNX_CallFunction(NWNX_Creature, sFunc);
     return NWNX_GetReturnValueInt(NWNX_Creature, sFunc);

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -895,7 +895,6 @@ float NWNX_Creature_GetPreferredAttackDistance(object oCreature);
 /// @param fPrefAtckDist The creatures preferred attack distance.
 void NWNX_Creature_SetPreferredAttackDistance(object oCreature, float fPrefAtckDist);
 
-
 /// @brief Get the skill penalty from wearing armor.
 /// @param oCreature The creature.
 int NWNX_Creature_GetArmorCheckPenalty(object oCreature);


### PR DESCRIPTION
Implements a Get/Set combo for bypassing/overriding effect immunity (I.E.  any of the IMMUNITY_TYPE_* group)

This is set on the target oCreature, and can be either:
A) For all effects that oCreature attempts to place on others (I.E. outgoing effects), or
B) For all effects that target oCreature (I.E. incoming effects)

If an incoming and outgoing bypass applies in opposite directions, the default effect happens (as though no bypass was used)

Additionally, the bypass can be given an nChance (%) of applying, where:
1) Positive chances 1:100 result in the effect bypassing immunity and forcing NOT IMMUNE
2) Negative chances -1:-100 result in the effect bypassing immunity (or lack of) and forcing IMMUNE)

This implements one part of #1028. I've reached out to Mord re: this PR but it's late my time. If there's an issue, happy to work that out.