### PR TITLE
Race: Fix feat usages being reset upon character relog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ https://github.com/nwnxee/unified/compare/build8193.34...HEAD
 - N/A
 
 ### Fixed
+- Feat: Fixed an issue with feat usages being reset upon character relog
 - Object: GetLocalVariable() now recognizes variables of type json.
 - Tweaks: Language override tweak now works for area names.
 - Events: Fixed a crash when skipping `NWNX_ON_CLIENT_CONNECT_BEFORE`

--- a/Plugins/Race/Race.cpp
+++ b/Plugins/Race/Race.cpp
@@ -644,6 +644,9 @@ int32_t Race::ValidateCharacterHook(CNWSPlayer *pPlayer, int32_t *bFailedServerR
 
     auto nRace = pCreature->m_pStats->m_nRace;
 
+    // Need to store the feat usages and set them after we remove/add the feat back to bypass Char Validation
+    std::unordered_map<uint16_t, uint8_t> featUses;
+
     for (auto &featDetails : g_plugin->m_RaceFeat[nRace])
     {
         auto featId = featDetails.first;
@@ -664,6 +667,7 @@ int32_t Race::ValidateCharacterHook(CNWSPlayer *pPlayer, int32_t *bFailedServerR
         {
             pLevelStats->AddFeat(feat);
         }
+        featUses.emplace(featId, pCreature->m_pStats->GetFeatRemainingUses(featId));
         pCreature->m_pStats->RemoveFeat(featId);
     }
 
@@ -678,6 +682,7 @@ int32_t Race::ValidateCharacterHook(CNWSPlayer *pPlayer, int32_t *bFailedServerR
         auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[featLevel-1];
         pLevelStats->AddFeat(featId);
         pCreature->m_pStats->AddFeat(featId);
+        pCreature->m_pStats->SetFeatRemainingUses(featId, featUses[featId]);
     }
 
     return retVal;


### PR DESCRIPTION
Fixes #1412 

To bypass character validation with `NWNX_Race` feats, we drop the feat and add it back. This resets their feat usage though so we have to make sure to store the current feat usage then set it back.