### PR TITLE
Effect: add AccessorizeVisualEffect() & some API updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ https://github.com/nwnxee/unified/compare/build8193.34...HEAD
 - N/A
 
 ##### New NWScript Functions
-- N/A
+- Effect: AccessorizeVisualEffect()
 
 ### Changed
 - N/A  

--- a/NWNXLib/API/API/CGameEffect.hpp
+++ b/NWNXLib/API/API/CGameEffect.hpp
@@ -72,6 +72,17 @@ struct CGameEffect
     void SaveGameEffect(CResGFF * pRes, CResStruct * pStruct);
     void LoadGameEffect(CResGFF * pRes, CResStruct * pStruct);
 
+    // Some inline helper functions
+    inline uint16_t GetDurationType() { return m_nSubType & NWNXLib::API::Constants::EffectDurationType::MASK; }
+    inline void SetDurationType(uint16_t nDurationType) { m_nSubType = (m_nSubType & ~NWNXLib::API::Constants::EffectDurationType::MASK) | nDurationType; }
+    inline uint16_t GetSubType() { return m_nSubType & NWNXLib::API::Constants::EffectSubType::MASK; }
+    inline void SetSubType(uint16_t nType) { m_nSubType = (m_nSubType & ~NWNXLib::API::Constants::EffectSubType::MASK) | nType;}
+    inline BOOL GetSubType_Magical() { return (m_nSubType & NWNXLib::API::Constants::EffectSubType::MASK) == NWNXLib::API::Constants::EffectSubType::Magical; }
+    inline void SetSubType_Magical() { m_nSubType = NWNXLib::API::Constants::EffectSubType::Magical | (m_nSubType & ~NWNXLib::API::Constants::EffectSubType::MASK); }
+    inline BOOL GetSubType_Supernatural() { return (m_nSubType & NWNXLib::API::Constants::EffectSubType::MASK) == NWNXLib::API::Constants::EffectSubType::Supernatural; }
+    inline void SetSubType_Supernatural() { m_nSubType = NWNXLib::API::Constants::EffectSubType::Supernatural | (m_nSubType & ~NWNXLib::API::Constants::EffectSubType::MASK);}
+    inline BOOL GetSubType_Extraordinary() { return (m_nSubType & NWNXLib::API::Constants::EffectSubType::MASK) == NWNXLib::API::Constants::EffectSubType::Extraordinary; }
+    inline void SetSubType_Extraordinary() { m_nSubType = NWNXLib::API::Constants::EffectSubType::Extraordinary | (m_nSubType & ~NWNXLib::API::Constants::EffectSubType::MASK);}
 
 #ifdef NWN_CLASS_EXTENSION_CGameEffect
     NWN_CLASS_EXTENSION_CGameEffect

--- a/NWNXLib/API/API/CResRef.hpp
+++ b/NWNXLib/API/API/CResRef.hpp
@@ -45,8 +45,7 @@ struct CResRef
     uint8_t GetLength() const;
 
     // Custom utility impl, missing from the API
-    // TODO: Commented out for now because this breaks stuff for some reason
-    // CResRef(const CResRef& other) { *this = other; }
+    CResRef(const CResRef& other) = default;
 
 #ifdef NWN_CLASS_EXTENSION_CResRef
     NWN_CLASS_EXTENSION_CResRef

--- a/NWNXLib/API/Constants/Base.hpp
+++ b/NWNXLib/API/Constants/Base.hpp
@@ -97,14 +97,17 @@ namespace AIState
 {
     enum TYPE
     {
-        IsAlive           = 0x01,
-        CanUseLegs        = 0x02,
-        CanUseHands       = 0x04,
-        CanUseMouth       = 0x08,
-        CanUseEars        = 0x10,
-        CanUseEyes        = 0x20,
-        CanUseMind        = 0x40,
-        IsAbleToGoHostile = 0x80,
+        IsDead            = 0x0000,
+        IsAlive           = 0x0001,
+        CanUseLegs        = 0x0002,
+        CanUseHands       = 0x0004,
+        CanUseMouth       = 0x0008,
+        CanUseEars        = 0x0010,
+        CanUseEyes        = 0x0020,
+        CanUseMind        = 0x0040,
+        IsAbleToGoHostile = 0x0080,
+        Controllable      = 0x0100,
+        EverythingIsFine  = 0xFFFF,
     };
 }
 

--- a/NWNXLib/API/Constants/Misc.hpp
+++ b/NWNXLib/API/Constants/Misc.hpp
@@ -260,11 +260,14 @@ namespace AssociateType
         AnimalCompanion = 2,
         Familiar = 3,
         Summoned = 4,
-        Dominated = 5,
+        DominatedByPC = 5,
+        DominatedByNPC = 6,
+        DMPossess = 7,
+        DMImpersonate = 8,
     };
     constexpr int32_t MIN   = 0;
-    constexpr int32_t MAX   = 5;
-    static_assert(MAX == Dominated);
+    constexpr int32_t MAX   = 8;
+    static_assert(MAX == DMImpersonate);
 
     constexpr const char* ToString(const unsigned value)
     {
@@ -275,7 +278,10 @@ namespace AssociateType
                 "AnimalCompanion",
                 "Familiar",
                 "Summoned",
-                "Dominated",
+                "DominatedByPC",
+                "DominatedByNPC",
+                "DMPossess",
+                "DMImpersonate",
         };
 
         return (value > MAX) ? "(invalid)" : TYPE_STRINGS[value];

--- a/NWNXLib/Utils/CMakeLists.txt
+++ b/NWNXLib/Utils/CMakeLists.txt
@@ -1,1 +1,2 @@
 nwnxlib_add("String.cpp")
+nwnxlib_add("VectorMath.cpp")

--- a/NWNXLib/Utils/VectorMath.cpp
+++ b/NWNXLib/Utils/VectorMath.cpp
@@ -1,0 +1,74 @@
+#include "nwnx.hpp"
+#include "cmath"
+
+namespace NWNXLib::VectorMath
+{
+    float MagnitudeSquared(const Vector& v)
+    {
+        return v.x * v.x + v.y * v.y + v.z * v.z;
+    }
+
+    float Magnitude(const Vector& v)
+    {
+        float f = MagnitudeSquared(v);
+
+        if (f == 1.0f)
+            return f;
+        else if (f <= 0.0f)
+            return 0.0f;
+
+        return std::sqrt(f);
+    }
+
+    float Dot(const Vector& a, const Vector& b)
+    {
+        return a.x * b.x + a.y * b.y + a.z * b.z;
+    }
+
+    Vector Add(const Vector& a, const Vector& b)
+    {
+        Vector v = a;
+        v.x += b.x;
+        v.y += b.y;
+        v.z += b.z;
+        return v;
+    }
+
+    Vector Subtract(const Vector& a, const Vector& b)
+    {
+        Vector v = a;
+        v.x -= b.x;
+        v.y -= b.y;
+        v.z -= b.z;
+        return v;
+    }
+
+    Vector Multiply(const Vector& v, const float f)
+    {
+        return Vector(v.x * f, v.y * f, v.z * f);
+    }
+
+    Vector Normalize(const Vector &v)
+    {
+        float f = MagnitudeSquared(v);
+
+        if (f == 1.0f)
+            return v;
+        else if (f <= 0.0f)
+            return Vector(1.0f, 0.0f, 0.0f);
+
+        f = std::sqrt(1 / f);
+        return Multiply(v, f);
+    }
+
+    Vector Lineproject(const Vector &a, const Vector &b, const Vector &c)
+    {
+        Vector v = Subtract(b, a);
+        float f = MagnitudeSquared(v);
+
+        if (f)
+            f = Dot(v, Subtract(c, a)) / f;
+
+        return Add(a, Multiply(v, f));
+    }
+}

--- a/NWNXLib/nwnx.hpp
+++ b/NWNXLib/nwnx.hpp
@@ -174,6 +174,18 @@ namespace String
     bool EndsWith(const std::string& str, const std::string& suffix);
 }
 
+namespace VectorMath
+{
+    float MagnitudeSquared(const Vector& v);
+    float Magnitude(const Vector& v);
+    float Dot(const Vector& a, const Vector& b);
+    Vector Add(const Vector& a, const Vector& b);
+    Vector Subtract(const Vector& a, const Vector& b);
+    Vector Multiply(const Vector& v, float s);
+    Vector Normalize(const Vector &v);
+    Vector Lineproject(const Vector &a, const Vector &b, const Vector &c);
+}
+
 namespace Utils
 {
     std::string ObjectIDToString(const ObjectID id);

--- a/Plugins/Area/Area.cpp
+++ b/Plugins/Area/Area.cpp
@@ -606,7 +606,7 @@ NWNX_EXPORT ArgumentStack ExportGIT(ArgumentStack&& args)
                         if (pCreature->m_pStats->m_bIsPC ||
                             pCreature->m_pStats->GetIsDM() ||
                             (pCreature->m_nAssociateType > Constants::AssociateType::None &&
-                            pCreature->m_nAssociateType < Constants::AssociateType::Dominated))
+                            pCreature->m_nAssociateType < Constants::AssociateType::DominatedByPC))
                             continue;
 
                         // Temporarily set pCreature's areaID to OBJECT_INVALID
@@ -1068,7 +1068,7 @@ NWNX_EXPORT ArgumentStack RotateArea(ArgumentStack&& args)
                     if (pCreature->m_pStats->m_bIsPC ||
                         pCreature->m_pStats->GetIsDM() ||
                         (pCreature->m_nAssociateType > Constants::AssociateType::None &&
-                         pCreature->m_nAssociateType < Constants::AssociateType::Dominated))
+                         pCreature->m_nAssociateType < Constants::AssociateType::DominatedByPC))
                         continue;
 
                     pCreature->SetPosition(GetNewPosition(pCreature->m_vPosition));

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -2386,7 +2386,7 @@ NWNX_EXPORT ArgumentStack AddAssociate(ArgumentStack&& args)
           ASSERT_OR_THROW(oidAssociate != Constants::OBJECT_INVALID);
         auto associateType = args.extract<int32_t>();
           ASSERT_OR_THROW(associateType > Constants::AssociateType::None);
-          ASSERT_OR_THROW(associateType <= Constants::AssociateType::Dominated);
+          ASSERT_OR_THROW(associateType <= Constants::AssociateType::DominatedByPC);
 
         if (auto *pAssociate = Utils::AsNWSCreature(Utils::GetGameObject(oidAssociate)))
         {

--- a/Plugins/Effect/NWScript/nwnx_effect.nss
+++ b/Plugins/Effect/NWScript/nwnx_effect.nss
@@ -122,6 +122,12 @@ int NWNX_Effect_RemoveEffectById(object oObject,  string sID);
 /// @param oObject The object to apply it to.
 void NWNX_Effect_Apply(effect eEffect, object oObject);
 
+/// @brief Accessorize an EffectVisualEffect(), making it undispellable and unable to be removed by resting or death.
+/// @note If linked with a non-visualeffect or a non-accessorized visualeffect it *will* get removed.
+/// @param eEffect An EffectVisualEffect(), does not work for other effect types.
+/// @return The accessorized effect or an unchanged effect if not an EffectVisualEffect().
+effect NWNX_Effect_AccessorizeVisualEffect(effect eEffect);
+
 /// @}
 
 struct NWNX_EffectUnpacked __NWNX_Effect_ResolveUnpack(string sFunc, int bLink=TRUE)
@@ -347,7 +353,6 @@ void NWNX_Effect_ReplaceEffectByIndex(object oObject, int nIndex, struct  NWNX_E
     NWNX_PushArgumentInt(nIndex);
     NWNX_PushArgumentObject(oObject);
     NWNX_CallFunction(NWNX_Effect, sFunc);
-
 }
 
 int NWNX_Effect_RemoveEffectById(object oObject,  string sID)
@@ -366,4 +371,12 @@ void NWNX_Effect_Apply(effect eEffect, object oObject)
     NWNX_PushArgumentObject(oObject);
     NWNX_PushArgumentEffect(eEffect);
     NWNX_CallFunction(NWNX_Effect, sFunc);
+}
+
+effect NWNX_Effect_AccessorizeVisualEffect(effect eEffect)
+{
+    string sFunc = "AccessorizeVisualEffect";
+    NWNX_PushArgumentEffect(eEffect);
+    NWNX_CallFunction(NWNX_Effect, sFunc);
+    return NWNX_GetReturnValueEffect();
 }

--- a/Plugins/Events/Events/EffectEvents.cpp
+++ b/Plugins/Events/Events/EffectEvents.cpp
@@ -34,7 +34,7 @@ void HandleEffectHook(const std::string& event, bool before, CNWSObject* pObject
     if (!pObject || !pEffect)
         return;
 
-    int32_t effectDurationType = pEffect->m_nSubType & EffectDurationType::MASK;
+    int32_t effectDurationType = pEffect->GetDurationType();
 
     if (effectDurationType != EffectDurationType::Temporary && effectDurationType != EffectDurationType::Permanent)
         return;
@@ -55,7 +55,7 @@ void HandleEffectHook(const std::string& event, bool before, CNWSObject* pObject
     PushEventData("UNIQUE_ID", std::to_string(pEffect->m_nID));
     PushEventData("CREATOR", Utils::ObjectIDToString(pEffect->m_oidCreator));
     PushEventData("TYPE", std::to_string(pEffect->m_nType));
-    PushEventData("SUB_TYPE", std::to_string(pEffect->m_nSubType & EffectSubType::MASK));
+    PushEventData("SUB_TYPE", std::to_string(pEffect->GetSubType()));
     PushEventData("DURATION_TYPE", std::to_string(effectDurationType));
     PushEventData("DURATION", std::to_string(pEffect->m_fDuration));
     PushEventData("SPELL_ID", std::to_string(pEffect->m_nSpellId));


### PR DESCRIPTION
Adds `effect NWNX_Effect_AccessorizeVisualEffect(effect eEffect);` to apply *really* permanent visual effects.

Some API changes:
* Updates some constants
* Adds some inline helpers for subtype/duration to CGameEffect.hpp
* Adds a missing ctor to CResRef.hpp to fix some compiler warnings and hopefully not break anything
* Adds some vector math helper functions to NWNXLib