### PR TITLE
Add "ON_DESTROY_SERVER_AFTER" signal.

### DIFF
--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -555,6 +555,9 @@ void NWNXCore::DestroyServerHandler(CAppManager* app)
 
     g_core->m_destroyServerHook.reset();
     app->DestroyServer();
+
+    MessageBus::Broadcast("NWNX_CORE_SIGNAL", { "ON_DESTROY_SERVER_AFTER" });
+
     g_core->Shutdown();
 
     RestoreCrashHandlers();

--- a/Plugins/DotNET/DotNETExports.cpp
+++ b/Plugins/DotNET/DotNETExports.cpp
@@ -137,10 +137,18 @@ static void RegisterHandlers(AllHandlers *handlers, unsigned size)
     MessageBus::Subscribe("NWNX_CORE_SIGNAL",
         [](const std::vector<std::string>& message)
         {
-            int spBefore = Utils::PushScriptContext(Constants::OBJECT_INVALID, 0, false);
-            s_handlers.SignalHandler(message[0].c_str());
-            int spAfter = Utils::PopScriptContext();
-            ASSERT_MSG(spBefore == spAfter, "spBefore=%x, spAfter=%x", spBefore, spAfter);
+            // We will crash the server if we try to create a script context after the server is destroyed.
+            if (message[0] == "ON_DESTROY_SERVER_AFTER")
+            {
+                s_handlers.SignalHandler(message[0].c_str());
+            }
+            else
+            {
+                int spBefore = Utils::PushScriptContext(Constants::OBJECT_INVALID, 0, false);
+                s_handlers.SignalHandler(message[0].c_str());
+                int spAfter = Utils::PopScriptContext();
+                ASSERT_MSG(spBefore == spAfter, "spBefore=%x, spAfter=%x", spBefore, spAfter);
+            }
         });
 }
 


### PR DESCRIPTION
Adds a new signal for solving a DotNET specific issue where some hooks were being unloaded too quickly (ObjectStorage).

Related PR: https://github.com/nwn-dotnet/Anvil/pull/330