### PR TITLE
Events: Add event data to various NWNX_ON_DM_* events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ https://github.com/nwnxee/unified/compare/build8193.34...HEAD
 
 ### Changed
 - Events: added event data `VERSION_MAJOR`/`VERSION_MINOR`/`PLATFORM_ID` to `NWNX_ON_CLIENT_CONNECT_*`
+- Events: added event data `STAT`/`VALUE`/`TARGET`/`SET` to `NWNX_ON_DM_SET_STAT_*`
+- Events: added event data `TYPE`/`TARGET`/`KEY` to `NWNX_ON_DM_GET_VARIABLE_*`
+- Events: added event data `TYPE`/`TARGET`/`KEY`/`VALUE` to `NWNX_ON_DM_SET_VARIABLE_*`
+- Events: added event data `TARGET`/`FACTION_ID`/`FACTION_NAME` to `NWNX_ON_DM_SET_FACTION_*`
 
 ### Deprecated
 - N/A

--- a/Plugins/Events/Events/DMActionEvents.cpp
+++ b/Plugins/Events/Events/DMActionEvents.cpp
@@ -1,6 +1,9 @@
 #include "Events.hpp"
 #include "API/CAppManager.hpp"
 #include "API/CServerExoApp.hpp"
+#include "API/CNWSFaction.hpp"
+#include "API/CServerExoAppInternal.hpp"
+#include "API/CFactionManager.hpp"
 #include "API/CGameObjectArray.hpp"
 #include "API/CNetLayer.hpp"
 #include "API/CNetLayerPlayerInfo.hpp"
@@ -477,7 +480,49 @@ int32_t HandleDMMessageHook(CNWSMessage *thisPtr, CNWSPlayer *pPlayer, uint8_t n
         case MessageDungeonMasterMinor::SetFactionByName:
         {
             event += "SET_FACTION";
-            DefaultSignalEvent();
+
+            int32_t offset = 0;
+
+            int32_t factionid;
+            std::string factionName;
+            std::string target;
+
+            if (nMinor == MessageDungeonMasterMinor::SetFaction)
+            {
+                factionid = Utils::PeekMessage<int32_t>(thisPtr, offset); offset += sizeof(int32_t);
+                target = Utils::ObjectIDToString(Utils::PeekMessage<ObjectID>(thisPtr, offset) & 0x7FFFFFFF);
+
+                auto* pFaction = Globals::AppManager()->m_pServerExoApp->m_pcExoAppInternal->m_pFactionManager->GetFaction(factionid);
+                if (pFaction)
+                {
+                    factionName = pFaction->m_sFactionName;
+                }
+            }
+            else
+            {
+                target = Utils::ObjectIDToString(Utils::PeekMessage<ObjectID>(thisPtr, offset) & 0x7FFFFFFF); offset += sizeof(ObjectID);
+                factionName = Utils::PeekMessage<std::string>(thisPtr, offset);
+
+                factionid = Globals::AppManager()->m_pServerExoApp->m_pcExoAppInternal->m_pFactionManager->GetFactionIdByName(factionName);
+            }
+
+            auto PushAndSignal = [&](const std::string& ev) -> bool {
+                PushEventData("TARGET", target);
+                PushEventData("FACTION_ID", std::to_string(factionid));
+                PushEventData("FACTION_NAME", factionName);
+                return SignalEvent(ev, oidDM);
+            };
+
+            if (PushAndSignal(event + "_BEFORE"))
+            {
+                retVal = s_HandlePlayerToServerDungeonMasterMessageHook->CallOriginal<int32_t>(thisPtr, pPlayer, nMinor, bGroup);
+            }
+            else
+            {
+                retVal = false;
+            }
+
+            PushAndSignal(event +"_AFTER");
             break;
         }
         case MessageDungeonMasterMinor::GiveItem:
@@ -526,19 +571,108 @@ int32_t HandleDMMessageHook(CNWSMessage *thisPtr, CNWSPlayer *pPlayer, uint8_t n
         case MessageDungeonMasterMinor::SetStat:
         {
             event += "SET_STAT";
-            DefaultSignalEvent();
+
+            int32_t offset = 0;
+
+            std::string stat = std::to_string(Utils::PeekMessage<int32_t>(thisPtr, offset)); offset += sizeof(int32_t);
+            std::string value = std::to_string(Utils::PeekMessage<float>(thisPtr, offset)); offset += sizeof(float);
+            std::string target = Utils::ObjectIDToString(Utils::PeekMessage<ObjectID>(thisPtr, offset) & 0x7FFFFFFF); offset += sizeof(ObjectID);
+            std::string set = std::to_string((bool)(Utils::PeekMessage<int32_t>(thisPtr, offset) & 0x10));
+
+            auto PushAndSignal = [&](const std::string& ev) -> bool {
+                PushEventData("STAT", stat);
+                PushEventData("VALUE", value);
+                PushEventData("TARGET", target);
+                PushEventData("SET", set);
+                return SignalEvent(ev, oidDM);
+            };
+
+            if (PushAndSignal(event + "_BEFORE"))
+            {
+                retVal = s_HandlePlayerToServerDungeonMasterMessageHook->CallOriginal<int32_t>(thisPtr, pPlayer, nMinor, bGroup);
+            }
+            else
+            {
+                retVal = false;
+            }
+
+            PushAndSignal(event +"_AFTER");
             break;
         }
         case MessageDungeonMasterMinor::GetVar:
         {
             event += "GET_VARIABLE";
-            DefaultSignalEvent();
+            
+            int32_t offset = 0;
+
+            uint8_t varType = Utils::PeekMessage<uint8_t>(thisPtr, offset); offset += sizeof(uint8_t);
+            std::string target = Utils::ObjectIDToString(Utils::PeekMessage<ObjectID>(thisPtr, offset) & 0x7FFFFFFF); offset += sizeof(ObjectID);
+            std::string key = Utils::PeekMessage<std::string>(thisPtr, offset);
+
+            auto PushAndSignal = [&](const std::string& ev) -> bool {
+                PushEventData("TYPE", std::to_string(varType));
+                PushEventData("TARGET", target);
+                PushEventData("KEY", key);
+                return SignalEvent(ev, oidDM);
+            };
+
+            if (PushAndSignal(event + "_BEFORE"))
+            {
+                retVal = s_HandlePlayerToServerDungeonMasterMessageHook->CallOriginal<int32_t>(thisPtr, pPlayer, nMinor, bGroup);
+            }
+            else
+            {
+                retVal = false;
+            }
+
+            PushAndSignal(event +"_AFTER");
             break;
         }
         case MessageDungeonMasterMinor::SetVar:
         {
             event += "SET_VARIABLE";
-            DefaultSignalEvent();
+
+            int32_t offset = 0;
+
+            uint8_t varType = Utils::PeekMessage<uint8_t>(thisPtr, offset); offset += sizeof(uint8_t);
+            std::string target = Utils::ObjectIDToString(Utils::PeekMessage<ObjectID>(thisPtr, offset) & 0x7FFFFFFF); offset += sizeof(ObjectID);
+            std::string key = Utils::PeekMessage<std::string>(thisPtr, offset); offset += key.length() + 4;
+            std::string value;
+
+            switch (varType)
+            {
+                case 0:
+                    value = std::to_string(Utils::PeekMessage<uint32_t>(thisPtr, offset));
+                    break;
+                case 1:
+                    value = std::to_string(Utils::PeekMessage<float>(thisPtr, offset));
+                    break;
+                case 2:
+                    value = Utils::PeekMessage<std::string>(thisPtr, offset);
+                    break;
+                case 3:
+                    value = Utils::ObjectIDToString(Utils::PeekMessage<ObjectID>(thisPtr, offset));
+                    break;
+            }
+
+            auto PushAndSignal = [&](const std::string& ev) -> bool {
+                PushEventData("TYPE", std::to_string(varType));
+                PushEventData("TARGET", target);
+                PushEventData("KEY", key);
+                PushEventData("VALUE", value);
+                return SignalEvent(ev, oidDM);
+            };
+
+            if (PushAndSignal(event + "_BEFORE"))
+            {
+                retVal = s_HandlePlayerToServerDungeonMasterMessageHook->CallOriginal<int32_t>(thisPtr, pPlayer, nMinor, bGroup);
+            }
+            else
+            {
+                retVal = false;
+            }
+
+            PushAndSignal(event +"_AFTER");
             break;
         }
         case MessageDungeonMasterMinor::SetTime:

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -479,21 +479,71 @@ _______________________________________
     PASSWORD              | string | The password the DM provided, only valid for NWNX_ON_DM_PLAYERDM_LOGIN_*
 
 _______________________________________
+    ## DM Set Stat Events
+    - NWNX_ON_DM_SET_STAT_BEFORE
+    - NWNX_ON_DM_SET_STAT_AFTER
+
+    `OBJECT_SELF` = The DM
+
+    Event Data Tag        | Type   | Notes
+    ----------------------|--------|-------
+    STAT                  | int    | Returns NWNX_EVENTS_DM_SET_STAT_TYPE_*
+    VALUE                 | int    | 
+    TARGET                | object | Convert to object with StringToObject()
+    SET                   | int    | TRUE if setting stat, FALSE if modifying
+
+_______________________________________
+    ## DM Get Variable Events
+    - NWNX_ON_DM_GET_VARIABLE_BEFORE
+    - NWNX_ON_DM_GET_VARIABLE_AFTER
+
+    `OBJECT_SELF` = The DM
+
+    Event Data Tag        | Type   | Notes
+    ----------------------|--------|-------
+    TYPE                  | int    | Returns NWNX_EVENTS_DM_SET_VARIABLE_TYPE_*
+    TARGET                | object | Convert to object with StringToObject()
+    KEY                   | string | Variable name
+
+    @note Vector variable types aren't supported.
+
+_______________________________________
+    ## DM Set Variable Events
+    - NWNX_ON_DM_SET_VARIABLE_BEFORE
+    - NWNX_ON_DM_SET_VARIABLE_AFTER
+
+    `OBJECT_SELF` = The DM
+
+    Event Data Tag        | Type   | Notes
+    ----------------------|--------|-------
+    TYPE                  | int    | Returns NWNX_EVENTS_DM_SET_VARIABLE_TYPE_*
+    TARGET                | object | Convert to object with StringToObject()
+    KEY                   | string | Variable name
+    VALUE                 | string | Variable value
+
+    @note Vector variable types aren't supported.
+
+_______________________________________
+    ## DM Set Faction Events
+    - NWNX_ON_DM_SET_FACTION_BEFORE
+    - NWNX_ON_DM_SET_FACTION_AFTER
+
+    `OBJECT_SELF` = The DM
+
+    Event Data Tag        | Type   | Notes
+    ----------------------|--------|-------
+    TARGET                | object | Convert to object with StringToObject()
+    FACTION_ID            | int    | Not the STANDARD_FACTION_* constants. See nwnx_creature->GetFaction(). 
+    FACTION_NAME          | string | 
+
+_______________________________________
     ## DM Other Events
     - NWNX_ON_DM_APPEAR_BEFORE
     - NWNX_ON_DM_APPEAR_AFTER
     - NWNX_ON_DM_DISAPPEAR_BEFORE
     - NWNX_ON_DM_DISAPPEAR_AFTER
-    - NWNX_ON_DM_SET_FACTION_BEFORE
-    - NWNX_ON_DM_SET_FACTION_AFTER
     - NWNX_ON_DM_TAKE_ITEM_BEFORE
     - NWNX_ON_DM_TAKE_ITEM_AFTER
-    - NWNX_ON_DM_SET_STAT_BEFORE
-    - NWNX_ON_DM_SET_STAT_AFTER
-    - NWNX_ON_DM_GET_VARIABLE_BEFORE
-    - NWNX_ON_DM_GET_VARIABLE_AFTER
-    - NWNX_ON_DM_SET_VARIABLE_BEFORE
-    - NWNX_ON_DM_SET_VARIABLE_AFTER
     - NWNX_ON_DM_SET_TIME_BEFORE
     - NWNX_ON_DM_SET_TIME_AFTER
     - NWNX_ON_DM_SET_DATE_BEFORE
@@ -1457,6 +1507,22 @@ const int NWNX_EVENTS_TIMING_BAR_REST          = 6;
 const int NWNX_EVENTS_TIMING_BAR_UNLOCK        = 7;
 const int NWNX_EVENTS_TIMING_BAR_LOCK          = 8;
 const int NWNX_EVENTS_TIMING_BAR_CUSTOM        = 10;
+*/
+
+/*
+const int NWNX_EVENTS_DM_SET_STAT_TYPE_STRENGTH         = 5;
+const int NWNX_EVENTS_DM_SET_STAT_TYPE_DEXTERITY        = 6;
+const int NWNX_EVENTS_DM_SET_STAT_TYPE_CONSTITUTION     = 7;
+const int NWNX_EVENTS_DM_SET_STAT_TYPE_INTELLIGENCE     = 8;
+const int NWNX_EVENTS_DM_SET_STAT_TYPE_WISDOM           = 9;
+const int NWNX_EVENTS_DM_SET_STAT_TYPE_CHARISMA         = 10;
+*/
+
+/*
+const int NWNX_EVENTS_DM_SET_VARIABLE_TYPE_INT          = 0;
+const int NWNX_EVENTS_DM_SET_VARIABLE_TYPE_FLOAT        = 1;
+const int NWNX_EVENTS_DM_SET_VARIABLE_TYPE_STRING       = 2;
+const int NWNX_EVENTS_DM_SET_VARIABLE_TYPE_OBJECT       = 3;
 */
 
 /// @brief Scripts can subscribe to events.


### PR DESCRIPTION
Adds event data to:
- NWNX_ON_DM_SET_STAT_{BEFORE|AFTER}
- NWNX_ON_DM_GET_VARIABLE_{BEFORE|AFTER}
- NWNX_ON_DM_SET_VARIABLE_{BEFORE|AFTER}
- NWNX_ON_DM_SET_FACTION_{BEFORE|AFTER}