### PR TITLE
SWIG: Add array wrappers for dialog structs. Split out function constants to new class. Use cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,4 @@ out/
 CMakeSettings.json
 
 # SWIG
-Plugins/SWIG/SWIG_*/out
-Plugins/SWIG/SWIG_*/SWIG_*Interop.cpp
 Plugins/SWIG/SWIG_*/NWNXLib.i

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ set(PLUGIN_PREFIX NWNX_)
 # Adds the provided shared library, then builds it with a NWNX_ prefix.
 function(add_plugin target)
     add_library(${target} MODULE ${ARGN})
+    configure_plugin(${target})
+endfunction()
+
+function(configure_plugin target)
     add_sanitizers(${target})
     target_link_libraries(${target} Core)
     set_target_properties(${target} PROPERTIES PREFIX "${PLUGIN_PREFIX}")

--- a/Plugins/SWIG/CMakeLists.txt
+++ b/Plugins/SWIG/CMakeLists.txt
@@ -1,26 +1,32 @@
 find_package(SWIG 4.0 COMPONENTS csharp)
 
-function(add_swig_plugin target)
-    set(interfaceFile ${target}.i)
-    set(interopFile ${target}Interop.cpp)
-
+function(add_swig_plugin target language interfaces)
     add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${target}/${interopFile}
+        OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${target}/NWNXLib.i
         DEPENDS Core
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${target}/${interfaceFile}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/generate.sh
-        COMMAND chmod a+x ../generate.sh && mkdir -p ./out && ../generate.sh -v -c++ -fcompact -o ${interopFile} -outdir ./out -I../../../NWNXLib/API ${ARGN} ${interfaceFile}
+        COMMAND chmod a+x ../generate.sh && mkdir -p ./out && ../generate.sh
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${target}
     )
 
-    add_library(${target} SHARED ${CMAKE_CURRENT_SOURCE_DIR}/${target}/${interopFile} ${CMAKE_CURRENT_SOURCE_DIR}/${target}/${target}.cpp)
-    add_sanitizers(${target})
-    target_link_libraries(${target} Core "-Wl,--no-undefined")
-    set_target_properties(${target} PROPERTIES PREFIX "${PLUGIN_PREFIX}")
-    target_include_directories(${target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/${target}")
-    target_compile_definitions(${target} PRIVATE "-DPLUGIN_NAME=\"${PLUGIN_PREFIX}${target}\"")
+    set_property(SOURCE ${interfaces} PROPERTY CPLUSPLUS ON)
+    set_property(SOURCE ${interfaces} PROPERTY DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${target}/NWNXLib.i)
+    set_property(SOURCE ${interfaces} PROPERTY COMPILE_OPTIONS ${ARGN})
+
+    swig_add_library(${target} TYPE SHARED LANGUAGE ${language} SOURCES ${interfaces})
+    configure_plugin(${target})
+
+    set_target_properties(${target} PROPERTIES
+      SWIG_INCLUDE_DIRECTORIES ../../../NWNXLib/API
+      SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON
+      POSITION_INDEPENDENT_CODE ON)
 endfunction()
 
 if(SWIG_FOUND)
-    add_swig_plugin(SWIG_DotNET -DSWIGWORDSIZE64 -csharp -dllimport "${PLUGIN_PREFIX}SWIG_DotNET" -namespace "NWN.Native.API")
+    cmake_policy(SET CMP0078 NEW)
+    INCLUDE(${SWIG_USE_FILE})
+
+    add_swig_plugin(SWIG_DotNET csharp
+        "${CMAKE_CURRENT_SOURCE_DIR}/SWIG_DotNET/API_NWNXLib.i;${CMAKE_CURRENT_SOURCE_DIR}/SWIG_DotNET/API_FunctionsLinux.i"
+        -DSWIGWORDSIZE64 -dllimport "${PLUGIN_PREFIX}SWIG_DotNET" -namespace "NWN.Native.API")
 endif(SWIG_FOUND)

--- a/Plugins/SWIG/SWIG_DotNET/API_FunctionsLinux.i
+++ b/Plugins/SWIG/SWIG_DotNET/API_FunctionsLinux.i
@@ -1,0 +1,17 @@
+%module FunctionsLinux
+
+%include <stdint.i>
+
+#pragma SWIG nowarn=317
+#define NWNXLIB_FUNCTION_NO_VERSION_CHECK
+#define NWNX_SWIG_PARSING
+
+%pragma(csharp) moduleclassmodifiers="public static class"
+
+%define NWNXLIB_FUNCTION(name, address)
+%constant uintptr_t name = address;
+%enddef
+
+%include "FunctionsLinux.hpp"
+
+#undef NWNXLIB_FUNCTION

--- a/Plugins/SWIG/SWIG_DotNET/API_NWNXLib.i
+++ b/Plugins/SWIG/SWIG_DotNET/API_NWNXLib.i
@@ -150,7 +150,7 @@
 %}
 
 %define MarshalType(CTYPE, CSTYPE, CSARRAYTYPE)
-%typemap(ctype) CTYPE*,CTYPE&,CTYPE[ANY] "CTYPE*"
+%typemap(ctype)  CTYPE*,CTYPE&,CTYPE[ANY] "CTYPE*"
 %typemap(imtype) CTYPE*,CTYPE&,CTYPE[ANY] "global::System.IntPtr"
 %typemap(cstype) CTYPE*,CTYPE& "CSTYPE*"
 %typemap(cstype) CTYPE[ANY] "NativeArray<CSARRAYTYPE>"
@@ -163,18 +163,21 @@
     global::System.IntPtr retVal = $imcall;$excode
     return (CSTYPE*)retVal;
   }
+
 %typemap(csvarout, excode=SWIGEXCODE2) CTYPE*,CTYPE& %{
     get {
         global::System.IntPtr retVal = $imcall;$excode
         return (CSTYPE*)retVal;
     }
 %}
+
 %typemap(csout, excode=SWIGEXCODE) CTYPE[ANY] {
     global::System.IntPtr arrayPtr = $imcall;$excode
     NativeArray<CSARRAYTYPE> retVal = new NativeArray<CSARRAYTYPE>(arrayPtr, $1_dim0);
 
     return retVal; // CSTYPE[$1_dim0]
   }
+
 %typemap(csvarout, excode=SWIGEXCODE2) CTYPE[ANY] %{
     get {
       global::System.IntPtr arrayPtr = $imcall;$excode
@@ -197,6 +200,7 @@
     global::System.IntPtr retVal = $imcall;$excode
     return (CSTYPE*)retVal;
   }
+
 %typemap(csvarout, excode=SWIGEXCODE2) CTYPE*,CTYPE& %{
     get {
         global::System.IntPtr retVal = $imcall;$excode
@@ -213,6 +217,7 @@
     NAME ret = (cPtr == global::System.IntPtr.Zero) ? null : new NAME(cPtr, false);
     return ret;
   }
+
 %typemap(csvarout, excode=SWIGEXCODE2) TYPE[ANY] %{
     get {
         global::System.IntPtr cPtr = $imcall;$excode;
@@ -220,6 +225,7 @@
         return ret;
     }
 %}
+
 %typemap(cscode) NAME %{
   public CSTYPE this[int index] {
     get {
@@ -562,17 +568,6 @@ MarshalPtrPtr(Task::CExoTaskManager*, void*)
 %template(CResHelperNDB) CResHelper<CResNDB,2064>;
 %template(CResHelperNCS) CResHelper<CResNCS,2010>;
 
-// Add function defines to subclass in module.
-%define NWNXLIB_FUNCTION(name, address)
-    %pragma(csharp) modulecode="    public const uint name = address;"
-%enddef
-
-%pragma(csharp) modulecode="  public static class Functions {"
-%include "FunctionsLinux.hpp"
-%pragma(csharp) modulecode="  }\n"
-
-#undef NWNXLIB_FUNCTION
-
 // Array wrappers for structures
 MapArray(CExoArrayList<CNWSStats_Spell *>, CExoArrayListCNWSStatsSpellPtr, CExoArrayListCNWSStatsSpellPtrArray)
 MapArray(CExoArrayList<CSpell_Add *>, CExoArrayListCSpellAddPtr, CExoArrayListCSpellAddPtrArray)
@@ -598,6 +593,10 @@ MapArray(CNWSTile, CNWSTile, CNWSTileArray);
 MapArray(CNWSQuickbarButton, CNWSQuickbarButton, CNWSQuickbarButtonArray);
 MapArray(CTlkTableToken, CTlkTableToken, CTlkTableTokenArray);
 MapArray(CTlkTableTokenCustom, CTlkTableTokenCustom, CTlkTableTokenCustomArray);
+MapArray(CNWSDialogEntry, CNWSDialogEntry, CNWSDialogEntryArray);
+MapArray(CNWSDialogReply, CNWSDialogReply, CNWSDialogReplyArray);
+MapArray(CNWSDialogLinkEntry, CNWSDialogLinkEntry, CNWSDialogLinkEntryArray);
+MapArray(CNWSDialogLinkReply, CNWSDialogLinkReply, CNWSDialogLinkReplyArray);
 
 %include "NWNXLib.i"
 
@@ -626,6 +625,10 @@ DefineArrayPtr(CNWSTile, CNWSTile, CNWSTileArray);
 DefineArrayPtr(CNWSQuickbarButton, CNWSQuickbarButton, CNWSQuickbarButtonArray);
 DefineArrayPtr(CTlkTableToken, CTlkTableToken, CTlkTableTokenArray);
 DefineArrayPtr(CTlkTableTokenCustom, CTlkTableTokenCustom, CTlkTableTokenCustomArray);
+DefineArrayPtr(CNWSDialogEntry, CNWSDialogEntry, CNWSDialogEntryArray);
+DefineArrayPtr(CNWSDialogReply, CNWSDialogReply, CNWSDialogReplyArray);
+DefineArrayPtr(CNWSDialogLinkEntry, CNWSDialogLinkEntry, CNWSDialogLinkEntryArray);
+DefineArrayPtr(CNWSDialogLinkReply, CNWSDialogLinkReply, CNWSDialogLinkReplyArray);
 
 // Std templates
 %template(VectorNWSyncAdvertisementManifest) std::vector<NWSyncAdvertisementManifest>;

--- a/Plugins/SWIG/generate.sh
+++ b/Plugins/SWIG/generate.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 NWNXLIB_SWG="${NWNXLIB_SWG:-NWNXLib.i}"
-FIRST_INCLUDES=(${FIRST_INCLUDES[@]:-"Functions.hpp" "API/CExoPackedFile.hpp" "API/CCallbackHandlerBase.hpp" "API/CGameObject.hpp" "API/CRes.hpp" "API/CResStruct.hpp" "API/CResGFF.hpp" "API/CNWSObject.hpp" "API/CNWTile.hpp" "API/CNWTileSet.hpp" "API/CVirtualMachineCmdImplementer.hpp" "API/STR_RES_HEADER_OLD.hpp" "API/CAurObjectVisualTransformData.hpp" "API/CNWSClient.hpp" "API/CNWMessage.hpp" "API/CExoFile.hpp" "API/CNWSClient.hpp" "API/CExoFile.hpp" "API/CGameEffectApplierRemover.hpp" "API/CNWItem.hpp" "API/CBaseExoApp.hpp" "API/CNWArea.hpp"})
+FIRST_INCLUDES=(${FIRST_INCLUDES[@]:-"API/CExoPackedFile.hpp" "API/CCallbackHandlerBase.hpp" "API/CGameObject.hpp" "API/CRes.hpp" "API/CResStruct.hpp" "API/CResGFF.hpp" "API/CNWSObject.hpp" "API/CNWTile.hpp" "API/CNWTileSet.hpp" "API/CVirtualMachineCmdImplementer.hpp" "API/STR_RES_HEADER_OLD.hpp" "API/CAurObjectVisualTransformData.hpp" "API/CNWSClient.hpp" "API/CNWMessage.hpp" "API/CExoFile.hpp" "API/CNWSClient.hpp" "API/CExoFile.hpp" "API/CGameEffectApplierRemover.hpp" "API/CNWItem.hpp" "API/CBaseExoApp.hpp" "API/CNWArea.hpp"})
+EXCLUDES=(${EXCLUDES[@]:-"Functions.hpp" "FunctionsLinux.hpp"})
+
+FIND_ARGS=()
+for exclude in "${EXCLUDES[@]}"; do
+    FIND_ARGS+=('!' '-name' "*$exclude")
+done
 
 echo "%{" > $NWNXLIB_SWG
-find ../../../NWNXLib/API -type f -name '*.hpp' -printf '#include "%P"\n' | sort >> $NWNXLIB_SWG
+find ../../../NWNXLib/API -type f -name '*.hpp' "${FIND_ARGS[@]}" -printf '#include "%P"\n' | sort >> $NWNXLIB_SWG
 echo "%}" >> $NWNXLIB_SWG
 
 for include in "${FIRST_INCLUDES[@]}"
@@ -11,6 +17,4 @@ do
     echo "%include \"$include\"" >> $NWNXLIB_SWG
 done
 
-find ../../../NWNXLib/API -type f -name '*.hpp' -printf '%%include "%P"\n' | sort >> $NWNXLIB_SWG
-
-swig ${@:1}
+find ../../../NWNXLib/API -type f -name '*.hpp' "${FIND_ARGS[@]}" -printf '%%include "%P"\n' | sort >> $NWNXLIB_SWG


### PR DESCRIPTION
Adds support for bundling multiple SWIG interfaces files into 1 binary, and converts the function constants into static initialised values that should be much more resilient to version changes.