### PR TITLE
Creature: Add {Get|Set}InitiativeModifer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ https://github.com/nwnxee/unified/compare/build8193.34...HEAD
 - Area: GetPathExists()
 - Area: {Get|Set}AreaFlags()
 - Creature: {Get|Set}SkillPointsRemainingByLevel()
+- Creature: {Get|Set}InitiativeModifier()
 - Effect: AccessorizeVisualEffect()
 - Events: SubscribeEventScriptChunk()
 - Events: UnsubscribeEventScriptChunk()

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -3268,16 +3268,16 @@ static void InitInitiativeRollHook()
                     pCreature->m_idSelf);
             if (pPlayer)
             {
-                auto *pData = new CNWCCMessageData;
-                pData->SetInteger(0, diceRoll);
-                pData->SetInteger(1, mod);
-                pData->SetObjectID(0, pCreature->m_idSelf);
+                CNWCCMessageData messageData;
+                messageData.SetObjectID(0, pCreature->m_idSelf);
+                messageData.SetInteger(0, diceRoll);
+                messageData.SetInteger(1, mod);
                 auto *pMessage = static_cast<CNWSMessage *>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
                 if (pMessage)
                 {
                     pMessage->SendServerToPlayerCCMessage(pPlayer->m_nPlayerID,
                                                           Constants::MessageClientSideMsgMinor::Initiative,
-                                                          pData, nullptr);
+                                                          &messageData, nullptr);
                 }
             }
             pCreature->m_bInitiativeExpired = 0;

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -1007,6 +1007,19 @@ int NWNX_Creature_RunUnequip(object oCreature, object oItem);
 /// @note Persistence is enabled after a server reset by the first use of this function. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
 void NWNX_Creature_OverrideRangedProjectileVFX(object oCreature, int nProjectileVFX, int bPersist = FALSE);
 
+/// @brief Sets a custom Initiative modifier
+/// @param oCreature The affected creature
+/// @param nMod The amount to adjust their initiative (+/-).
+/// @param bPersist Whether the modifier should persist to .bic file (for PCs)
+/// @note Persistence is enabled after a server reset by the first use of this function. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
+/// @warning This modifier takes precedence over an NWNX_Race Initiative modifier; they're not additive
+void NWNX_Creature_SetInitiativeModifer(object oCreature, int nMod, int bPersist = FALSE);
+
+/// @brief Gets the custom Initiative modifier.
+/// @param oCreature The target creature
+/// @return the current custom initiative modifier for the creature
+int NWNX_Creature_GetInitiativeModifer(object oCreature);
+
 /// @}
 
 void NWNX_Creature_AddFeat(object creature, int feat)
@@ -2564,4 +2577,23 @@ void NWNX_Creature_OverrideRangedProjectileVFX(object oCreature, int nProjectile
     NWNX_PushArgumentInt(nProjectileVFX);
     NWNX_PushArgumentObject(oCreature);
     NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_SetInitiativeModifier(object oCreature, int nMod, int bPersist = FALSE)
+{
+    string sFunc = "SetInitiativeModifier";
+
+    NWNX_PushArgumentInt(bPersist);
+    NWNX_PushArgumentInt(nMod);
+    NWNX_PushArgumentObject(oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+int NWNX_Creature_GetInitiativeModifier(object oCreature)
+{
+    string sFunc = "GetInitiativeModifier";
+
+    NWNX_PushArgumentObject(oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+    return NWNX_GetReturnValueInt();
 }

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -275,5 +275,9 @@ void main()
     ApplyEffectToObject(DURATION_TYPE_TEMPORARY, VersusRacialTypeEffect(EffectACIncrease(5, AC_DEFLECTION_BONUS), RACIAL_TYPE_HUMAN), oCreature, 10.0);
     NWNX_Tests_Report("NWNX_Creature", "Touch AC increased after deflection buff GetArmorClassVersus", nOldTouchAC <  NWNX_Creature_GetArmorClassVersus(oCreature, oCreature2, TRUE));
 
+    int nInitiativeMod = NWNX_Creature_GetInitiativeModifier(oCreature);
+    NWNX_Creature_SetInitiativeModifier(oCreature, nInitiativeMod + 10);
+    NWNX_Tests_Report("NWNX_Creature", "{S,G}etInitiativeModifer", NWNX_Creature_GetInitiativeModifier(oCreature) == nInitiativeMod+10);
+
     WriteTimestampedLogEntry("NWNX_Creature unit test end.");
 }

--- a/Plugins/Race/Race.cpp
+++ b/Plugins/Race/Race.cpp
@@ -621,14 +621,16 @@ void Race::ResolveInitiativeHook(CNWSCreature *pCreature)
         auto *pPlayer = Globals::AppManager()->m_pServerExoApp->GetClientObjectByObjectId(pCreature->m_idSelf);
         if (pPlayer)
         {
-            auto *pData = new CNWCCMessageData;
-            pData->SetInteger(0, diceRoll);
-            pData->SetInteger(1, mod);
-            pData->SetObjectID(0, pCreature->m_idSelf);
-            auto *pMessage = static_cast<CNWSMessage*>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
+            CNWCCMessageData messageData;
+            messageData.SetObjectID(0, pCreature->m_idSelf);
+            messageData.SetInteger(0, diceRoll);
+            messageData.SetInteger(1, mod);
+            auto *pMessage = static_cast<CNWSMessage *>(Globals::AppManager()->m_pServerExoApp->GetNWSMessage());
             if (pMessage)
             {
-                pMessage->SendServerToPlayerCCMessage(pPlayer->m_nPlayerID, MessageClientSideMsgMinor::Initiative, pData, nullptr);
+                pMessage->SendServerToPlayerCCMessage(pPlayer->m_nPlayerID,
+                                                      Constants::MessageClientSideMsgMinor::Initiative,
+                                                      &messageData, nullptr);
             }
         }
         pCreature->m_bInitiativeExpired = 0;


### PR DESCRIPTION
Resolved #1501 

As noted in the docs, this will override any `NWNX_Race` initiative bonuses, they are not additive.