### PR TITLE
Compiler Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ https://github.com/nwnxee/unified/compare/build8193.22...HEAD
 - N/A
 
 ##### New Plugins
-- N/A
+- Compiler: Adds command-line compilation of nss files using the in-built compiler.
 
 ##### New NWScript Functions
 - Object: GetLastSpellCastFeat()

--- a/NWNXLib/Utils/String.cpp
+++ b/NWNXLib/Utils/String.cpp
@@ -1,6 +1,6 @@
 #include "nwnx.hpp"
 #include <sstream>
-#include <stdlib.h> 
+#include <stdlib.h>
 #include <string.h>
 
 namespace NWNXLib::String
@@ -95,19 +95,19 @@ template<> std::optional<double> FromString(const std::string& str)
     return (!*end || std::isspace(*end)) ? std::optional<double>(res) : std::optional<double>();
 }
 
-std::string& LTrim(std::string& str) 
+std::string& LTrim(std::string& str)
 {
     str.erase(0, str.find_first_not_of(" \n\r\t"));
     return str;
 }
 
-std::string& RTrim(std::string& str) 
+std::string& RTrim(std::string& str)
 {
     str.erase(str.find_last_not_of(" \n\r\t") + 1);
     return str;
 }
 
-std::string& Trim(std::string& str) 
+std::string& Trim(std::string& str)
 {
     return LTrim(RTrim(str));
 }
@@ -120,9 +120,9 @@ std::string Join(const std::vector<std::string>& v, const char* delim)
     auto it = std::begin(v);
 
     out << *it;
-    while(++it != std::end(v)) 
+    while(++it != std::end(v))
     {
-        out << delim << *it; 
+        out << delim << *it;
     }
     return out.str();
 }
@@ -134,7 +134,7 @@ std::vector<std::string> Split(const std::string& sp, char delim, bool skipEmpty
     std::string item;
     while (getline(ss, item, delim))
     {
-        if (skipEmpty && item.empty()) 
+        if (skipEmpty && item.empty())
             continue;
 
         if (trimmed)
@@ -158,5 +158,9 @@ std::string Basename(const std::string& path)
     return name;
 }
 
+bool EndsWith(const std::string& str, const std::string& suffix)
+{
+    return str.size() >= suffix.size() && 0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
+}
 
 }

--- a/NWNXLib/nwnx.hpp
+++ b/NWNXLib/nwnx.hpp
@@ -171,6 +171,7 @@ namespace String
     std::vector<std::string> Split(const std::string& str, char delim, bool skipEmpty = true, bool trimmed = true);
 
     std::string Basename(const std::string& path);
+    bool EndsWith(const std::string& str, const std::string& suffix);
 }
 
 namespace Utils

--- a/Plugins/Compiler/CMakeLists.txt
+++ b/Plugins/Compiler/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_plugin(Compiler
+    "Compiler.cpp")

--- a/Plugins/Compiler/Compiler.cpp
+++ b/Plugins/Compiler/Compiler.cpp
@@ -144,7 +144,7 @@ static void CreateResourceDirectory(const CExoString& alias, const std::string& 
 
     Globals::ExoBase()->m_pcExoAliasList->Add(qualifiedAlias, path.c_str());
     Globals::ExoResMan()->CreateDirectory(qualifiedAlias);
-    Globals::ExoResMan()->AddResourceDirectory(qualifiedAlias, priority, true);
+    Globals::ExoResMan()->AddResourceDirectory(qualifiedAlias, priority, false);
 }
 
 static void RemoveResourceDirectory(const CExoString& alias)

--- a/Plugins/Compiler/Compiler.cpp
+++ b/Plugins/Compiler/Compiler.cpp
@@ -164,6 +164,7 @@ static std::unique_ptr<CScriptCompiler> CreateAndConfigureCompiler(const CExoStr
     scriptCompiler->SetIdentifierSpecification("nwscript");
     scriptCompiler->SetCompileConditionalOrMain(true);
     scriptCompiler->SetCompileConditionalFile(true);
+    scriptCompiler->SetAutomaticCleanUpAfterCompiles(false);
 
     scriptCompiler->SetOutputAlias(outputAlias);
 

--- a/Plugins/Compiler/Compiler.cpp
+++ b/Plugins/Compiler/Compiler.cpp
@@ -1,0 +1,155 @@
+#include "nwnx.hpp"
+
+#include "API/CScriptCompiler.hpp"
+#include "API/CExoAliasList.hpp"
+#include "API/CExoBase.hpp"
+#include "API/CExoResMan.hpp"
+
+#include <filesystem>
+
+namespace Compiler
+{
+
+using namespace NWNXLib;
+using namespace API;
+
+static void CleanOutput(const std::filesystem::path&);
+static void CreateResourceDirectory(const CExoString&, const std::filesystem::path&);
+static std::unique_ptr<CScriptCompiler> CreateAndConfigureCompiler(const CExoString&);
+static int Compile(const std::filesystem::path&, const std::filesystem::path&, std::unique_ptr<CScriptCompiler>);
+static void RemoveResourceDirectory(const CExoString&);
+
+void Compiler() __attribute__((constructor));
+
+void Compiler()
+{
+    const auto source = Config::Get<std::string>("SRC_DIR");
+    const auto output = Config::Get<std::string>("OUT_DIR");
+
+    if (!source.has_value() || !output.has_value())
+    {
+        LOG_INFO("Skipping compilation. NWNX_COMPILER_SRC_DIR or NWNX_COMPILER_OUT_DIR was not specified.");
+        return;
+    }
+
+    const std::filesystem::path sourcePath(source.value());
+    const std::filesystem::path outputPath(output.value());
+
+    if (sourcePath == outputPath)
+    {
+        LOG_INFO("Skipping compilation. NWNX_COMPILER_SRC_DIR must not be the same path as NWNX_COMPILER_OUT_DIR.");
+        return;
+    }
+
+    if (!exists(sourcePath))
+    {
+        LOG_INFO("Skipping compilation. Source directory %s does not exist.", source.value());
+        return;
+    }
+
+    if (Config::Get<bool>("CLEAN_COMPILE", false) && exists(outputPath))
+    {
+        CleanOutput(output.value());
+    }
+
+    const auto sourceAlias = CExoString("NWNXCOMPILE_SRC");
+    const auto outputAlias = CExoString("NWNXCOMPILE_OUT");
+
+    if (!Globals::ExoBase()->m_pcExoAliasList->GetAliasPath(sourceAlias).IsEmpty() || !Globals::ExoBase()->m_pcExoAliasList->GetAliasPath(outputAlias).IsEmpty())
+    {
+        LOG_WARNING("Skipping compilation. A Resource Directory with %s, or %s already exists. Please remove these entries from nwn.ini.", sourceAlias.CStr(), outputAlias.CStr());
+        return;
+    }
+
+    CreateResourceDirectory(sourceAlias, sourcePath);
+    CreateResourceDirectory(outputAlias, outputPath);
+
+    const auto result = Compile(sourcePath, outputPath, CreateAndConfigureCompiler(outputAlias));
+
+    RemoveResourceDirectory(sourceAlias);
+    RemoveResourceDirectory(outputAlias);
+
+    if (Config::Get<bool>("EXIT_ON_COMPLETE", true))
+    {
+        exit(result);
+    }
+}
+
+static void CleanOutput(const std::filesystem::path& outputPath)
+{
+    for (const auto& entry : std::filesystem::directory_iterator(outputPath))
+    {
+        if (entry.path().extension() == ".ncs")
+        {
+            std::filesystem::remove(entry.path());
+        }
+    }
+}
+
+static void CreateResourceDirectory(const CExoString& alias, const std::filesystem::path& path)
+{
+    Globals::ExoBase()->m_pcExoAliasList->Add(alias, path.c_str());
+    Globals::ExoResMan()->CreateDirectory(alias);
+    Globals::ExoResMan()->AddResourceDirectory(alias, UINT32_MAX, true);
+}
+
+static void RemoveResourceDirectory(const CExoString& alias)
+{
+    Globals::ExoResMan()->RemoveResourceDirectory(alias);
+    Globals::ExoBase()->m_pcExoAliasList->Delete(alias);
+}
+
+static std::unique_ptr<CScriptCompiler> CreateAndConfigureCompiler(const CExoString& outputAlias)
+{
+    auto scriptCompiler = std::make_unique<CScriptCompiler>();
+
+    scriptCompiler->SetCompileDebugLevel(Config::Get<int>("DEBUG_LEVEL", 0));
+    scriptCompiler->SetCompileSymbolicOutput(Config::Get<int>("SYMBOLIC_OUTPUT", 0));
+    scriptCompiler->SetGenerateDebuggerOutput(Config::Get<int>("GENERATE_DEBUGGER_OUTPUT", 0));
+    scriptCompiler->SetOptimizeBinaryCodeLength(Config::Get<bool>("OPTIMIZE_BINARY_CODE_LENGTH", true));
+    scriptCompiler->SetCompileConditionalOrMain(true);
+    scriptCompiler->SetIdentifierSpecification("nwscript");
+
+    scriptCompiler->SetOutputAlias(outputAlias);
+
+    return scriptCompiler;
+}
+
+static int Compile(const std::filesystem::path& sourcePath, const std::filesystem::path& outputPath, std::unique_ptr<CScriptCompiler> scriptCompiler)
+{
+    const auto continueOnError = Config::Get<bool>("CONTINUE_ON_ERROR", false);
+    auto exitCode = 0;
+
+    for (const auto& sourceFile : std::filesystem::directory_iterator(sourcePath))
+    {
+        auto outputFile = outputPath / sourceFile.path().stem() / ".ncs";
+        if (exists(outputFile) && last_write_time(outputFile) > sourceFile.last_write_time())
+        {
+            LOG_INFO("%s - Compilation skipped as the output file is newer.", sourceFile.path().c_str());
+            continue;
+        }
+
+        LOG_INFO("Compiling: %s", sourceFile.path().c_str());
+        const auto result = scriptCompiler->CompileFile(sourceFile.path().filename().c_str());
+
+        if (result == 0)
+        {
+            LOG_INFO("Succeeded: %s", outputFile.c_str());
+        }
+        else
+        {
+            exitCode = result;
+
+            LOG_ERROR("Failed: %s", scriptCompiler->m_sCapturedError.CStr());
+
+            if (!continueOnError)
+            {
+                break;
+            }
+        }
+    }
+
+    return exitCode;
+}
+
+}

--- a/Plugins/Compiler/README.md
+++ b/Plugins/Compiler/README.md
@@ -1,0 +1,18 @@
+@page compiler Readme
+@ingroup compiler
+
+Compiles all Neverwinter source files from the specified directory to the specified output directory, before shutting down the server.
+
+## Environment Variables
+
+| Variable Name | Value | Default | Notes |
+| ------------- | :---: | ------- | ----- |
+| `NWNX_COMPILER_SRC_DIR` | string | Unset | The directory containing the source .nss files.
+| `NWNX_COMPILER_OUT_DIR` | string | Unset | The directory to output the compiled .ncs files.
+| `NWNX_COMPILER_CLEAN_COMPILE` | true/false | false | Cleans all .ncs files from the output directory.
+| `NWNX_COMPILER_CONTINUE_ON_ERROR` | true/false | false | Continue processing scripts after a compiler error.
+| `NWNX_COMPILER_EXIT_ON_COMPLETE` | true/false | true | After completing compilation, shuts down the server.
+| `NWNX_COMPILER_DEBUG_LEVEL` | int | 0 | CScriptCompiler->SetCompileDebugLevel()
+| `NWNX_COMPILER_SYMBOLIC_OUTPUT` | int | 0 | CScriptCompiler->SetCompileSymbolicOutput()
+| `NWNX_COMPILER_GENERATE_DEBUGGER_OUTPUT` | int | 0 | CScriptCompiler->SetGenerateDebuggerOutput()
+| `NWNX_COMPILER_OPTIMIZE_BINARY_CODE_LENGTH` | true/false | true | CScriptCompiler->SetOptimizeBinaryCodeLength()


### PR DESCRIPTION
Proof of concept for a plugin that compiles a specified directory of nss files, and spits out the compiled result into another, before immediately closing the server with the appropriate exit code.

I used std::filesystem, thinking that it was in C++17, and in GCC 7, but it looks like it's GCC 8+. The other APIs looked painful to use, and I might need some help swapping this stuff out.