### PR TITLE
Player: add SetTlkOverride()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ https://github.com/nwnxee/unified/compare/build8193.21...HEAD
 - Effect: GetTrueEffect()
 - Effect: RemoveEffectById()
 - Effect: ReplaceEffectByIndex()
+- Player: SetTlkOverride()
 
 ### Changed
 - The argument stack is now cleared after every NWNX function call.

--- a/NWNXLib/API/Constants/Messages.hpp
+++ b/NWNXLib/API/Constants/Messages.hpp
@@ -60,9 +60,10 @@ namespace MessageMajor
         PlayModuleCharacterList                = 0x31,
         CustomToken                            = 0x32,
         Cutscene                               = 0x33,
+        Resman                                 = 0x34,
     };
     constexpr int32_t MIN   = 0;
-    constexpr int32_t MAX   = 0x33;
+    constexpr int32_t MAX   = 0x34;
 
     constexpr const char* ToString(const unsigned value)
     {
@@ -120,6 +121,7 @@ namespace MessageMajor
             "PlayModuleCharacterList",
             "CustomToken",
             "Cutscene",
+            "Resman",
         };
 
         return (value > MAX) ? "(invalid)" : TYPE_STRINGS[value];
@@ -1779,6 +1781,31 @@ namespace MessageCutsceneMinor
             "StopFade",
             "BlackScreen",
             "HideGui",
+        };
+
+        return (value > MAX) ? "(invalid)" : TYPE_STRINGS[value];
+    }
+}
+
+namespace MessageResmanMinor
+{
+    enum TYPE
+    {
+        Override                            = 0x01,
+        TlkOverride                         = 0x02,
+        TlkOverrideList                     = 0x03,
+    };
+    constexpr int32_t MIN   = 1;
+    constexpr int32_t MAX   = 0x03;
+
+    constexpr const char* ToString(const unsigned value)
+    {
+        constexpr const char* TYPE_STRINGS[] =
+        {
+            "Null",
+            "Override",
+            "TlkOverride",
+            "TlkOverrideList",
         };
 
         return (value > MAX) ? "(invalid)" : TYPE_STRINGS[value];

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -382,6 +382,14 @@ struct NWNX_Player_JournalEntry NWNX_Player_GetJournalEntry(object oPlayer, stri
 /// @param oPlayer The player object.
 void NWNX_Player_CloseStore(object oPlayer);
 
+/// @brief Override nStrRef from the TlkTable with sOverride for oPlayer only.
+/// @param oPlayer The player.
+/// @param nStrRef The StrRef.
+/// @param sOverride The new value for nStrRef or "" to remove the override.
+/// @param bRestoreGlobal If TRUE, when removing a personal override it will attempt to restore the global override if it exists.
+/// @note Overrides will not persist through relogging.
+void NWNX_Player_SetTlkOverride(object oPlayer, int nStrRef, string sOverride, int bRestoreGlobal = TRUE);
+
 /// @}
 
 void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable)
@@ -958,6 +966,17 @@ void NWNX_Player_CloseStore(object oPlayer)
 {
     string sFunc = "CloseStore";
 
+    NWNX_PushArgumentObject(NWNX_Player, sFunc, oPlayer);
+    NWNX_CallFunction(NWNX_Player, sFunc);
+}
+
+void NWNX_Player_SetTlkOverride(object oPlayer, int nStrRef, string sOverride, int bRestoreGlobal = TRUE)
+{
+    string sFunc = "SetTlkOverride";
+
+    NWNX_PushArgumentInt(NWNX_Player, sFunc, bRestoreGlobal);
+    NWNX_PushArgumentString(NWNX_Player, sFunc, sOverride);
+    NWNX_PushArgumentInt(NWNX_Player, sFunc, nStrRef);
     NWNX_PushArgumentObject(NWNX_Player, sFunc, oPlayer);
     NWNX_CallFunction(NWNX_Player, sFunc);
 }

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -35,6 +35,7 @@
 #include "API/CExoLocString.hpp"
 #include "API/CNWSPlayerStoreGUI.hpp"
 #include "API/CExoResMan.hpp"
+#include "API/CTlkTable.hpp"
 #include "API/Constants.hpp"
 #include "API/Globals.hpp"
 #include "API/Functions.hpp"
@@ -1616,6 +1617,28 @@ NWNX_EXPORT ArgumentStack CloseStore(ArgumentStack&& args)
     {
         if (auto *pPlayerStoreGUI = pPlayer->m_pStoreGUI)
             pPlayerStoreGUI->CloseStore(pPlayer, true);
+    }
+
+    return {};
+}
+
+NWNX_EXPORT ArgumentStack SetTlkOverride(ArgumentStack&& args)
+{
+    if (auto *pPlayer = Utils::PopPlayer(args))
+    {
+        const auto strRef = args.extract<int32_t>();
+          ASSERT_OR_THROW(strRef >= 0);
+        auto override = args.extract<std::string>();
+        const auto restoreGlobal = !!args.extract<int32_t>();
+
+        if (override.empty() && restoreGlobal)
+        {
+            if (Globals::TlkTable()->m_overrides.find(strRef) != Globals::TlkTable()->m_overrides.end())
+                override = Globals::TlkTable()->m_overrides[strRef].CStr();
+        }
+
+        if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
+            pMessage->SendServerToPlayerSetTlkOverride(pPlayer->m_nPlayerID, strRef, override);
     }
 
     return {};


### PR DESCRIPTION
```c
/// @brief Override nStrRef from the TlkTable with sOverride for oPlayer only.
/// @param oPlayer The player.
/// @param nStrRef The StrRef.
/// @param sOverride The new value for nStrRef or "" to remove the override.
/// @param bRestoreGlobal If TRUE, when removing a personal override it will attempt to restore the global override if it exists.
/// @note Overrides will not persist through relogging.
void NWNX_Player_SetTlkOverride(object oPlayer, int nStrRef, string sOverride, int bRestoreGlobal = TRUE);
```