### PR TITLE
ELC: add config flag to non-basegame caster primary stat check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ https://github.com/nwnxee/unified/compare/build8193.30...HEAD
 
 ### Added
 - Events: Added NWNX_ON_ITEM_MERGE_BEFORE and NWNX_ON_ITEM_MERGE_AFTER.
+- ELC: added `NWNX_ELC_ENFORCE_CASTER_PRIMARY_STAT_IS_11`, if enabled, ELC will check when a character's first level class is a spellcaster, if their primary casting stat is >= 11.
 
 ##### New Plugins
 - N/A

--- a/Plugins/ELC/ELC.cpp
+++ b/Plugins/ELC/ELC.cpp
@@ -139,6 +139,7 @@ static std::string s_elcScript = Config::Get<std::string>("ELC_SCRIPT", "");
 static bool s_enableCustomELCCheck = Config::Get<bool>("CUSTOM_ELC_CHECK", false);
 static bool s_enforceDefaultEventScripts = Config::Get<bool>("ENFORCE_DEFAULT_EVENT_SCRIPTS", false);
 static bool s_enforceEmptyDialogResRef = Config::Get<bool>("ENFORCE_EMPTY_DIALOG_RESREF", false);
+static bool s_enforceCasterPrimaryStatIs11 = Config::Get<bool>("ENFORCE_CASTER_PRIMARY_STAT_IS_11", false);
 static uint32_t s_elcDepth = 0;
 static bool s_skipValidationFailure;
 static int32_t s_validationFailureType;
@@ -657,17 +658,20 @@ static auto s_ValidateCharacter = Hooks::HookFunction(API::Functions::_ZN10CNWSP
                     }
                 }
 
-                // Check if our first level class is a spellcaster and if their primary casting stat is >= 11
-                if (nLevel == 1 && pClassLeveledUpIn->m_bIsSpellCasterClass)
+                if (s_enforceCasterPrimaryStatIs11)
                 {
-                    if (nAbilityAtLevel[pClassLeveledUpIn->m_nPrimaryAbility] < 11)
+                    // Check if our first level class is a spellcaster and if their primary casting stat is >= 11
+                    if (nLevel == 1 && pClassLeveledUpIn->m_bIsSpellCasterClass)
                     {
-                        if (auto strrefFailure = HandleValidationFailure(
-                                ValidationFailureType::Character,
-                                ValidationFailureSubType::ClassSpellcasterInvalidPrimaryStat,
-                                STRREF_CHARACTER_INVALID_ABILITY_SCORES))
+                        if (nAbilityAtLevel[pClassLeveledUpIn->m_nPrimaryAbility] < 11)
                         {
-                            return strrefFailure;
+                            if (auto strrefFailure = HandleValidationFailure(
+                                    ValidationFailureType::Character,
+                                    ValidationFailureSubType::ClassSpellcasterInvalidPrimaryStat,
+                                    STRREF_CHARACTER_INVALID_ABILITY_SCORES))
+                            {
+                                return strrefFailure;
+                            }
                         }
                     }
                 }

--- a/Plugins/ELC/README.md
+++ b/Plugins/ELC/README.md
@@ -15,6 +15,7 @@ This is a pretty advanced plugin and may at times require you to dive into the s
 | `NWNX_ELC_CUSTOM_ELC_CHECK` | true/false | false | Enables the custom ELC check, an ELC script must be set for it to run.
 | `NWNX_ELC_ENFORCE_DEFAULT_EVENT_SCRIPTS` | true/false | false | If enabled, resets a character's event scripts to `default`. Requires ELC to be enabled.
 | `NWNX_ELC_ENFORCE_EMPTY_DIALOG_RESREF` | true/false | false | If enabled, resets a character's dialog resref to empty. Requires ELC to be enabled.
+| `NWNX_ELC_ENFORCE_CASTER_PRIMARY_STAT_IS_11` | true/false | false | If enabled, check when a character's first level class is a spellcaster, if their primary casting stat is >= 11.
 
 ## Events
 This plugin adds the following events which can be subscribed to with NWNX_Events.


### PR DESCRIPTION
Should fix #1408