### PR TITLE
Events: add some CharacterSheet events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ https://github.com/nwnxee/unified/compare/build8193.21...HEAD
 ### Added
 - Events: added skippable event `NWNX_ON_CLIENT_LEVEL_UP_BEGIN_*` which fires when a player clicks the levelup button.
 - Events: added skippable event `NWNX_ON_POSSESS_FAMILIAR_*` which fires when a player attempts to possess their familiar.
+- Events: added skippable event `NWNX_ON_CHARACTER_SHEET_PERMITTED_*` which fires when a player attempts to view a charactersheet.
+- Events: added events `NWNX_ON_CHARACTER_SHEET_{OPEN|CLOSE}_*` which fire when a player opens or closes a charactersheeet.   
 - Tweaks: added `NWNX_TWEAKS_SEND_TLK_OVERRIDE_BEFORE_CHARGEN` to send TlkTable overrides before Character Generation.
 - Tweaks: added `NWNX_TWEAKS_RETAIN_LOCAL_VARIABLES_ON_ITEM_SPLIT` to retain local variables when an item is split.
 

--- a/Plugins/Events/Events/ExamineEvents.hpp
+++ b/Plugins/Events/Events/ExamineEvents.hpp
@@ -13,6 +13,8 @@ private:
     static void HandleExamine(bool, ObjectID, ObjectID);
 
     static int32_t ExamineTrapHook(CNWSMessage*, CNWSPlayer*, ObjectID, CNWSCreature*, int32_t);
+    static int32_t PermittedToDisplayCharacterSheetHook(CNWSPlayer*, ObjectID);
+    static int32_t HandlePlayerToServerCharacterSheetMessageHook(CNWSMessage*, CNWSPlayer*, uint8_t);
 };
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1334,7 +1334,7 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    FAMILIAR              | object | The familiar. Convert to object with StringToObject()  |
+    FAMILIAR              | object | The familiar. Convert to object with StringToObject() |
 
 _______________________________________
     ## Client Levelup Begin Event
@@ -1355,7 +1355,31 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    FAMILIAR              | object | The familiar. Convert to object with StringToObject()  |
+    FAMILIAR              | object | The familiar. Convert to object with StringToObject() |
+_______________________________________
+    ## Player CharacterSheet Permitted Event
+    - NWNX_ON_CHARACTER_SHEET_PERMITTED_BEFORE
+    - NWNX_ON_CHARACTER_SHEET_PERMITTED_AFTER
+
+    `OBJECT_SELF` = The player trying to view a charactersheet
+
+    Event Data Tag        | Type   | Notes
+    ----------------------|--------|-------
+    TARGET                | object | Convert to object with StringToObject() |
+
+    @note When skipping this event, be sure to set the event result.
+_______________________________________
+    ## Player CharacterSheet Open/Close Events
+    - NWNX_ON_CHARACTER_SHEET_OPEN_BEFORE
+    - NWNX_ON_CHARACTER_SHEET_OPEN_AFTER
+    - NWNX_ON_CHARACTER_SHEET_CLOSE_BEFORE
+    - NWNX_ON_CHARACTER_SHEET_CLOSE_AFTER
+
+    `OBJECT_SELF` = The player opening or closing a charactersheet
+
+    Event Data Tag        | Type   | Notes
+    ----------------------|--------|-------
+    TARGET                | object | Convert to object with StringToObject() |
 _______________________________________
 */
 /*
@@ -1448,6 +1472,7 @@ string NWNX_Events_GetEventData(string tag);
 /// - Faction events
 /// - UnpossessFamiliar event
 /// - ClientLevelUpBegin event
+/// - CharacterSheetPermitted event
 void NWNX_Events_SkipEvent();
 
 /// Set the return value of the event.
@@ -1466,6 +1491,7 @@ void NWNX_Events_SkipEvent();
 /// - Has Feat event -> "1" or "0"
 /// - Stealth event -> "1" to perform HiPS (without the feat), "0" to bypass HiPS
 /// - Faction set reputation event -> The new reputation to apply instead. ("0" - "100")
+/// - CharacterSheetPermitted event -> "1" allow the player to view the character sheet or "0" to disallow
 void NWNX_Events_SetEventResult(string data);
 
 /// Returns the current event name


### PR DESCRIPTION
Resolves #1317

Adds:
`NWNX_ON_CHARACTER_SHEET_PERMITTED_BEFORE` -> Can be skipped and have its result set.
`NWNX_ON_CHARACTER_SHEET_PERMITTED_AFTER`
`NWNX_ON_CHARACTER_SHEET_OPEN_BEFORE`
`NWNX_ON_CHARACTER_SHEET_OPEN_AFTER`
`NWNX_ON_CHARACTER_SHEET_CLOSE_BEFORE`
`NWNX_ON_CHARACTER_SHEET_CLOSE_AFTER`
