### PR TITLE
Feat: Fix issue with ABILITY SCORE feat counting toward server cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ https://github.com/nwnxee/unified/compare/build8193.34...HEAD
 
 ### Fixed
 - Feat: Fixed an issue with feat usages being reset upon character relog
+- Feat: Fixed an issue with an Ability Score feat counting towards the server capped limit when they should not
 - Object: GetLocalVariable() now recognizes variables of type json.
 - Tweaks: Language override tweak now works for area names.
 - Events: Fixed a crash when skipping `NWNX_ON_CLIENT_CONNECT_BEFORE`

--- a/Plugins/Feat/Feat.cpp
+++ b/Plugins/Feat/Feat.cpp
@@ -465,7 +465,7 @@ int32_t Feat::GetTotalEffectBonusHook(CNWSCreature *pCreature, uint8_t nEffectBo
         }
         else if (nEffectBonusType == 4)
         {
-            auto modAbilityBonus = g_plugin->m_FeatAbility[nFeat][nSkill];
+            auto modAbilityBonus = g_plugin->m_FeatAbility[nFeat][nAbilityScore];
             pServerExoApp->SetAbilityBonusLimit(pServerExoApp->GetAbilityBonusLimit() + modAbilityBonus);
         }
     }


### PR DESCRIPTION
A copy/paste typo caused an issue with the `GetTotalEffectBonus` hook not properly accounting for Ability Score modifying feats.