### PR TITLE
Move "ON_DESTROY_SERVER" signal after shutdown script has been invoked.

### DIFF
--- a/Core/NWNXCore.cpp
+++ b/Core/NWNXCore.cpp
@@ -569,8 +569,6 @@ void NWNXCore::DestroyServerHandler(CAppManager* app)
 {
     g_CoreShuttingDown = true;
 
-    MessageBus::Broadcast("NWNX_CORE_SIGNAL", { "ON_DESTROY_SERVER" });
-
     if (auto shutdownScript = Config::Get<std::string>("SHUTDOWN_SCRIPT"))
     {
         if (Globals::AppManager()->m_pServerExoApp->GetServerMode() == 2)
@@ -579,6 +577,8 @@ void NWNXCore::DestroyServerHandler(CAppManager* app)
             Utils::ExecuteScript(*shutdownScript, 0);
         }
     }
+
+    MessageBus::Broadcast("NWNX_CORE_SIGNAL", { "ON_DESTROY_SERVER" });
 
     g_core->m_destroyServerHook.reset();
     app->DestroyServer();


### PR DESCRIPTION
Resolves an edge case issue if a shutdown script tried to use a plugin that has shutdown logic tied to the "ON_DESTROY_SERVER" signal. (ResourceEvents/Dotnet)

I moved the existing signal instead of adding a new one as it is not exposed in nss, and is useless in it's current setup for dotnet. If it's preferred to have a new signal, I'm happy to update the PR.