### PR TITLE
Feature: ApplyEffect

### DIFF
--- a/Plugins/Effect/Effect.cpp
+++ b/Plugins/Effect/Effect.cpp
@@ -322,8 +322,11 @@ NWNX_EXPORT ArgumentStack RemoveEffectById(ArgumentStack&& args)
 NWNX_EXPORT ArgumentStack ApplyEffect(ArgumentStack&& args)
 {
     auto *pObject = Utils::PopObject(args);
-    auto eEffect = args.extract<CGameEffect*>();
-    pObject->ApplyEffect(eEffect, false, true);
+    if(pObject)
+    {
+        auto eEffect = args.extract<CGameEffect*>();
+        pObject->ApplyEffect(eEffect, false, true);
+    }
 
     return {};
 }

--- a/Plugins/Effect/Effect.cpp
+++ b/Plugins/Effect/Effect.cpp
@@ -318,3 +318,12 @@ NWNX_EXPORT ArgumentStack RemoveEffectById(ArgumentStack&& args)
 
     return false;
 }
+
+NWNX_EXPORT ArgumentStack ApplyEffect(ArgumentStack&& args)
+{
+    auto *pObject = Utils::PopObject(args);
+    auto eEffect = args.extract<CGameEffect*>();
+    pObject->ApplyEffect(eEffect, false, true);
+
+    return {};
+}

--- a/Plugins/Effect/NWScript/nwnx_effect.nss
+++ b/Plugins/Effect/NWScript/nwnx_effect.nss
@@ -121,7 +121,7 @@ int NWNX_Effect_RemoveEffectById(object oObject,  string sID);
 /// @brief Applys an effect, bypassing any processing done by ApplyEffectToObject
 /// @param eEffect The effect to be applied.
 /// @param oObject The object to apply it to.
-void ApplyEffect(effect eEffect, object oObject)
+void ApplyEffect(effect eEffect, object oObject);
 
 /// @}
 
@@ -364,7 +364,7 @@ int NWNX_Effect_RemoveEffectById(object oObject,  string sID)
 void ApplyEffect(effect eEffect, object oObject)
 {
     string sFunc = "ApplyEffect";
-    NWNX_PushArgumentEffect(NWNX_Effect, sFunc, eEffect);
-    NWNX_PushArgumentObject(NWNX_Effect, sFunc, oObject);
+    NWNX_PushArgumentEffect(eEffect);
+    NWNX_PushArgumentObject(oObject);
     NWNX_CallFunction(NWNX_Effect, sFunc);
 }

--- a/Plugins/Effect/NWScript/nwnx_effect.nss
+++ b/Plugins/Effect/NWScript/nwnx_effect.nss
@@ -118,7 +118,7 @@ void NWNX_Effect_ReplaceEffectByIndex(object oObject, int nIndex, struct  NWNX_E
 int NWNX_Effect_RemoveEffectById(object oObject,  string sID);
 
 
-/// @brief Applys an effect, bypassing any processing done by ApplyEffectToObject/Location
+/// @brief Applys an effect, bypassing any processing done by ApplyEffectToObject
 /// @param eEffect The effect to be applied.
 /// @param oObject The object to apply it to.
 void ApplyEffect(effect eEffect, object oObject)

--- a/Plugins/Effect/NWScript/nwnx_effect.nss
+++ b/Plugins/Effect/NWScript/nwnx_effect.nss
@@ -121,7 +121,7 @@ int NWNX_Effect_RemoveEffectById(object oObject,  string sID);
 /// @brief Applys an effect, bypassing any processing done by ApplyEffectToObject
 /// @param eEffect The effect to be applied.
 /// @param oObject The object to apply it to.
-void ApplyEffect(effect eEffect, object oObject);
+void NWNX_Effect_Apply(effect eEffect, object oObject);
 
 /// @}
 
@@ -361,7 +361,7 @@ int NWNX_Effect_RemoveEffectById(object oObject,  string sID)
     return  NWNX_GetReturnValueInt();
 }
 
-void ApplyEffect(effect eEffect, object oObject)
+void NWNX_Effect_Apply(effect eEffect, object oObject)
 {
     string sFunc = "ApplyEffect";
     NWNX_PushArgumentEffect(eEffect);

--- a/Plugins/Effect/NWScript/nwnx_effect.nss
+++ b/Plugins/Effect/NWScript/nwnx_effect.nss
@@ -117,6 +117,12 @@ void NWNX_Effect_ReplaceEffectByIndex(object oObject, int nIndex, struct  NWNX_E
 /// @return FALSE/0 on failure TRUE/1 on success.
 int NWNX_Effect_RemoveEffectById(object oObject,  string sID);
 
+
+/// @brief Applys an effect, bypassing any processing done by ApplyEffectToObject/Location
+/// @param eEffect The effect to be applied.
+/// @param oObject The object to apply it to.
+void ApplyEffect(effect eEffect, object oObject)
+
 /// @}
 
 struct NWNX_EffectUnpacked __NWNX_Effect_ResolveUnpack(string sFunc, int bLink=TRUE)
@@ -353,4 +359,12 @@ int NWNX_Effect_RemoveEffectById(object oObject,  string sID)
     NWNX_CallFunction(NWNX_Effect, sFunc);
 
     return  NWNX_GetReturnValueInt();
+}
+
+void ApplyEffect(effect eEffect, object oObject)
+{
+    string sFunc = "ApplyEffect";
+    NWNX_PushArgumentEffect(NWNX_Effect, sFunc, eEffect);
+    NWNX_PushArgumentObject(NWNX_Effect, sFunc, oObject);
+    NWNX_CallFunction(NWNX_Effect, sFunc);
 }


### PR DESCRIPTION
ApplyEffect to the object bypassing any forced change of the effect by ApplyEffectToObject

Placed in effect plugin due to it not having much use without it.

Parameter order was chosen due to it being the order of ApplyEffectToObject, without the unnecessary parameters.