### PR TITLE
nwnxlib: clear argument stack after every function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ https://github.com/nwnxee/unified/compare/build8193.21...HEAD
 - Creature: {Get/Set}BypassEffectImmunity()
 
 ### Changed
-- N/A
+- The argument stack is now cleared after every NWNX function call.
 
 ### Deprecated
 - N/A

--- a/NWNXLib/Events.cpp
+++ b/NWNXLib/Events.cpp
@@ -55,6 +55,17 @@ void Call(const std::string& pluginName, const std::string& eventName)
         {
             LOG_ERROR("Plugin '%s' failed event '%s'. Error: %s", pluginName, eventName, err.what());
         }
+
+        if (!s_arguments.empty())
+        {
+            LOG_WARNING("Argument stack not empty after running %s::%s from %s.ncs. Discarding unused arguments",
+                pluginName, eventName, Utils::GetCurrentScript());
+            while (!s_arguments.empty())
+            {
+                LOG_DEBUG("Discarding argument '%s'", s_arguments.top().toString());
+                s_arguments.pop();
+            }
+        }
     }
     else
     {


### PR DESCRIPTION
@julien-lecomte this will fix the redis issue and spew warnings when there's arguments still left over due to a bad call to other functions.