### PR TITLE
Rename: Check if the creature exists in the LUO list before sending an update

### DIFF
--- a/Plugins/Rename/Rename.hpp
+++ b/Plugins/Rename/Rename.hpp
@@ -41,6 +41,7 @@ private:
     void GlobalNameChange(bool, PlayerID, PlayerID);
 
     std::string GenerateRandomPlayerName(size_t length, ObjectID targetOid);
+    bool IsCreatureInLastUpdateObjectList(CNWSPlayer *player, ObjectID creatureId);
 
     void SendNameUpdate(CNWSCreature *targetCreature, PlayerID observerPlayerId);
 


### PR DESCRIPTION
The client may crash if an object update packet is sent for a creature that doesn't exist on the client, so we need to check that the creature exists in the LUO lists before sending the update.