### PR TITLE
SetCasterLevel* fixes

### DIFF
--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -1799,18 +1799,14 @@ static uint8_t CNWSCreatureStats__GetClassLevel(CNWSCreatureStats* pThis, uint8_
 
         if (nClass != Constants::ClassType::Invalid)
         {
+            auto nLevelOverride = pThis->m_pBaseCreature->nwnxGet<int>("CASTERLEVEL_OVERRIDE" + std::to_string(nClass));
+            if (nLevelOverride)
+                return std::clamp(nLevelOverride.value(), 0, 255);
+
             int32_t nModifier = 0;
             auto nLevelModifier = pThis->m_pBaseCreature->nwnxGet<int>("CASTERLEVEL_MODIFIER" + std::to_string(nClass));
             if (nLevelModifier)
                 nModifier = nLevelModifier.value();
-
-            auto nLevelOverride = pThis->m_pBaseCreature->nwnxGet<int>("CASTERLEVEL_OVERRIDE" + std::to_string(nClass));
-            if (nLevelOverride)
-            {
-                auto nLevel = nLevelOverride.value();
-                nModifier = nLevel - retVal;
-            }
-
 
             //Make sure m_nLevel doesn't over/underflow
             nModifier = std::min(nModifier, 255 - pThis->m_ClassInfo[nMultiClass].m_nLevel);

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -1809,9 +1809,9 @@ static uint8_t CNWSCreatureStats__GetClassLevel(CNWSCreatureStats* pThis, uint8_
                 nModifier = nLevelModifier.value();
 
             //Make sure m_nLevel doesn't over/underflow
-            nModifier = std::min(nModifier, 255 - pThis->m_ClassInfo[nMultiClass].m_nLevel);
+            nModifier = std::min(nModifier, 255 - retVal);
             if (nModifier < 0)
-                nModifier = -std::min(-nModifier, static_cast<int32_t>(pThis->m_ClassInfo[nMultiClass].m_nLevel));
+                nModifier = -std::min(-nModifier, static_cast<int32_t>(retVal));
 
             retVal += nModifier;
         }


### PR DESCRIPTION
Fix: Only changes class level when a verified caster level (resistance/effect creation events included) event fires

Fix 2:  SetCasterLevelModification no longer sets caster level to a 255 or higher

Other additions: Changed it so the caster level override fires after modification, so that it's actually an override.

Changed hook order so that the Creatures hook happens after the tweak hook. Again so that a set override can override the tweak. (bit strange that was by changing it to earliest.. but okay)