### PR TITLE
Encoding: Add support for a missing character in cp1251

### DIFF
--- a/NWNXLib/Encoding.cpp
+++ b/NWNXLib/Encoding.cpp
@@ -175,6 +175,8 @@ std::string FromUTF8(const char *str, Locale locale)
                         {
                             if (codepoint == 1025)
                                 codepoint = 1016;
+                            if (codepoint == 1105)
+                                codepoint = 1032;
 
                             iso8859.push_back(static_cast<char>(codepoint - 848));
                         }


### PR DESCRIPTION
Add support for decoding one missing Cyrillic character: ё