### PR TITLE
Fixes NPC conversation, adds ON_ITEM_MERGE event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 https://github.com/nwnxee/unified/compare/build8193.30...HEAD
 
 ### Added
-- N/A
+- Events: Added NWNX_ON_ITEM_MERGE_BEFORE and NWNX_ON_ITEM_MERGE_AFTER.
 
 ##### New Plugins
 - N/A

--- a/Plugins/Chat/Chat.cpp
+++ b/Plugins/Chat/Chat.cpp
@@ -265,13 +265,13 @@ Events::ArgumentStack Chat::SendMessage(Events::ArgumentStack&& args)
         auto targetObj = Utils::AsNWSObject(Utils::GetGameObject(target));
         if (targetObj && targetObj->m_bListening)
         {
-            // Sets last speaker.
-            targetObj->m_oidLastSpeaker = speaker;
-
             // Sets listening pattern.
             targetObj->m_nMatchedPos = targetObj->TestListenExpression(message);
             if (targetObj->m_nMatchedPos != -1)
             {
+                // Sets last speaker.
+                targetObj->m_oidLastSpeaker = speaker;
+
                 for (int i = 0; i < targetObj->m_aListenExpressions.num; ++i)
                 {
                     if (targetObj->m_aListenExpressions[i]->m_nExpressionId == targetObj->m_nMatchedPos)
@@ -281,20 +281,20 @@ Events::ArgumentStack Chat::SendMessage(Events::ArgumentStack&& args)
                             targetObj->AddMatchedExpressionString(*targetObj->m_aListenExpressions[i]->m_aStored[j]);
                     }
                 }
-            }
 
-            // Triggers OnConversation event.
-            switch (targetObj->m_nObjectType)
-            {
-                case Constants::ObjectType::Creature:
-                    retVal = targetObj->RunEventScript(Constants::CreatureEvent::OnConversation);
-                    break;
-                case Constants::ObjectType::Placeable:
-                    retVal = targetObj->RunEventScript(Constants::PlaceableEvent::OnConversation);
-                    break;
-                case Constants::ObjectType::Door:
-                    retVal = targetObj->RunEventScript(Constants::DoorEvent::OnConversation);
-                    break;
+                // Triggers OnConversation event.
+                switch (targetObj->m_nObjectType)
+                {
+                    case Constants::ObjectType::Creature:
+                        retVal = targetObj->RunEventScript(Constants::CreatureEvent::OnConversation);
+                        break;
+                    case Constants::ObjectType::Placeable:
+                        retVal = targetObj->RunEventScript(Constants::PlaceableEvent::OnConversation);
+                        break;
+                    case Constants::ObjectType::Door:
+                        retVal = targetObj->RunEventScript(Constants::DoorEvent::OnConversation);
+                        break;
+                }
             }
         }
     }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -236,6 +236,18 @@ _______________________________________
     NUMBER_SPLIT_OFF      | int    | |
 
 _______________________________________
+    ## Item Merge Events
+    - NWNX_ON_ITEM_MERGE_BEFORE
+    - NWNX_ON_ITEM_MERGE_AFTER
+
+    `OBJECT_SELF` = The player attempting to merge an item
+
+    Event Data Tag        | Type   | Notes                                                                             |
+    ----------------------|--------|-----------------------------------------------------------------------------------|
+    ITEM_TO_MERGE_INTO    | object | Convert to object with StringToObject()                                           |
+    ITEM_TO_MERGE         | object | Convert to object with StringToObject() (May be OBJECT_INVALID in the AFTER event)|
+
+_______________________________________
     ## Acquire Item Events
     - NWNX_ON_ITEM_ACQUIRE_BEFORE
     - NWNX_ON_ITEM_ACQUIRE_AFTER


### PR DESCRIPTION
This PR consists of two changes:

1) Fixes recently introduced NPC targeted chat messages. I didn't understand original behavior well and OnConversation event should trigger only in case there's matched pattern.

2) I added ON_ITEM_MERGE events to Events plugin.