### PR TITLE
Update CI to support community nwserver images.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,8 +196,8 @@ jobs:
           username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.CR_PAT }}
 
-      - name: Build and push
-        id: docker_build
+      - name: Build and push Beamdog image
+        id: docker_build_beamdog
         uses: docker/build-push-action@v2
         with:
           context: ./
@@ -221,8 +221,92 @@ jobs:
             ghcr.io/${{ github.repository }}:build${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}
             ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.sha_short }}
 
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Beamdog Image digest
+        run: echo ${{ steps.docker_build_beamdog.outputs.digest }}
+
+      - name: Build and push community buster image
+        id: docker_build_community_buster
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./gha.Dockerfile
+          push: true
+          build-args: NWNXEE_BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest-debian-buster
+          labels: |
+              org.opencontainers.image.title=NWNX:EE
+              org.opencontainers.image.description=This is the NWNX:EE image. NWNX:EE is a framework that developers can use to modify existing hardcoded rules or inject brand new functionality into Neverwinter Nights: Enhanced edition.
+              org.opencontainers.image.author=NWNX:EE Community
+              org.opencontainers.image.vendor=NWNX:EE Community
+              org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
+              org.opencontainers.image.created=${{ steps.vars.outputs.created }}
+              org.opencontainers.image.revision=${{ github.sha }}
+              org.opencontainers.image.documentation=https://nwnxee.github.io/unified
+          tags: |
+            ${{ github.repository }}:latest-debian-buster
+            ${{ github.repository }}:${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-debian-buster
+            ${{ github.repository }}:${{ steps.vars.outputs.sha_short }}-debian-buster
+            ghcr.io/${{ github.repository }}:latest-debian-buster
+            ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-debian-buster
+            ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.sha_short }}-debian-buster
+
+      - name: Buster Image digest
+        run: echo ${{ steps.docker_build_community_buster.outputs.digest }}
+
+      - name: Build and push community bullseye image
+        id: docker_build_community_bullseye
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./gha.Dockerfile
+          push: true
+          build-args: NWNXEE_BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest-debian-bullseye
+          labels: |
+              org.opencontainers.image.title=NWNX:EE
+              org.opencontainers.image.description=This is the NWNX:EE image. NWNX:EE is a framework that developers can use to modify existing hardcoded rules or inject brand new functionality into Neverwinter Nights: Enhanced edition.
+              org.opencontainers.image.author=NWNX:EE Community
+              org.opencontainers.image.vendor=NWNX:EE Community
+              org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
+              org.opencontainers.image.created=${{ steps.vars.outputs.created }}
+              org.opencontainers.image.revision=${{ github.sha }}
+              org.opencontainers.image.documentation=https://nwnxee.github.io/unified
+          tags: |
+            ${{ github.repository }}:latest-debian-bullseye
+            ${{ github.repository }}:${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-debian-bullseye
+            ${{ github.repository }}:${{ steps.vars.outputs.sha_short }}-debian-bullseye
+            ghcr.io/${{ github.repository }}:latest-debian-bullseye
+            ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-debian-bullseye
+            ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.sha_short }}-debian-bullseye
+
+      - name: Bullseye Image digest
+        run: echo ${{ steps.docker_build_community_bullseye.outputs.digest }}
+
+      - name: Build and push community focal image
+        id: docker_build_community_focal
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./gha.Dockerfile
+          push: true
+          build-args: NWNXEE_BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest-ubuntu-focal
+          labels: |
+              org.opencontainers.image.title=NWNX:EE
+              org.opencontainers.image.description=This is the NWNX:EE image. NWNX:EE is a framework that developers can use to modify existing hardcoded rules or inject brand new functionality into Neverwinter Nights: Enhanced edition.
+              org.opencontainers.image.author=NWNX:EE Community
+              org.opencontainers.image.vendor=NWNX:EE Community
+              org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
+              org.opencontainers.image.created=${{ steps.vars.outputs.created }}
+              org.opencontainers.image.revision=${{ github.sha }}
+              org.opencontainers.image.documentation=https://nwnxee.github.io/unified
+          tags: |
+            ${{ github.repository }}:latest-ubuntu-focal
+            ${{ github.repository }}:${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-ubuntu-focal
+            ${{ github.repository }}:${{ steps.vars.outputs.sha_short }}-ubuntu-focal
+            ghcr.io/${{ github.repository }}:latest-ubuntu-focal
+            ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-ubuntu-focal
+            ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.sha_short }}-ubuntu-focal
+
+      - name: Bullseye Image digest
+        run: echo ${{ steps.docker_build_community_focal.outputs.digest }}
 
   release:
     if: contains(github.ref, 'tags/build')

--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -43,7 +43,7 @@ jobs:
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.CR_PAT }}
 
-    - name: Build and push
+    - name: Build and push Beamdog base image
       id: docker_build
       uses: docker/build-push-action@v2
       with:
@@ -63,6 +63,69 @@ jobs:
           ${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}
           ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest
           ghcr.io/${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}
+
+    - name: Build and push community buster base image
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./base.Dockerfile
+        build-args: BD_NWSERVER_IMAGE=urothis/nwnee-community-images:nwserver-${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-debian-buster
+        push: true
+        labels: |
+          org.opencontainers.image.title=NWNX:EE Base
+          org.opencontainers.image.description=This image is the base for NWNX:EE, it includes all the dependencies required to run NWNX and all plugins. It is used as an intermediary container before the freshly built binaries are placed.
+          org.opencontainers.image.author=NWNX:EE Community
+          org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
+          org.opencontainers.image.created=${{ steps.vars.outputs.created }}
+          org.opencontainers.image.revision=${{ github.sha }}
+        tags: |
+          ${{ github.repository_owner }}/nwnxee-base:latest-debian-buster
+          ${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-debian-buster
+          ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest-debian-buster
+          ghcr.io/${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-debian-buster
+
+    - name: Build and push community bullseye base image
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./base.Dockerfile
+        build-args: BD_NWSERVER_IMAGE=beamdog/nwserver:${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-debian-bullseye
+        push: true
+        labels: |
+          org.opencontainers.image.title=NWNX:EE Base
+          org.opencontainers.image.description=This image is the base for NWNX:EE, it includes all the dependencies required to run NWNX and all plugins. It is used as an intermediary container before the freshly built binaries are placed.
+          org.opencontainers.image.author=NWNX:EE Community
+          org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
+          org.opencontainers.image.created=${{ steps.vars.outputs.created }}
+          org.opencontainers.image.revision=${{ github.sha }}
+        tags: |
+          ${{ github.repository_owner }}/nwnxee-base:latest-debian-bullseye
+          ${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-debian-bullseye
+          ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest-debian-bullseye
+          ghcr.io/${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-debian-bullseye   
+
+    - name: Build and push community focal base image
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./base.Dockerfile
+        build-args: BD_NWSERVER_IMAGE=beamdog/nwserver:${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-ubuntu-focal
+        push: true
+        labels: |
+          org.opencontainers.image.title=NWNX:EE Base
+          org.opencontainers.image.description=This image is the base for NWNX:EE, it includes all the dependencies required to run NWNX and all plugins. It is used as an intermediary container before the freshly built binaries are placed.
+          org.opencontainers.image.author=NWNX:EE Community
+          org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
+          org.opencontainers.image.created=${{ steps.vars.outputs.created }}
+          org.opencontainers.image.revision=${{ github.sha }}
+        tags: |
+          ${{ github.repository_owner }}/nwnxee-base:latest-ubuntu-focal
+          ${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-ubuntu-focal
+          ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest-ubuntu-focal
+          ghcr.io/${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-ubuntu-focal
 
     - name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -6,126 +6,126 @@ on:
     branches:
       - master
     paths:
-      - 'base.Dockerfile'
-      - '**docker-base.yml'
-      - '**run-server.patch'
-      - 'CMakeLists.txt'
+      - "base.Dockerfile"
+      - "**docker-base.yml"
+      - "**run-server.patch"
+      - "CMakeLists.txt"
   schedule:
-    - cron: '5 4 15 * *'
+    - cron: "5 4 15 * *"
 jobs:
   docker-base:
     runs-on: ubuntu-18.04
     if: github.event_name == 'push' || github.event_name == 'schedule'
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set outputs
-      id: vars
-      run: |
-        echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-        echo "::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-        echo "::set-output name=nwn_build::$(grep 'set(TARGET_NWN_BUILD ' CMakeLists.txt | cut -d' ' -f2 | sed 's/)//')"
-        echo "::set-output name=nwn_build_revision::$(grep 'set(TARGET_NWN_BUILD_REVISION ' CMakeLists.txt | cut -d' ' -f2 | sed 's/)//')"
+      - name: Set outputs
+        id: vars
+        run: |
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          echo "::set-output name=nwn_build::$(grep 'set(TARGET_NWN_BUILD ' CMakeLists.txt | cut -d' ' -f2 | sed 's/)//')"
+          echo "::set-output name=nwn_build_revision::$(grep 'set(TARGET_NWN_BUILD_REVISION ' CMakeLists.txt | cut -d' ' -f2 | sed 's/)//')"
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
-    - name: Login to DockerHub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ secrets.GHCR_USERNAME }}
-        password: ${{ secrets.CR_PAT }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.CR_PAT }}
 
-    - name: Build and push Beamdog base image
-      id: docker_build
-      uses: docker/build-push-action@v2
-      with:
-        context: ./
-        file: ./base.Dockerfile
-        build-args: BD_NWSERVER_IMAGE=beamdog/nwserver:${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}
-        push: true
-        labels: |
-          org.opencontainers.image.title=NWNX:EE Base
-          org.opencontainers.image.description=This image is the base for NWNX:EE, it includes all the dependencies required to run NWNX and all plugins. It is used as an intermediary container before the freshly built binaries are placed.
-          org.opencontainers.image.author=NWNX:EE Community
-          org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
-          org.opencontainers.image.created=${{ steps.vars.outputs.created }}
-          org.opencontainers.image.revision=${{ github.sha }}
-        tags: |
-          ${{ github.repository_owner }}/nwnxee-base:latest
-          ${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}
-          ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest
-          ghcr.io/${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}
+      - name: Build and push Beamdog base image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./base.Dockerfile
+          build-args: BD_NWSERVER_IMAGE=beamdog/nwserver:${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}
+          push: true
+          labels: |
+            org.opencontainers.image.title=NWNX:EE Base
+            org.opencontainers.image.description=This image is the base for NWNX:EE, it includes all the dependencies required to run NWNX and all plugins. It is used as an intermediary container before the freshly built binaries are placed.
+            org.opencontainers.image.author=NWNX:EE Community
+            org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
+            org.opencontainers.image.created=${{ steps.vars.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          tags: |
+            ${{ github.repository_owner }}/nwnxee-base:latest
+            ${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}
+            ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest
+            ghcr.io/${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}
 
-    - name: Build and push community buster base image
-      id: docker_build
-      uses: docker/build-push-action@v2
-      with:
-        context: ./
-        file: ./base.Dockerfile
-        build-args: BD_NWSERVER_IMAGE=urothis/nwnee-community-images:nwserver-${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-debian-buster
-        push: true
-        labels: |
-          org.opencontainers.image.title=NWNX:EE Base
-          org.opencontainers.image.description=This image is the base for NWNX:EE, it includes all the dependencies required to run NWNX and all plugins. It is used as an intermediary container before the freshly built binaries are placed.
-          org.opencontainers.image.author=NWNX:EE Community
-          org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
-          org.opencontainers.image.created=${{ steps.vars.outputs.created }}
-          org.opencontainers.image.revision=${{ github.sha }}
-        tags: |
-          ${{ github.repository_owner }}/nwnxee-base:latest-debian-buster
-          ${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-debian-buster
-          ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest-debian-buster
-          ghcr.io/${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-debian-buster
+      - name: Build and push community buster base image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./base.Dockerfile
+          build-args: BD_NWSERVER_IMAGE=urothis/nwnee-community-images:nwserver-${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-debian-buster
+          push: true
+          labels: |
+            org.opencontainers.image.title=NWNX:EE Base
+            org.opencontainers.image.description=This image is the base for NWNX:EE, it includes all the dependencies required to run NWNX and all plugins. It is used as an intermediary container before the freshly built binaries are placed.
+            org.opencontainers.image.author=NWNX:EE Community
+            org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
+            org.opencontainers.image.created=${{ steps.vars.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          tags: |
+            ${{ github.repository_owner }}/nwnxee-base:latest-debian-buster
+            ${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-debian-buster
+            ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest-debian-buster
+            ghcr.io/${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-debian-buster
 
-    - name: Build and push community bullseye base image
-      id: docker_build
-      uses: docker/build-push-action@v2
-      with:
-        context: ./
-        file: ./base.Dockerfile
-        build-args: BD_NWSERVER_IMAGE=beamdog/nwserver:${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-debian-bullseye
-        push: true
-        labels: |
-          org.opencontainers.image.title=NWNX:EE Base
-          org.opencontainers.image.description=This image is the base for NWNX:EE, it includes all the dependencies required to run NWNX and all plugins. It is used as an intermediary container before the freshly built binaries are placed.
-          org.opencontainers.image.author=NWNX:EE Community
-          org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
-          org.opencontainers.image.created=${{ steps.vars.outputs.created }}
-          org.opencontainers.image.revision=${{ github.sha }}
-        tags: |
-          ${{ github.repository_owner }}/nwnxee-base:latest-debian-bullseye
-          ${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-debian-bullseye
-          ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest-debian-bullseye
-          ghcr.io/${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-debian-bullseye   
+      - name: Build and push community bullseye base image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./base.Dockerfile
+          build-args: BD_NWSERVER_IMAGE=urothis/nwnee-community-images:nwserver-${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-debian-bullseye
+          push: true
+          labels: |
+            org.opencontainers.image.title=NWNX:EE Base
+            org.opencontainers.image.description=This image is the base for NWNX:EE, it includes all the dependencies required to run NWNX and all plugins. It is used as an intermediary container before the freshly built binaries are placed.
+            org.opencontainers.image.author=NWNX:EE Community
+            org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
+            org.opencontainers.image.created=${{ steps.vars.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          tags: |
+            ${{ github.repository_owner }}/nwnxee-base:latest-debian-bullseye
+            ${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-debian-bullseye
+            ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest-debian-bullseye
+            ghcr.io/${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-debian-bullseye
 
-    - name: Build and push community focal base image
-      id: docker_build
-      uses: docker/build-push-action@v2
-      with:
-        context: ./
-        file: ./base.Dockerfile
-        build-args: BD_NWSERVER_IMAGE=beamdog/nwserver:${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-ubuntu-focal
-        push: true
-        labels: |
-          org.opencontainers.image.title=NWNX:EE Base
-          org.opencontainers.image.description=This image is the base for NWNX:EE, it includes all the dependencies required to run NWNX and all plugins. It is used as an intermediary container before the freshly built binaries are placed.
-          org.opencontainers.image.author=NWNX:EE Community
-          org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
-          org.opencontainers.image.created=${{ steps.vars.outputs.created }}
-          org.opencontainers.image.revision=${{ github.sha }}
-        tags: |
-          ${{ github.repository_owner }}/nwnxee-base:latest-ubuntu-focal
-          ${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-ubuntu-focal
-          ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest-ubuntu-focal
-          ghcr.io/${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-ubuntu-focal
+      - name: Build and push community focal base image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./base.Dockerfile
+          build-args: BD_NWSERVER_IMAGE=urothis/nwnee-community-images:nwserver-${{ steps.vars.outputs.nwn_build }}.${{ steps.vars.outputs.nwn_build_revision }}-ubuntu-focal
+          push: true
+          labels: |
+            org.opencontainers.image.title=NWNX:EE Base
+            org.opencontainers.image.description=This image is the base for NWNX:EE, it includes all the dependencies required to run NWNX and all plugins. It is used as an intermediary container before the freshly built binaries are placed.
+            org.opencontainers.image.author=NWNX:EE Community
+            org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/unified
+            org.opencontainers.image.created=${{ steps.vars.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          tags: |
+            ${{ github.repository_owner }}/nwnxee-base:latest-ubuntu-focal
+            ${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-ubuntu-focal
+            ghcr.io/${{ github.repository_owner }}/nwnxee-base:latest-ubuntu-focal
+            ghcr.io/${{ github.repository_owner }}/nwnxee-base:${{ steps.vars.outputs.sha_short }}-ubuntu-focal
 
-    - name: Image digest
-      run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
I wanted to add support for these images to nwnxee.
https://hub.docker.com/r/urothis/nwnee-community-images/

The repo powering these images can be found here.
https://github.com/urothis/nwnee-community-images

Images include buster and bullseye Debian releases and an Ubuntu focal image which should resolve some longstanding issues in the Dotnet community.

This change will not affect or change the mainline/Beamdog image/tags.
It will only add these new images/tags to existing.
```
28406e8-debian-buster
8193.32-ubuntu-focal
latest-debian-buster

28406e8-debian-bullseye
8193.32-debian-bullseye
latest-debian-bullseye

28406e8-ubuntu-focal
8193.32-ubuntu-focal
latest-ubuntu-focal