### PR TITLE
Platform: add AmICalledBy()

### DIFF
--- a/NWNXLib/Platform/Debug.cpp
+++ b/NWNXLib/Platform/Debug.cpp
@@ -61,7 +61,7 @@ std::string GetStackTrace(uint8_t levels)
 static std::map<uintptr_t, std::string> s_FunctionMap;
 static void InitFunctionMap()
 {
-    if (s_FunctionMap.size()) return;
+    if (!s_FunctionMap.empty()) return;
 
 #undef NWNXLIB_FUNCTION
 #define NWNXLIB_FUNCTION_NO_VERSION_CHECK
@@ -91,7 +91,7 @@ std::string ResolveAddress(uintptr_t address)
 uintptr_t GetFunctionAddress(const std::string& mangledname)
 {
     InitFunctionMap();
-    for (auto it: s_FunctionMap)
+    for (const auto& it: s_FunctionMap)
     {
         if (it.second == mangledname)
             return it.first;
@@ -99,5 +99,20 @@ uintptr_t GetFunctionAddress(const std::string& mangledname)
     return 0;
 }
 
+bool AmICalledBy(uintptr_t address, uintptr_t returnAddress)
+{
+    InitFunctionMap();
+
+    if (returnAddress > GetRelocatedAddress(0))
+        returnAddress -= GetRelocatedAddress(0);
+
+    auto it = s_FunctionMap.upper_bound(returnAddress);
+    if (it != s_FunctionMap.begin())
+    {
+        --it;
+        return it->first == address;
+    }
+    return false;
+}
 
 }

--- a/NWNXLib/nwnx.hpp
+++ b/NWNXLib/nwnx.hpp
@@ -127,6 +127,8 @@ namespace Platform
     void CalculateBaseAddress();
     uintptr_t GetRelocatedAddress(const uintptr_t address);
     uintptr_t GetRelocatedGlobalAddress(const uintptr_t address);
+
+    bool AmICalledBy(uintptr_t address, uintptr_t returnAddress = (uintptr_t)__builtin_return_address(0));
 }
 
 namespace Commands


### PR DESCRIPTION
Put `__builtin_return_address()` in the function declaration since calling it with a non-zero level is considered unsafe and gives compiler warnings.

`Calling this function with a nonzero argument can have unpredictable effects, including crashing the calling program. As a result, calls that are considered unsafe are diagnosed when the -Wframe-address option is in effect. Such calls should only be made in debugging situations. `