### PR TITLE
Dialog: fix a crash when calling GetCurrentNodeID() in an OnConversationAborted script, attempt 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ https://github.com/nwnxee/unified/compare/build8193.23...HEAD
 
 ### Fixed
 - Core: {Get|Set}LocalCassowary() actually work and no longer throw asserts.
+- Dialog: fixed a crash when calling GetCurrentNodeID() in an OnConversationAborted script.
 - Events: InputEvents: NWNX_ON_INPUT_FORCE_MOVE_TO_OBJECT_* now uses the right hook.
 
 ## 8193.22

--- a/Plugins/Dialog/Dialog.cpp
+++ b/Plugins/Dialog/Dialog.cpp
@@ -196,6 +196,9 @@ NWNX_EXPORT ArgumentStack GetCurrentScriptType(ArgumentStack&&)
 
 NWNX_EXPORT ArgumentStack GetCurrentNodeID(ArgumentStack&&)
 {
+    if (s_statestack[s_ssp] == DIALOG_STATE_HANDLE_REPLY && s_idxReply == 0xFFFFFFFF)
+        return -1;
+
     switch (s_statestack[s_ssp])
     {
         case DIALOG_STATE_START:


### PR DESCRIPTION
Actually fixes #1356 this time.