### PR TITLE
Add Area_RotateArea() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ https://github.com/nwnxee/unified/compare/build8193.33...HEAD
 - N/A
 
 ##### New NWScript Functions
+- Area: RotateArea()
 - Creature: OverrideRangedProjectileVFX()
 - Object: GetAoEObjectDurationRemaining()
 
@@ -157,7 +158,7 @@ https://github.com/nwnxee/unified/compare/build8193.21...build8193.22
 - Events: added skippable event `NWNX_ON_CLIENT_LEVEL_UP_BEGIN_*` which fires when a player clicks the levelup button.
 - Events: added skippable event `NWNX_ON_POSSESS_FAMILIAR_*` which fires when a player attempts to possess their familiar.
 - Events: added skippable event `NWNX_ON_CHARACTER_SHEET_PERMITTED_*` which fires when a player attempts to view a charactersheet.
-- Events: added events `NWNX_ON_CHARACTER_SHEET_{OPEN|CLOSE}_*` which fire when a player opens or closes a charactersheeet.   
+- Events: added events `NWNX_ON_CHARACTER_SHEET_{OPEN|CLOSE}_*` which fire when a player opens or closes a charactersheeet.
 - Tweaks: added `NWNX_TWEAKS_SEND_TLK_OVERRIDE_BEFORE_CHARGEN` to send TlkTable overrides before Character Generation.
 - Tweaks: added `NWNX_TWEAKS_RETAIN_LOCAL_VARIABLES_ON_ITEM_SPLIT` to retain local variables when an item is split.
 - Tweaks: added `NWNX_TWEAKS_PREVENT_ATTACK_BONUS_BYPASSING_REDUCTION` to make attack bonuses not bypass reductions (soak).
@@ -180,7 +181,7 @@ https://github.com/nwnxee/unified/compare/build8193.21...build8193.22
 ### Changed
 - The argument stack is now cleared after every NWNX function call.
 - Effect: (Un)PackEffect functions now can retrieve the id and Item Property Source. _**ABI breaking:** You will need to update nwnx_effect.nss if you are using these functions_.
-- Events: `NWNX_ON_UNPOSSESS_FAMILIAR_*` is now skippable. 
+- Events: `NWNX_ON_UNPOSSESS_FAMILIAR_*` is now skippable.
 - ItemProperty: UnpackIP now can retrieve the item property's id. _**ABI breaking:** You will need to update nwnx_itemprop.nss if you are using these functions_.
 - ***API BREAKING*** Damage: The NWNX_Damage_AttackEventData fields have changed their names: `iAttackType -> iWeaponAttackType`, `iAttackType_REAL -> iAttackType`.
 - ***API BREAKING*** Object: The `NWNX_Object_Export` function has had its arguments reordered.

--- a/Plugins/Area/NWScript/nwnx_area.nss
+++ b/Plugins/Area/NWScript/nwnx_area.nss
@@ -295,6 +295,12 @@ int NWNX_Area_GetAmbientSoundNightVolume(object oArea);
 /// @return The sound object.
 object NWNX_Area_CreateSoundObject(object oArea, vector vPosition, string sResRef);
 
+/// @brief Rotates an existing area, including all objects within (excluding PCs).
+/// @note Functions while clients are in the area, but not recommended as tiles/walkmesh only updates on area load, and this may reuslt in unexpected clientside results.
+/// @param oArea The area to be rotated
+/// @param nRotation How many 90 degrees clockwise to rotate (1-3).
+void NWNX_Area_RotateArea(object oArea, int nRotation);
+
 /// @}
 
 int NWNX_Area_GetNumberOfPlayersInArea(object area)
@@ -735,8 +741,18 @@ object NWNX_Area_CreateSoundObject(object oArea, vector vPosition, string sResRe
     NWNX_PushArgumentFloat(vPosition.y);
     NWNX_PushArgumentFloat(vPosition.x);
     NWNX_PushArgumentObject(oArea);
-    
+
     NWNX_CallFunction(NWNX_Area, sFunc);
 
     return NWNX_GetReturnValueObject();
+}
+
+void NWNX_Area_RotateArea(object oArea, int nRotation)
+{
+    string sFunc = "RotateArea";
+
+    NWNX_PushArgumentInt(nRotation);
+    NWNX_PushArgumentObject(oArea);
+
+    NWNX_CallFunction(NWNX_Area, sFunc);
 }


### PR DESCRIPTION
Rotates an existing area and all objects within by 1, 2 or 3 positions (90 degrees) clockwise.

As noted in function declaration this does work with clients in the area, but has some unexpected behavior on client movement and such, so is not recommended. Simply having the client reload the area (port out-and-in) restores normal functionality.

Thanks to GoLoT and Daz for their assistance.