### PR TITLE
Add FIX_TRIGGER_ENTER_DETECTION tweak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ https://github.com/nwnxee/unified/compare/build8193.34...HEAD
 ### Added
 - Tweaks: added `NWNX_TWEAKS_CANUSEITEM_CHECK_ILR_FOR_HENCHMEN` to have the CNWSCreature::CanUseItem() function also check ILR for Henchmen.
 - Tweaks: added `NWNX_TWEAKS_FIX_DM_SELECTION_BOX` to fix the DM creature selection box not showing up when player party control is off.
+- Tweaks: added `NWNX_TWEAKS_FIX_TRIGGER_ENTER_DETECTION` to fix a rare issue where triggers/traps fire enter events without a creature inside.
 - Optimizations: added `NWNX_OPTIMIZATIONS_FIX_PLACEABLE_VFX_REAPPLY_BUG` to fix a bug where VFXs keep getting reapplied to placeables.
 - Optimizations: added `NWNX_OPTIMIZATIONS_CACHE_SCRIPT_CHUNKS` to cache script chunks after first execution.
 - Events: added skippable event `NWNX_ON_INPUT_DROP_ITEM_{BEFORE|AFTER}` which fires when a player attempts to drop an item.

--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -16,6 +16,7 @@ add_plugin(Tweaks
     "FixDMSelectionBox.cpp"
     "FixGreaterSanctuaryBug.cpp"
     "FixItemNullptrInCItemRepository.cpp"
+    "FixTriggerEnterDetection.cpp"
     "FixUnlimitedPotionsBug.cpp"
     "HideClassesOnCharList.cpp"
     "HideHardcodedItemVFX.cpp"

--- a/Plugins/Tweaks/FixTriggerEnterDetection.cpp
+++ b/Plugins/Tweaks/FixTriggerEnterDetection.cpp
@@ -1,0 +1,63 @@
+#include "nwnx.hpp"
+
+#include "API/CNWSTrigger.hpp"
+#include "API/CScriptEvent.hpp"
+
+namespace Tweaks {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+using namespace NWNXLib::API::Constants;
+
+bool VectorInTriggerBounds(CNWSTrigger* trigger, Vector point)
+{
+    Vector* vertices = trigger->m_pvVertices;
+    int numVertices = trigger->m_nVertices;
+
+    int i, j;
+    bool inside = false;
+
+    for (i = 0, j = numVertices - 1; i < numVertices; j = i++)
+    {
+        if ((vertices[i].y >= point.y ) != (vertices[j].y >= point.y))
+        {
+            if ((point.x <= (vertices[j].x - vertices[i].x) * (point.y - vertices[i].y) / (vertices[j].y - vertices[i].y) + vertices[i].x))
+            {
+                inside = !inside;
+            }
+        }
+    }
+
+    return inside;
+}
+
+void FixTriggerEnterDetection() __attribute__((constructor));
+void FixTriggerEnterDetection()
+{
+    if (!Config::Get<bool>("FIX_TRIGGER_ENTER_DETECTION", false))
+        return;
+
+    LOG_INFO("Will additionally validate trigger enter events to fix a trigger enter detection bug.");
+
+    static Hooks::Hook s_TriggerEventHandlerHook = Hooks::HookFunction(Functions::_ZN11CNWSTrigger12EventHandlerEjjPvjj,
+    (void*)+[](CNWSTrigger *thisPtr, uint32_t nEventId, OBJECT_ID nCallerObjectId, void* pScript, uint32_t nCalendarDay, uint32_t nTimeOfDay) -> void
+    {
+        if (nEventId == AIMasterEvent::SignalEvent)
+        {
+            auto* pScriptEvent = static_cast<CScriptEvent*>(pScript);
+            if (pScriptEvent->m_nType == ScriptEvent::OnObjectEnter)
+            {
+                auto* pEntered = Utils::AsNWSObject(Utils::GetGameObject(pScriptEvent->GetObjectID(0)));
+                if (pEntered != nullptr && !VectorInTriggerBounds(thisPtr, pEntered->m_vPosition))
+                {
+                    delete pScriptEvent;
+                    return;
+                }
+            }
+        }
+
+        s_TriggerEventHandlerHook->CallOriginal<void>(thisPtr, nEventId, nCallerObjectId, pScript, nCalendarDay, nTimeOfDay);
+    }, Hooks::Order::Early);
+}
+
+}

--- a/Plugins/Tweaks/README.md
+++ b/Plugins/Tweaks/README.md
@@ -44,6 +44,7 @@ Tweaks stuff. See below.
 | `NWNX_TWEAKS_FIX_DM_FACTION_BUG` | true or false | Fixes a DM faction bug when using a non-DMClient BIC file. |
 | `NWNX_TWEAKS_CANUSEITEM_CHECK_ILR_FOR_HENCHMEN` | true or false | The CNWSCreature::CanUseItem() function will also check ILR for Henchmen. |
 | `NWNX_TWEAKS_FIX_DM_SELECTION_BOX` | true or false | Fixes the DM creature selection box not showing up when player party control is off. |
+| `NWNX_TWEAKS_FIX_TRIGGER_ENTER_DETECTION` | true or false | Adds an additional bounds check for triggers to fix a trigger detection bug. |
   
 ## Environment variable values
 


### PR DESCRIPTION
I initially tried using `CNWSTrigger::InTrigger` for this check and it fixed most cases where this happens, but there were still some cases where the object position was way outside the trigger bounds, and `CNWSTrigger::InTrigger` still returned true.

The custom `VectorInTriggerBounds` implementation seemed to work for all the cases I tested, but I wonder if there's any other caveats I am missing :)