### PR TITLE
redis: password authentication

### DIFF
--- a/Plugins/Redis/README.md
+++ b/Plugins/Redis/README.md
@@ -70,5 +70,6 @@ if (NWNX_Redis_GetResultAsInt(NWNX_Redis_EXISTS("examples:examplekey")))
 | ---------------------------- | :---------------------: | ---------------------------------- |
 | `NWNX_REDIS_HOST`            | string                  | (none)                             |
 | `NWNX_REDIS_PORT`            | int16                   | 6379                               |
+| `NWNX_REDIS_AUTH_PASSWORD`   | string                  | ""                                 |
 | `NWNX_REDIS_PUBSUB_SCRIPT`   | string                  | on_pubsub                          |
 | `NWNX_REDIS_PUBSUB_CHANNELS` | comma-separated strings | ""                                 |

--- a/Plugins/Redis/Redis.hpp
+++ b/Plugins/Redis/Redis.hpp
@@ -29,6 +29,8 @@ public:
         std::string m_host;
         // PORT
         int m_port;
+        // AUTH (no ACL support)
+        std::string m_password;
 
         // TODO:
         // Bridge the internal message bus to redis?


### PR DESCRIPTION
Fixes #467

This is the least-effort solution by simply making new pool instances (and the pubsub conn) AUTH on setup.

* Only superficial local testing.
* Does not support Redis 6.0 ACLs. The whole library+commands.rb would need a lot of love for that.
