### PR TITLE
API: Fix cswy engine structure size

### DIFF
--- a/NWNXLib/API/API/CassowarySolverEngineStructure.hpp
+++ b/NWNXLib/API/API/CassowarySolverEngineStructure.hpp
@@ -8,14 +8,18 @@
 NWN_API_PROLOGUE(CassowarySolverEngineStructure)
 #endif
 
-
-
-
-
-struct CassowarySolverEngineStructure
+template<typename T>
+struct SharedPtrEngineStructure
 {
-    std::shared_ptr<void*> m_shared;
+    std::shared_ptr<T> m_shared;
+    virtual ~SharedPtrEngineStructure() {}
+};
 
+
+struct CassowarySolverEngineStructureShared;
+struct CassowarySolverEngineStructure : public SharedPtrEngineStructure<CassowarySolverEngineStructureShared>
+{
+    virtual ~CassowarySolverEngineStructure() {}
 
 #ifdef NWN_CLASS_EXTENSION_CassowarySolverEngineStructure
     NWN_CLASS_EXTENSION_CassowarySolverEngineStructure


### PR DESCRIPTION
Needs to have a correct vtable. This should suffice, hopefully.

Fixes #1387 . @Jorteck could you please verify? Thanks.