### PR TITLE
Use stdout for all error reporting, require it on bug reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,12 @@ https://github.com/nwnxee/unified/compare/build8193.30...HEAD
 - SQL: PreparedNULL()
 
 ### Changed
-- Core: Assert backtraces now show up in `logs.0/nwnx.txt`.
+- Core: **POLICY CHANGE:** Only `stdout` output will be accepted in bug reports.
+- Core: Assert backtraces now show up in the log file.
 - Core: Assert backtraces are now printed to `stdout` instead of `stderr`.
+- Core: Other error messages are now printed to `stdout` instead of `stderr`
+- Core: The default NWN carsh handler is no longer called by default. Set `NWNX_CORE_BASE_GAME_CRASH_HANDLER=y` to call it.
+- Core: `nwnx.txt` is no longer created by default. Set `NWNX_CORE_LOG_FILE_PATH="path/to/nwnx.txt"` to use it.
 
 ### Deprecated
 - N/A

--- a/Core/README.md
+++ b/Core/README.md
@@ -25,8 +25,9 @@ The core of NWNX:EE that does all the things.
 | `NWNX_CORE_LOG_SOURCE` | 0-1 | 1 | Set whether to show source code location in logs printed by NWNX.
 | `NWNX_CORE_LOG_COLOR` | 0-1 | 1 | Set whether to show logs printed by NWNX in color (only when printing to a TTY).
 | `NWNX_CORE_LOG_FORCE_COLOR` | 0-1| 0 | Sets whether to force color output.
-| `NWNX_CORE_LOG_ASYNC` | 0-1| 0 | Sets whether to flush the log to disk in an async thread.
+| `NWNX_CORE_LOG_FILE_NAME` | string | Unset | Sets the secondary (in addition to `stdout`) log file.
 | `NWNX_CORE_HARD_EXIT` | 0-1| 0 | If set, NWNX will hard kill the process after it unloads.
+| `NWNX_CORE_BASE_GAME_CRASH_HANDLER` | 0-1 | 0 | Sets whether to also call the base game handler in case of crash.
 
 ## Console Commands
 
@@ -101,18 +102,18 @@ This following function would wrap a call which passes three parameters, receive
         string funcName = "GiveMeBackTheSameValues";
 
         // Note the inverse argument push order.
-        // C++-side, arguments will be consumed from right to left.
-        NWNX_PushArgumentFloat(pluginName, funcName, z);
-        NWNX_PushArgumentFloat(pluginName, funcName, y);
-        NWNX_PushArgumentFloat(pluginName, funcName, x);
+        // C++-side, arguments will be consumed from left to right.
+        NWNX_PushArgumentFloat(z);
+        NWNX_PushArgumentFloat(y);
+        NWNX_PushArgumentFloat(x);
 
         // This calls the function, which will prepare the return values.
         NWNX_CallFunction(pluginName, funcName);
 
         // C++-side pushes the return values in reverse order so we can consume them naturally here.
-        float _x = NWNX_GetReturnValueFloat(pluginName, funcName);
-        float _y = NWNX_GetReturnValueFloat(pluginName, funcName);
-        float _z = NWNX_GetReturnValueFloat(pluginName, funcName);
+        float _x = NWNX_GetReturnValueFloat();
+        float _y = NWNX_GetReturnValueFloat();
+        float _z = NWNX_GetReturnValueFloat();
 
         return vector(_x, _y, _z);
     }

--- a/NWNXLib/Log.cpp
+++ b/NWNXLib/Log.cpp
@@ -15,6 +15,8 @@ static bool s_PrintPlugin;
 static bool s_PrintSource;
 static bool s_ColorOutput;
 static bool s_ForceColor;
+static std::string s_LogFile;
+
 void SetPrintTimestamp(bool value)
 {
     s_PrintTimestamp = value;
@@ -65,6 +67,10 @@ bool GetForceColor()
 {
     return s_ForceColor;
 }
+void SetLogFile(const std::string& logfilepath)
+{
+    s_LogFile = logfilepath;
+}
 
 void InternalTrace(Channel::Enum channel, Channel::Enum allowedChannel, const char* message)
 {
@@ -85,8 +91,7 @@ void InternalTrace(Channel::Enum channel, Channel::Enum allowedChannel, const ch
     }
     std::cout << message << rang::style::reset << rang::fg::reset  << std::endl;
 
-    // Also write to a file - this could be done in a much nicer way but I just want to retain the old functionality
-    // for now. We can change this later if we want or need to.
+    // Also write to a file if configured
     WriteToLogFile(message);
 
     if (channel == Channel::SEV_FATAL)
@@ -98,9 +103,20 @@ void InternalTrace(Channel::Enum channel, Channel::Enum allowedChannel, const ch
 
 void WriteToLogFile(const char* message)
 {
-    static std::string logPath = API::Globals::ExoBase()->m_sUserDirectory.CStr() + std::string("/logs.0/nwnx.txt");
-    static FILE* logFile = std::fopen(logPath.c_str(), "a+");
+    static FILE* logFile;
 
+    if (!logFile && s_LogFile != "")
+    {
+        logFile = std::fopen(s_LogFile.c_str(), "a+");
+        if (logFile)
+        {
+            std::fprintf(logFile,
+        "=====================================================================\n"
+        "       NWNX secondary log file. This log file may be incomplete!     \n"
+        " Please attach stdout output instead of this file to any bug reports.\n"
+        "=====================================================================\n");
+        }
+    }
     if (logFile)
     {
         std::fprintf(logFile, "%s\n", message);

--- a/NWNXLib/Log.hpp
+++ b/NWNXLib/Log.hpp
@@ -65,8 +65,7 @@ void SetColorOutput(bool value);
 bool GetColorOutput();
 void SetForceColor(bool value);
 bool GetForceColor();
-
-//void SetAsync(NWNXLib::Services::Tasks* tasks);
+void SetLogFile(const std::string& logfile = "");
 
 void InternalTrace(Channel::Enum channel, Channel::Enum allowedChannel, const char* message);
 void WriteToLogFile(const char* message);

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ To build on Windows:
 
 All contribution are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for requirements and style guidelines.
 
+## Reporting bugs
+
+Use the [issue tracker](https://github.com/nwnxee/unified/issues/new) to report any bugs. Please always provide the relevant `stdout` output of your runs, ideally at debug log level (`NWNX_CORE_LOG_LEVEL=7`).
+
 ## Who makes NWNX:EE?
 
 The project is an open source project created and maintained by community members for free in their spare time.


### PR DESCRIPTION
Policy change: All bug reports now need to have stdout attached.

To avoid confusion, disable `nwnx.txt` and the `nwserver-crash-xxx.log` by default unless overridden via config.
Also allow nwnx.txt to be any file path.