### PR TITLE
Events: expose RunScriptEvent() and make skippable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ https://github.com/nwnxee/unified/compare/build8193.34...HEAD
 - Events: added skippable event `NWNX_ON_INPUT_DROP_ITEM_{BEFORE|AFTER}` which fires when a player attempts to drop an item.
 - Events: added skippable event `NWNX_ON_DECREMENT_SPELL_COUNT_{BEFORE|AFTER}` which fires when spell count (Memorized, non-memorized, or spell-like ability) decreases.
 - Events: added skippable event `NWNX_ON_DEBUG_PLAY_VISUAL_EFFECT_{BEFORE|AFTER}` which fires when the dm_visualeffect console command is used.
+- Events: added skippable event `NWNX_ON_RUN_EVENT_SCRIPT_{BEFORE|AFTER}` which fires on all object event scripts. Only BEFORE is skippable.
 
 ##### New Plugins
 - N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ https://github.com/nwnxee/unified/compare/build8193.34...HEAD
 - Events: added skippable event `NWNX_ON_INPUT_DROP_ITEM_{BEFORE|AFTER}` which fires when a player attempts to drop an item.
 - Events: added skippable event `NWNX_ON_DECREMENT_SPELL_COUNT_{BEFORE|AFTER}` which fires when spell count (Memorized, non-memorized, or spell-like ability) decreases.
 - Events: added skippable event `NWNX_ON_DEBUG_PLAY_VISUAL_EFFECT_{BEFORE|AFTER}` which fires when the dm_visualeffect console command is used.
-- Events: added skippable event `NWNX_ON_RUN_EVENT_SCRIPT_{BEFORE|AFTER}` which fires on all object event scripts. Only BEFORE is skippable.
+- Events: added skippable event `NWNX_ON_RUN_EVENT_SCRIPT_{BEFORE|AFTER}` which fires on all object event scripts.
 
 ##### New Plugins
 - N/A

--- a/Plugins/Events/CMakeLists.txt
+++ b/Plugins/Events/CMakeLists.txt
@@ -8,6 +8,7 @@ add_plugin(Events
     "Events/DebugEvents.cpp"
     "Events/DMActionEvents.cpp"
     "Events/EffectEvents.cpp"
+    "Events/EventScriptEvents.cpp"
     "Events/ExamineEvents.cpp"
     "Events/FactionEvents.cpp"
     "Events/FeatEvents.cpp"

--- a/Plugins/Events/Events/EventScriptEvents.cpp
+++ b/Plugins/Events/Events/EventScriptEvents.cpp
@@ -1,0 +1,92 @@
+#include "Events.hpp"
+
+#include "API/CNWSArea.hpp"
+#include "API/CNWSModule.hpp"
+#include "API/CNWSObject.hpp"
+
+namespace Events {
+
+using namespace NWNXLib::API;
+using namespace NWNXLib::API::Constants;
+
+// BOOL CNWSArea::RunEventScript(int32_t nScript, CExoString* psOverrideScriptName)
+static NWNXLib::Hooks::Hook s_runAreaEventScript;
+// BOOL CNWSModule::RunEventScript(int32_t nScript, CExoString* psOverrideScriptName)
+static NWNXLib::Hooks::Hook s_runModuleEventScript;
+// BOOL CNWSObject::RunEventScript(int32_t nScript, CExoString* psOverrideScriptName)
+static NWNXLib::Hooks::Hook s_runObjectEventScript;
+
+static void AreaRunEventScript(CNWSArea*, int32_t, CExoString*);
+static void ModuleRunEventScript(CNWSModule*, int32_t, CExoString*);
+static void ObjectRunEventScript(CNWSObject*, int32_t, CExoString*);
+
+#define CNWSAREA_SCRIPTARRAY_MAX_SCRIPTS            4
+#define CNWSMODULE_SCRIPTARRAY_MAX_SCRIPTS         22
+
+void HookEvents() __attribute__((constructor));
+void HookEvents()
+{
+    InitOnFirstSubscribe("NWNX_ON_RUN_EVENT_SCRIPT_(BEFORE|AFTER)", []() {
+        s_runAreaEventScript = NWNXLib::Hooks::HookFunction(Functions::_ZN8CNWSArea14RunEventScriptEiP10CExoString,
+                                             (void*)&AreaRunEventScript, NWNXLib::Hooks::Order::Earliest);
+
+        s_runModuleEventScript = NWNXLib::Hooks::HookFunction(Functions::_ZN10CNWSModule14RunEventScriptEiP10CExoString,
+                                             (void*)&ModuleRunEventScript, NWNXLib::Hooks::Order::Earliest);
+
+        s_runObjectEventScript = NWNXLib::Hooks::HookFunction(Functions::_ZN10CNWSObject14RunEventScriptEiP10CExoString,
+                                             (void*)&ObjectRunEventScript, NWNXLib::Hooks::Order::Earliest);
+    });
+}
+
+static void DoEH(uint32_t tySelf, ObjectID idSelf, 
+    int32_t nScriptIdx, CExoString* psScript,
+    std::function<void()> fnEv)
+{
+    const int32_t nType = tySelf * 1000 + nScriptIdx;
+
+    auto PushAndSignal = [&](const std::string& ev) -> bool {
+        PushEventData("EVENT_TYPE", std::to_string(nType));
+        PushEventData("EVENT_SCRIPT", psScript->CStr());
+        return SignalEvent(ev, idSelf);
+    };
+
+    if (!PushAndSignal("NWNX_ON_RUN_EVENT_SCRIPT_BEFORE"))
+    {
+        return;
+    }
+
+    fnEv();
+
+    PushAndSignal("NWNX_ON_RUN_EVENT_SCRIPT_AFTER");
+}
+
+void AreaRunEventScript(CNWSArea* thisPtr, int32_t nScript, CExoString* psOverrideScriptName)
+{
+    ASSERT(nScript >= 0 && nScript < CNWSAREA_SCRIPTARRAY_MAX_SCRIPTS);
+    CExoString* psScript = psOverrideScriptName ? psOverrideScriptName : &(thisPtr->m_sScripts[nScript]);
+
+    DoEH(thisPtr->m_nObjectType, thisPtr->m_idSelf, nScript, psScript, [&]() {
+        s_runAreaEventScript->CallOriginal<void>(thisPtr, nScript, psOverrideScriptName);    
+    });
+}
+
+void ModuleRunEventScript(CNWSModule* thisPtr, int32_t nScript, CExoString* psOverrideScriptName)
+{
+    ASSERT(nScript >= 0 && nScript < CNWSMODULE_SCRIPTARRAY_MAX_SCRIPTS);
+    CExoString* psScript = psOverrideScriptName ? psOverrideScriptName : &(thisPtr->m_sScripts[nScript]);
+
+    DoEH(thisPtr->m_nObjectType, thisPtr->m_idSelf, nScript, psScript, [&]() {
+        s_runModuleEventScript->CallOriginal<void>(thisPtr, nScript, psOverrideScriptName);
+    });
+}
+
+void ObjectRunEventScript(CNWSObject* thisPtr, int32_t nScript, CExoString* psOverrideScriptName)
+{
+    CExoString* psScript = psOverrideScriptName ? psOverrideScriptName : thisPtr->GetScriptName(nScript);
+
+    DoEH(thisPtr->m_nObjectType, thisPtr->m_idSelf, nScript, psScript, [&]() {
+        s_runObjectEventScript->CallOriginal<void>(thisPtr, nScript, psOverrideScriptName);
+    });
+}
+
+}

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1633,7 +1633,7 @@ string NWNX_Events_GetEventData(string tag);
 /// - Input Drop Item
 /// - Decrement Spell Count event
 /// - Play Visual Effect event
-/// - EventScript event (BEFORE only)
+/// - EventScript event
 void NWNX_Events_SkipEvent();
 
 /// Set the return value of the event.
@@ -1676,6 +1676,7 @@ void NWNX_Events_RemoveObjectFromDispatchList(string sEvent, string sScriptOrChu
 /// ONLY WORKS WITH THE FOLLOWING EVENTS -> ID TYPES:
 /// - NWNX_ON_CAST_SPELL -> SpellID
 /// - NWNX_ON_HAS_FEAT -> FeatID (default enabled)
+/// - NWNX_ON_RUN_EVENT_SCRIPT -> EVENT_SCRIPT_* (default enabled)
 ///
 /// @note This enables the whitelist for ALL scripts subscribed to sEvent.
 /// @param sEvent The event name without _BEFORE / _AFTER.

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1505,6 +1505,17 @@ _______________________________________
     METAMAGIC             | int    | |
     CASTERLEVEL           | int    | Only returns for spell-like abilities |
 _______________________________________
+    ## EventScript Events
+    - NWNX_ON_RUN_EVENT_SCRIPT_BEFORE
+    - NWNX_ON_RUN_EVENT_SCRIPT_AFTER
+
+    `OBJECT_SELF` = The object the event script is running on
+
+    Event Data Tag        | Type   | Notes
+    ----------------------|--------|-------
+    EVENT_TYPE            | int    | EVENT_SCRIPT_* in nwscript.nss |
+    EVENT_SCRIPT          | int    | Script name running (can be empty) |
+_______________________________________
 */
 /*
 const int NWNX_EVENTS_OBJECT_TYPE_CREATURE          = 5;
@@ -1622,6 +1633,7 @@ string NWNX_Events_GetEventData(string tag);
 /// - Input Drop Item
 /// - Decrement Spell Count event
 /// - Play Visual Effect event
+/// - EventScript event (BEFORE only)
 void NWNX_Events_SkipEvent();
 
 /// Set the return value of the event.

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1515,6 +1515,14 @@ _______________________________________
     ----------------------|--------|-------
     EVENT_TYPE            | int    | EVENT_SCRIPT_* in nwscript.nss |
     EVENT_SCRIPT          | int    | Script name running (can be empty) |
+    
+    @note This event should definitely be used with the Event ID Whitelist, which is turned on by default
+    for this event. Until you add your EVENT_SCRIPT_ to the whitelist this event will not function:
+    ```c
+    NWNX_Events_SubscribeEvent("NWNX_ON_RUN_EVENT_SCRIPT_BEFORE", "creature_hb_ovr");
+    NWNX_Events_AddIDToWhitelist("NWNX_ON_RUN_EVENT_SCRIPT", EVENT_SCRIPT_MODULE_ON_HEARTBEAT);
+    ```
+    @warning Toggling the Whitelist to be off for this event will degrade performance.
 _______________________________________
 */
 /*


### PR DESCRIPTION
Fixes #1503

This reuses the Get/SetEventScript constant scheme.

* [x] Tested it locally.
* [x] Have a ID whitelist on the event type.