### PR TITLE
Events: InputEvents: use the right hook for NWNX_ON_INPUT_FORCE_MOVE_TO_OBJECT_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ https://github.com/nwnxee/unified/compare/build8193.23...HEAD
 
 ### Fixed
 - Core: {Get|Set}LocalCassowary() actually work and no longer throw asserts.
+- Events: InputEvents: NWNX_ON_INPUT_FORCE_MOVE_TO_OBJECT_* now uses the right hook.
 
 ## 8193.22
 https://github.com/nwnxee/unified/compare/build8193.22...build8193.23

--- a/Plugins/Events/Events/InputEvents.cpp
+++ b/Plugins/Events/Events/InputEvents.cpp
@@ -133,7 +133,7 @@ int32_t InputEvents::AddMoveToPointActionToFrontHook(CNWSCreature *pCreature, ui
     int32_t retVal;
     if (oidObjectMovingTo != Constants::OBJECT_INVALID)
     {
-        retVal = s_HandlePlayerToServerInputWalkToWaypointHook->CallOriginal<int32_t>(
+        retVal = s_AddMoveToPointActionToFrontHook->CallOriginal<int32_t>(
                 pCreature, nGroupId, vNewWalkPosition, oidNewWalkArea, oidObjectMovingTo, bRunToPoint, fRange, fTimeout,
                 bClientMoving, nClientPathNumber, nMoveToPosition, nMoveMode, bStraightLine, bCheckedActionPoint);
     }
@@ -141,7 +141,7 @@ int32_t InputEvents::AddMoveToPointActionToFrontHook(CNWSCreature *pCreature, ui
     {
         Events::PushEventData("TARGET", Utils::ObjectIDToString(oidObjectMovingTo));
         Events::SignalEvent("NWNX_ON_INPUT_FORCE_MOVE_TO_OBJECT_BEFORE", pCreature->m_idSelf);
-        retVal = s_HandlePlayerToServerInputWalkToWaypointHook->CallOriginal<int32_t>(
+        retVal = s_AddMoveToPointActionToFrontHook->CallOriginal<int32_t>(
                 pCreature, nGroupId, vNewWalkPosition, oidNewWalkArea, oidObjectMovingTo, bRunToPoint, fRange, fTimeout,
                 bClientMoving, nClientPathNumber, nMoveToPosition, nMoveMode, bStraightLine, bCheckedActionPoint);
         Events::PushEventData("TARGET", Utils::ObjectIDToString(oidObjectMovingTo));


### PR DESCRIPTION
Durrr.