### PR TITLE
Ensure builds run sequentially

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,10 @@ env:
   CC: gcc-7 -m64
   CXX: g++-7 -m64
 
+concurrency: 
+  group: "build"
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-18.04

--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -12,6 +12,11 @@ on:
       - 'CMakeLists.txt'
   schedule:
     - cron: '5 4 15 * *'
+
+concurrency: 
+  group: "build-base"
+  cancel-in-progress: false
+
 jobs:
   docker-base:
     runs-on: ubuntu-18.04

--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -10,6 +10,11 @@ on:
       - '**docker-builder.yml'
   schedule:
     - cron: '5 4 14 * *'
+
+concurrency: 
+  group: "build-builder"
+  cancel-in-progress: false
+
 jobs:
   docker-builder:
     runs-on: ubuntu-18.04

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,10 @@ on:
       - '**.md'
       - 'docgen/**'
 
+concurrency: 
+  group: "docs"
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
If a build running on a newer commit finishes before an older commit, the older commit will be incorrectly tagged as the latest build.

This PR should prevent newer builds from running until the previous one finishes:
https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency