### PR TITLE
Update base.Dockerfile to dotnet 6 packages

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -17,8 +17,8 @@ RUN runDeps="hunspell \
     inotify-tools \
     patch \
     unzip \
-    dotnet-runtime-5.0 \
-    dotnet-apphost-pack-5.0" \
+    dotnet-runtime-6.0 \
+    dotnet-apphost-pack-6.0" \
     installDeps="ca-certificates wget" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $installDeps \


### PR DESCRIPTION
No regressions noted in testing. 
Backwards compatible with old projects and no breakages.