### PR TITLE
Events: fix a crash when skipping `NWNX_ON_CLIENT_CONNECT_BEFORE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ https://github.com/nwnxee/unified/compare/build8193.34...HEAD
 ### Fixed
 - Object: GetLocalVariable() now recognizes variables of type json.
 - Tweaks: Language override tweak now works for area names.
+- Events: Fixed a crash when skipping `NWNX_ON_CLIENT_CONNECT_BEFORE`
 
 ## 8193.34
 https://github.com/nwnxee/unified/compare/build8193.33...build8193.34

--- a/Plugins/Events/Events/ClientEvents.cpp
+++ b/Plugins/Events/Events/ClientEvents.cpp
@@ -137,7 +137,14 @@ int32_t SendServerToPlayerCharListHook(CNWSMessage* pThis, CNWSPlayer *pPlayer)
     }
     else
     {
-        pNetLayer->DisconnectPlayer(pPlayer->m_nPlayerID, 5838, true, reason.c_str());
+        Tasks::QueueOnMainThread([pNetLayer, pPlayer, reason]()
+        {
+            if (pPlayer)
+            {
+                pNetLayer->DisconnectPlayer(pPlayer->m_nPlayerID, 5838, true, reason.c_str());
+            }
+        });
+
         retVal = false;
     }
     PushAndSignal("NWNX_ON_CLIENT_CONNECT_AFTER");


### PR DESCRIPTION
fixes  #1487 