### PR TITLE
Racefixes - Effects vs child race.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ https://github.com/nwnxee/unified/compare/build8193.21...HEAD
 - Tweaks: removed deprecated `NWNX_TWEAKS_HIDE_DMS_ON_CHAR_LIST` environment variable. Use `NWNX_TWEAKS_HIDE_PLAYERS_ON_CHAR_LIST`
 
 ### Fixed
-- N/A
+- Race: Effects vs Child Races are now functional. Battle Training Vs. * feats now apply their bonus against child races as well.
 
 ## 8193.20
 https://github.com/nwnxee/unified/compare/build8193.20...build8193.21

--- a/Plugins/Race/Race.cpp
+++ b/Plugins/Race/Race.cpp
@@ -1178,7 +1178,7 @@ int32_t Race::GetAttackModifierVersus(CNWSCreatureStats* pStats, CNWSCreature* p
 
         if((pStats->HasFeat(Feat::BattleTrainingVersusOrcs) && parRace == RacialType::HumanoidOrc) ||
             (pStats->HasFeat(Feat::BattleTrainingVersusGoblins) && parRace == RacialType::HumanoidGoblinoid) ||
-            (pStats->HasFeat(Feat::BattleTrainingVersusReptilians) && perRace == RacialType::HumanoidReptilian))
+            (pStats->HasFeat(Feat::BattleTrainingVersusReptilians) && parRace == RacialType::HumanoidReptilian))
         {
             modABVSRaceBonus += Globals::Rules()->GetRulesetIntEntry("OFFENSIVE_TRAINING_MODIFIER", 1);
 

--- a/Plugins/Race/Race.cpp
+++ b/Plugins/Race/Race.cpp
@@ -448,8 +448,14 @@ int32_t Race::GetWeaponPowerHook(CNWSCreature *pCreature, CNWSObject *pObject, i
     uint8_t modABVSRaceBonus = 0;
     auto *pTargetCreature = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(pObject->m_idSelf);
     if (pTargetCreature)
-        modABVSRaceBonus = g_plugin->m_RaceABVsRace[nRace][pTargetCreature->m_pStats->m_nRace] +
-                           g_plugin->m_RaceABVsRace[nRace][g_plugin->m_RaceParent[pTargetCreature->m_pStats->m_nRace]];
+    {
+        modABVSRaceBonus = g_plugin->m_RaceABVsRace[nRace][pTargetCreature->m_pStats->m_nRace];
+        auto parRace = g_plugin->m_RaceParent[pTargetCreature->m_pStats->m_nRace];
+        if(parRace != RacialType::Invalid)
+            modABVSRaceBonus = g_plugin->m_RaceABVsRace[nRace][parRace];
+    }
+
+
     pServerExoApp->SetAttackBonusLimit(pServerExoApp->GetAttackBonusLimit() + modABBonus + modABVSRaceBonus);
 
     auto retVal = s_GetWeaponPowerHook->CallOriginal<int32_t>(pCreature, pObject, bOffHand);
@@ -534,8 +540,10 @@ int32_t Race::GetTotalEffectBonusHook(CNWSCreature *pCreature, uint8_t nEffectBo
         uint8_t modABVSRaceBonus = 0;
         if (pTargetCreature)
         {
-            modABVSRaceBonus = g_plugin->m_RaceABVsRace[nRace][pTargetCreature->m_pStats->m_nRace] +
-                               g_plugin->m_RaceABVsRace[nRace][g_plugin->m_RaceParent[pTargetCreature->m_pStats->m_nRace]];
+            modABVSRaceBonus = g_plugin->m_RaceABVsRace[nRace][pTargetCreature->m_pStats->m_nRace];
+            auto parRace = g_plugin->m_RaceParent[pTargetCreature->m_pStats->m_nRace];
+            if(parRace != RacialType::Invalid)
+                modABVSRaceBonus = g_plugin->m_RaceABVsRace[nRace][parRace];
         }
         pServerExoApp->SetAttackBonusLimit(attackBonusLimit + modABBonus + modABVSRaceBonus);
     }

--- a/Plugins/Race/Race.cpp
+++ b/Plugins/Race/Race.cpp
@@ -1180,9 +1180,9 @@ int32_t Race::GetAttackModifierVersusHook(CNWSCreatureStats* pStats, CNWSCreatur
     {
         auto parRace = g_plugin->m_RaceParent[pCreature->m_pStats->m_nRace];
 
-        if((pStats->HasFeat(Feat::BattleTrainingVersusOrcs) && parRace == RacialType::HumanoidOrc) ||
-            (pStats->HasFeat(Feat::BattleTrainingVersusGoblins) && parRace == RacialType::HumanoidGoblinoid) ||
-            (pStats->HasFeat(Feat::BattleTrainingVersusReptilians) && parRace == RacialType::HumanoidReptilian))
+        if((parRace == RacialType::HumanoidOrc && pStats->HasFeat(Feat::BattleTrainingVersusOrcs)) ||
+            (parRace == RacialType::HumanoidGoblinoid && pStats->HasFeat(Feat::BattleTrainingVersusGoblins)) ||
+            (parRace == RacialType::HumanoidReptilian && pStats->HasFeat(Feat::BattleTrainingVersusReptilians)))
         {
             modABVSRaceBonus = Globals::Rules()->GetRulesetIntEntry("OFFENSIVE_TRAINING_MODIFIER", 1);
 
@@ -1209,7 +1209,7 @@ int16_t Race::GetArmorClassVersusHook(CNWSCreatureStats* pStats, CNWSCreature* p
     {
         auto parRace = g_plugin->m_RaceParent[pCreature->m_pStats->m_nRace];
 
-        if(pStats->HasFeat(Feat::BattleTrainingVersusGiants) && parRace == RacialType::Giant)
+        if(parRace == RacialType::Giant && pStats->HasFeat(Feat::BattleTrainingVersusGiants))
             modACVSRaceBonus = Globals::Rules()->GetRulesetIntEntry("DEFENSIVE_TRAINING_MODIFIER", 4);
 
     }

--- a/Plugins/Race/Race.hpp
+++ b/Plugins/Race/Race.hpp
@@ -101,6 +101,8 @@ private:
     static void LoadRaceInfoHook(CNWRules*);
     static int32_t CheckItemRaceRestrictionsHook(CNWSCreature*, CNWSItem*);
     static int32_t GetFavoredEnemyBonusHook(CNWSCreatureStats*, CNWSCreature*);
+    static int32_t GetAttackModifierVersus(CNWSCreatureStats *pStats, CNWSCreature* pCreature);
+
 };
 
 }

--- a/Plugins/Race/Race.hpp
+++ b/Plugins/Race/Race.hpp
@@ -101,7 +101,8 @@ private:
     static void LoadRaceInfoHook(CNWRules*);
     static int32_t CheckItemRaceRestrictionsHook(CNWSCreature*, CNWSItem*);
     static int32_t GetFavoredEnemyBonusHook(CNWSCreatureStats*, CNWSCreature*);
-    static int32_t GetAttackModifierVersus(CNWSCreatureStats *pStats, CNWSCreature* pCreature);
+    static int32_t GetAttackModifierVersusHook(CNWSCreatureStats *pStats, CNWSCreature* pCreature);
+    static int16_t GetArmorClassVersusHook(CNWSCreatureStats* pStats, CNWSCreature* pCreature, BOOL bVsTouchAttack);
 
 };
 


### PR DESCRIPTION


Removed the race switch in gettotaleffects, it was unncessary due to all effects that are applied against a parent race apply to each child race.  -> This fixes effects applied vs child race, handled by gettotaleffectbonus, not applying. 
The game handling of stacking is unmodified.

AB added via plugin (NWNX_Race_SetRacialModifier) now increases AB cap by adding AB vs child race AND abvs parent race as that matched how it was stacking above. (Ie a +2 Vs Elf (parent race of drow) and a +3 Vs Drow will increase AB cap vs Drow by 5);

new CGameEfffect to false as no need to generate an id if one is being copied over.