### PR TITLE
add NWNX_Util_GetModuleMtime()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ https://github.com/nwnxee/unified/compare/build8193.32...HEAD
 - N/A
 
 ##### New NWScript Functions
-- N/A
+- Util: GetModuleMtime()
 
 ### Changed
 - N/A

--- a/Plugins/Util/NWScript/nwnx_util.nss
+++ b/Plugins/Util/NWScript/nwnx_util.nss
@@ -58,6 +58,10 @@ string NWNX_Util_GetAsciiTableString();
 /// @return The hashed string as an integer.
 int NWNX_Util_Hash(string str);
 
+/// @brief Gets the last modified timestamp (mtime) of the module file in seconds.
+/// @return The mtime of the module file.
+int NWNX_Util_GetModuleMtime();
+
 /// @brief Gets the value of customTokenNumber.
 /// @param customTokenNumber The token number to query.
 /// @return The string representation of the token value.
@@ -280,6 +284,12 @@ int NWNX_Util_Hash(string str)
     string sFunc = "Hash";
     NWNX_PushArgumentString(str);
     NWNX_CallFunction(NWNX_Util, sFunc);
+    return NWNX_GetReturnValueInt();
+}
+
+int NWNX_Util_GetModuleMtime()
+{
+    NWNX_CallFunction(NWNX_Util, "GetModuleMtime");
     return NWNX_GetReturnValueInt();
 }
 

--- a/Plugins/Util/NWScript/nwnx_util_t.nss
+++ b/Plugins/Util/NWScript/nwnx_util_t.nss
@@ -13,6 +13,8 @@ void main()
     int hash = NWNX_Util_Hash(str);
     NWNX_Tests_Report("NWNX_Util", "Hash", hash != 0);
 
+    NWNX_Tests_Report("NWNX_Util", "GetModuleMtime", NWNX_Util_GetModuleMtime() > 0);
+
     string ascii = NWNX_Util_GetAsciiTableString();
     NWNX_Tests_Report("NWNX_Util", "GetAsciiTableString", GetSubString(ascii, 65, 1) == "A");
 


### PR DESCRIPTION
(Edited. Previously this was about getting a hash of the module file.)

The idea is to compare the last modified timestamp (mtime) of the currently running module with a stored one and only run certain actions if the module changed.