### PR TITLE
Fix custom plugins building in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,5 +92,5 @@ endforeach(plugin)
 
 # Allow specifying out of tree plugins by putting their paths in an env. variable
 foreach(addplugin $ENV{NWNX_ADDITIONAL_PLUGINS})
-    add_subdirectory(${addplugin} ${CMAKE_CURRENT_SOURCE_DIR}/Binaries)
+    add_subdirectory(${addplugin} ${CMAKE_BINARY_DIR}/custom)
 endforeach(addplugin)


### PR DESCRIPTION
The binary dir for out-of-tree libraries needs to be a subdir of whatever contains CMakeCache.txt (i.e. CMAKE_BINARY_DIR) of the project.
Wasn't always like this. Likely breakage due to cmake update, dunno, don't care.