### PR TITLE
Add safeguard to MessageDeleteLuo to prevent rare crash

### DIFF
--- a/Plugins/Optimizations/LuoLookup.cpp
+++ b/Plugins/Optimizations/LuoLookup.cpp
@@ -148,7 +148,8 @@ static void MessageDeleteLuo(CNWSMessage* msg, CLastUpdateObject* luo, CNWSPlaye
         bool bDelete = true;
         if (auto obj = Utils::AsNWSObject(Utils::GetGameObject(luo->m_nId)))
         {
-            if (obj->GetArea() == player->GetGameObject()->GetArea())
+            auto pgo = player->GetGameObject();
+            if (pgo && (obj->GetArea() == pgo->GetArea()))
                 bDelete = false;
         }
 


### PR DESCRIPTION
We had a crash related to this on Ravenloft POTM. Not sure of the underlying cause, but adding a safeguard should prevent it from reoccuring.