### PR TITLE
[WIP] Attack Animation Override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 https://github.com/nwnxee/unified/compare/build8193.23...HEAD
 
 ### Added
-- N/A
+- Player: SetAttackAnimation() - This function will override both Melee & Ranked Attack Animation. Hook from NWNX Attack Event to check for Melee/Ranged Weapons. Obeys same requirements as NWNX_Player_SetRestAnimation().
 
 ##### New Plugins
 - N/A

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -390,6 +390,13 @@ void NWNX_Player_CloseStore(object oPlayer);
 /// @note Overrides will not persist through relogging.
 void NWNX_Player_SetTlkOverride(object oPlayer, int nStrRef, string sOverride, int bRestoreGlobal = TRUE);
 
+/// @brief Override player's attack animation.
+/// @param oPlayer The player object.
+/// @param nAnimation The NWNX animation id. This does not take ANIMATION_LOOPING_* or
+/// ANIMATION_FIREFORGET_* constants. Instead use NWNX_Consts_TranslateNWScriptAnimation() to get
+/// the NWNX equivalent. -1 to clear the override.
+void NWNX_Player_SetAttackAnimation(object oPlayer, int nAnimation);
+
 /// @}
 
 void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable)
@@ -978,5 +985,15 @@ void NWNX_Player_SetTlkOverride(object oPlayer, int nStrRef, string sOverride, i
     NWNX_PushArgumentString(sOverride);
     NWNX_PushArgumentInt(nStrRef);
     NWNX_PushArgumentObject(oPlayer);
+    NWNX_CallFunction(NWNX_Player, sFunc);
+}
+
+void NWNX_Player_SetAttackAnimation(object oPlayer, int nAnimation)
+{
+    string sFunc = "SetAttackAnimation";
+
+    NWNX_PushArgumentInt(nAnimation);
+    NWNX_PushArgumentObject(oPlayer);
+
     NWNX_CallFunction(NWNX_Player, sFunc);
 }

--- a/Plugins/Player/NWScript/nwnx_player_t.nss
+++ b/Plugins/Player/NWScript/nwnx_player_t.nss
@@ -1,4 +1,5 @@
 #include "nwnx_player"
+#include "nwnx_consts"
 #include "nwnx_tests"
 
 void main()
@@ -11,6 +12,20 @@ void main()
         WriteTimestampedLogEntry("NWNX_Player test: No PC found");
         return;
     }
+
+    //
+    // Player Attack Animation Override
+    // Recommend hooking into Attack Event
+    //
+
+    //Ranged Weapon Check / Reverts to Normal Animation
+    if (GetBaseItemType(GetItemInSlot(INVENTORY_SLOT_RIGHTHAND, oAttacker)) == BASE_ITEM_SHORTBOW)
+        NWNX_Player_SetAttackAnimation(oAttacker, -1);
+    //Otherwise, adjust Attack Animation
+    else NWNX_Player_SetAttackAnimation(oAttacker, NWNX_Consts_TranslateNWScriptAnimation(ANIMATION_LOOPING_SPASM));
+
+    //DelayCommand Recommended to return Attack state to original
+    DelayCommand(0.1f, NWNX_Player_SetAttackAnimation(oAttacker, -1));
 
     WriteTimestampedLogEntry("NWNX_Player unit test end.");
 }

--- a/Plugins/Player/README.md
+++ b/Plugins/Player/README.md
@@ -51,3 +51,16 @@ In this example make you would make sure to reset the `persistent_locs_loaded` b
         NWNX_SQL_PrepareQuery(sSQL);
         NWNX_SQL_ExecutePreparedQuery();
 ```
+
+#### SetAttackAnimation()
+This function is best used in the NWNX Attack event so that better control of animations can be offered for Melee vs Ranged attacks.
+
+Recommended to set the Animation for players via a saved Persistent Variable in conversation, and call that variable during NWNX Attack events to set the Animation desired.
+
+Also recommended to set a short DelayCommand reset to ensure visual hiccups when swapping between animations are avoided. Example below:
+```c
+void main()
+{
+    DelayCommand(0.1f, NWNX_Player_SetAttackAnimation(oAttacker, -1));
+}
+```


### PR DESCRIPTION
WIP~

This function will override Attack Animations for the player. Care should be taken when using animations that are much longer in duration than a standard attack. This **does** allow Whirlwind animation to be fired at will/OnAttack, however duration is a factor. Looping & Fire/Forget Animations have been proven to work, and this function follows the same requirements as SetRestAnimation.