### PR TITLE
Prevent attack bonuses from bypassing reductions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ https://github.com/nwnxee/unified/compare/build8193.21...HEAD
 - Events: added skippable event `NWNX_ON_CLIENT_LEVEL_UP_BEGIN_*` which fires when a player clicks the levelup button.
 - Tweaks: added `NWNX_TWEAKS_SEND_TLK_OVERRIDE_BEFORE_CHARGEN` to send TlkTable overrides before Character Generation.
 - Tweaks: added `NWNX_TWEAKS_RETAIN_LOCAL_VARIABLES_ON_ITEM_SPLIT` to retain local variables when an item is split.
+- Tweaks: added `NWNX_TWEAKS_PREVENT_ATTACK_BONUS_BYPASSING_REDUCTION` to make attack bonuses not bypass reductions (soak).
 
 ##### New Plugins
 - NoStack: Adds `NWNX_NOSTACK_*` variables to control ability, skill, attack and/or saving throw bonuses stacking

--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -27,4 +27,5 @@ add_plugin(Tweaks
     "SneakAttackCritImmunity.cpp"
     "StringToIntBaseToAuto.cpp"
     "TURDByCDKey.cpp"
-    "UnhardcodeShields.cpp")
+    "UnhardcodeShields.cpp"
+    "PreventAttackBonusBypassingReductions.cpp")

--- a/Plugins/Tweaks/PreventAttackBonusBypassingReductions.cpp
+++ b/Plugins/Tweaks/PreventAttackBonusBypassingReductions.cpp
@@ -1,0 +1,162 @@
+#include "nwnx.hpp"
+
+#include "API/CAppManager.hpp"
+#include "API/CNWBaseItem.hpp"
+#include "API/CNWBaseItemArray.hpp"
+#include "API/CNWRules.hpp"
+#include "API/CNWSAreaOfEffectObject.hpp"
+#include "API/CNWSCombatRound.hpp"
+#include "API/CNWSCreature.hpp"
+#include "API/CNWSCreatureStats.hpp"
+#include "API/CNWSInventory.hpp"
+#include "API/CNWSItem.hpp"
+#include "API/CServerExoApp.hpp"
+
+namespace Tweaks
+{
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+int32_t CNWSCreature__GetWeaponPower(CNWSCreature* thisPtr, CNWSObject* pTarget, int32_t bOffhand);
+
+static Hooks::Hook s_getWeaponPowerHook = nullptr;
+
+void PreventAttackBonusBypassingReductions() __attribute__((constructor));
+void PreventAttackBonusBypassingReductions()
+{
+    if (!Config::Get<bool>("PREVENT_ATTACK_BONUS_BYPASSING_REDUCTION", false))
+        return;
+
+    LOG_INFO("Preventing attack bonus effects from bypassing damage reductions");
+
+    s_getWeaponPowerHook = Hooks::HookFunction(Functions::_ZN12CNWSCreature14GetWeaponPowerEP10CNWSObjecti, (void*)&CNWSCreature__GetWeaponPower, Hooks::Order::Final);
+}
+
+int32_t CNWSCreature__GetWeaponPower(CNWSCreature* thisPtr, CNWSObject* pTarget, int32_t bOffhand)
+{
+    auto pCombatRound = thisPtr->m_pcCombatRound;
+    auto pCurrentAttack = pCombatRound->GetAttack(pCombatRound->m_nCurrentAttack);
+    uint8_t nAlignmentLaw = static_cast<uint8_t>(~0u), nAlignmentGood = static_cast<uint8_t>(~0u);
+    uint16_t nRace = static_cast<uint16_t>(~0u);
+    int32_t nWeaponPower = 0;
+
+    auto nWeaponAttackType = pCurrentAttack->m_nWeaponAttackType;
+    if (nWeaponAttackType == 0)
+        nWeaponAttackType = !!bOffhand + 1;
+
+    CNWSItem* pAttackWeapon = nullptr;
+    if (bOffhand)
+    {
+        auto* pItem = pCombatRound->GetCurrentAttackWeapon(2);
+        // Make sure it isn't a ranged weapon or a shield (shouldn't happen)
+        if (auto* pBaseItem = Globals::Rules()->m_pBaseItemArray->GetBaseItem(pAttackWeapon->m_nBaseItem))
+        {
+            if (!pBaseItem->m_nWeaponRanged && pBaseItem->m_nWeaponType && pBaseItem->m_nWeaponWield != 7)
+            {
+                pAttackWeapon = pItem;
+            }
+        }
+    }
+    else
+    {
+        pAttackWeapon = pCombatRound->GetCurrentAttackWeapon(0);
+    }
+
+    if (thisPtr->m_appliedEffects.num < 1 && pAttackWeapon->m_lstPassiveProperties.num < 1)
+        return 0;
+
+    if (pTarget)
+    {
+        CNWSCreature* pTargetCreature = Utils::AsNWSCreature(pTarget);
+        if (!pTargetCreature)
+        {
+            auto pTargetAoe = Utils::AsNWSAreaOfEffectObject(pTarget);
+            if (!pTargetAoe ||
+                !(pTargetCreature = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(pTargetAoe->m_oidCreator)) ||
+                !pTargetCreature->m_pStats)
+            {
+
+                pTargetCreature = nullptr;
+            }
+        }
+
+        if (pTargetCreature)
+        {
+            nRace = pTargetCreature->m_pStats->m_nRace;
+            nAlignmentLaw = pTargetCreature->m_pStats->GetSimpleAlignmentLawChaos();
+            nAlignmentGood = pTargetCreature->m_pStats->GetSimpleAlignmentGoodEvil();
+        }
+    }
+
+    if (pAttackWeapon)
+    {
+        // Get enhancement bonuses on weapon instead of attack bonuses on creature
+        for (auto& pItemProperty : pAttackWeapon->m_lstPassiveProperties)
+        {
+            if (nWeaponPower >= pItemProperty.m_nCostTableValue)
+                continue;
+
+            switch (pItemProperty.m_nPropertyName)
+            {
+                case Constants::ItemProperty::EnhancementBonus:
+                    nWeaponPower = pItemProperty.m_nCostTableValue;
+                    break;
+
+                case Constants::ItemProperty::EnhancementBonusVSAlignmentGroup:
+                    if (pItemProperty.m_nSubType == nAlignmentGood || pItemProperty.m_nSubType == nAlignmentLaw)
+                        nWeaponPower = pItemProperty.m_nCostTableValue;
+                    break;
+
+                case Constants::ItemProperty::EnhancementBonusVSRacialGroup:
+                    if (nRace == pItemProperty.m_nSubType)
+                        nWeaponPower = pItemProperty.m_nCostTableValue;
+                    break;
+
+                case Constants::ItemProperty::EnhancementBonusVSSpecificAlignment:
+                    if (nWeaponPower < pItemProperty.m_nCostTableValue)
+                    {
+                        if (pItemProperty.m_nSubType < 9)
+                        {
+                            uint8_t nRequiredAlignLaw = 2;
+                            if (pItemProperty.m_nSubType > 5)
+                                nRequiredAlignLaw = 3;
+                            else if (pItemProperty.m_nSubType > 2)
+                                nRequiredAlignLaw = 1;
+
+                            uint8_t nRequiredAlignGood = 4;
+                            if (pItemProperty.m_nSubType % 3 == 1)
+                                nRequiredAlignGood = 1;
+                            else if (pItemProperty.m_nSubType % 3 == 2)
+                                nRequiredAlignGood = 5;
+
+                            if (nAlignmentLaw == nRequiredAlignLaw && nAlignmentGood == nRequiredAlignGood)
+                                nWeaponPower = pItemProperty.m_nCostTableValue;
+                        }
+                    }
+                    break;
+            }
+        }
+    }
+
+    // Get damage reduction to apply enhancement equal to reduction on creature weapons
+    if (nWeaponAttackType == Constants::WeaponAttackType::CreatureLeftWeapon
+        || nWeaponAttackType == Constants::WeaponAttackType::CreatureRightWeapon
+        || nWeaponAttackType == Constants::WeaponAttackType::CreatureBiteWeapon)
+    {
+        for (int i = thisPtr->m_pStats->m_nDamageReductionPtr;
+            i < thisPtr->m_appliedEffects.num
+            && thisPtr->m_appliedEffects.element[i]->m_nType == Constants::EffectTrueType::DamageReduction;
+            i++)
+        {
+            auto nEffectPower = thisPtr->m_appliedEffects.element[i]->GetInteger(1);
+            if (nWeaponPower < nEffectPower)
+                nWeaponPower = nEffectPower;
+        }
+    }
+
+    int nMaxAttackBonus = Globals::AppManager()->m_pServerExoApp->GetAttackBonusLimit();
+    return std::min(nWeaponPower, nMaxAttackBonus);
+}
+
+}

--- a/Plugins/Tweaks/PreventAttackBonusBypassingReductions.cpp
+++ b/Plugins/Tweaks/PreventAttackBonusBypassingReductions.cpp
@@ -48,13 +48,15 @@ int32_t CNWSCreature__GetWeaponPower(CNWSCreature* thisPtr, CNWSObject* pTarget,
     CNWSItem* pAttackWeapon = nullptr;
     if (bOffhand)
     {
-        auto* pItem = pCombatRound->GetCurrentAttackWeapon(2);
-        // Make sure it isn't a ranged weapon or a shield (shouldn't happen)
-        if (auto* pBaseItem = Globals::Rules()->m_pBaseItemArray->GetBaseItem(pAttackWeapon->m_nBaseItem))
+        if (auto* pItem = pCombatRound->GetCurrentAttackWeapon(2))
         {
-            if (!pBaseItem->m_nWeaponRanged && pBaseItem->m_nWeaponType && pBaseItem->m_nWeaponWield != 7)
+            // Make sure it isn't a ranged weapon or a shield (shouldn't happen)
+            if (auto* pBaseItem = Globals::Rules()->m_pBaseItemArray->GetBaseItem(pItem->m_nBaseItem))
             {
-                pAttackWeapon = pItem;
+                if (!pBaseItem->m_nWeaponRanged && pBaseItem->m_nWeaponType && pBaseItem->m_nWeaponWield != 7)
+                {
+                    pAttackWeapon = pItem;
+                }
             }
         }
     }

--- a/Plugins/Tweaks/README.md
+++ b/Plugins/Tweaks/README.md
@@ -40,6 +40,7 @@ Tweaks stuff. See below.
 * `NWNX_TWEAKS_LANGUAGE_OVERRIDE`: between 1 and 5, or between 128 and 131
 * `NWNX_TWEAKS_SEND_TLK_OVERRIDE_BEFORE_CHARGEN`: true or false
 * `NWNX_TWEAKS_RETAIN_LOCAL_VARIABLES_ON_ITEM_SPLIT`: true or false
+* `NWNX_TWEAKS_PREVENT_ATTACK_BONUS_BYPASSING_REDUCTION`: true or false
   
 ## Environment variable values
 


### PR DESCRIPTION
closes #323 

Testing with a +1 enhancement weapon vs +5 attack bonus weapon:
![image](https://user-images.githubusercontent.com/1606943/111899543-89809980-8a2d-11eb-9abf-db293c6c41e4.png)

Hopefully I didn't screw up the alignment filters or anything else.