### PR TITLE
[WIP] sql: support running queries on async thread

### DIFF
--- a/NWNXLib/Pool.hpp
+++ b/NWNXLib/Pool.hpp
@@ -4,6 +4,11 @@
 #include <set>
 #include <thread>
 #include <mutex>
+#include <functional>
+
+#include "nwnx.hpp"
+
+namespace NWNXLib {
 
 // This is a generic pool you can use to manage opaque objects.
 // It can be used, for example, to do database connection management, but is
@@ -119,4 +124,6 @@ private:
     MakeFunc m_make;
     size_t m_min;
     size_t m_max;
+};
+
 };

--- a/Plugins/Redis/Internal.hpp
+++ b/Plugins/Redis/Internal.hpp
@@ -10,12 +10,12 @@ namespace Redis
 {
 
 struct Internal {
-    Internal(Pool<cpp_redis::redis_client>::MakeFunc m) :
+    Internal(NWNXLib::Pool<cpp_redis::redis_client>::MakeFunc m) :
         m_redis_pool(m) {}
 
     // Connection pool for redis, used both for nwscript and for
     // external consumers (like other Plugins).
-    Pool<cpp_redis::redis_client> m_redis_pool;
+    NWNXLib::Pool<cpp_redis::redis_client> m_redis_pool;
 
     // The pubsub connection.
     cpp_redis::redis_subscriber m_connection_pubsub;

--- a/Plugins/SQL/NWScript/nwnx_sql.nss
+++ b/Plugins/SQL/NWScript/nwnx_sql.nss
@@ -16,6 +16,12 @@ int NWNX_SQL_PrepareQuery(string query);
 /// @return The ID of this query if successful, else FALSE.
 int NWNX_SQL_ExecutePreparedQuery();
 
+/// @brief Executes a prepared query on a background thread. 
+/// 
+/// @param script The script to call when the query finishes.
+/// @return The ID of this query if successful, else FALSE.
+int NWNX_SQL_ExecutePreparedQueryAsync(string scriptWhenComplete);
+
 /// @brief Directly execute an SQL query.
 /// @note Clears previously prepared query states.
 /// @return The ID of this query if successful, else FALSE.
@@ -117,6 +123,15 @@ int NWNX_SQL_ExecutePreparedQuery()
 {
     string sFunc = "ExecutePreparedQuery";
 
+    NWNX_CallFunction(NWNX_SQL, sFunc);
+    return NWNX_GetReturnValueInt();
+}
+
+int NWNX_SQL_ExecutePreparedQueryAsync(string scriptWhenComplete)
+{
+    string sFunc = "ExecutePreparedQueryAsync";
+
+    NWNX_PushArgumentString(scriptWhenComplete);
     NWNX_CallFunction(NWNX_SQL, sFunc);
     return NWNX_GetReturnValueInt();
 }

--- a/Plugins/SQL/SQL.hpp
+++ b/Plugins/SQL/SQL.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
 #include "nwnx.hpp"
+#include "Pool.hpp"
+
 #include "Targets/ITarget.hpp"
 
+#include <atomic>
 #include <memory>
+#include <chrono>
 
 using ArgumentStack = NWNXLib::Events::ArgumentStack;
 
@@ -17,6 +21,7 @@ public:
 
     ArgumentStack PrepareQuery                  (ArgumentStack&& args);
     ArgumentStack ExecutePreparedQuery          (ArgumentStack&& args);
+    ArgumentStack ExecutePreparedQueryAsync     (ArgumentStack&& args);
     ArgumentStack ReadyToReadNextRow            (ArgumentStack&& args);
     ArgumentStack ReadNextRow                   (ArgumentStack&& args);
     ArgumentStack ReadDataInActiveRow           (ArgumentStack&& args);
@@ -32,18 +37,53 @@ public:
     ArgumentStack DestroyPreparedQuery          (ArgumentStack&& args);
     ArgumentStack GetLastError                  (ArgumentStack&& args);
     ArgumentStack GetPreparedQueryParamCount    (ArgumentStack&& args);
-private:
-    bool Reconnect(int32_t attempts = 1);
 
-    std::unique_ptr<ITarget> m_target;
-    Query m_activeQuery;
-    ResultSet m_activeResults;
-    ResultRow m_activeRow;
-    int32_t m_nextQueryId;
+private:
+    std::string m_type;
+
+    NWNXLib::Pool<ITarget> m_pool;
+
+    std::unique_ptr<ITarget> MakeInstance();
+
+    struct QueryContext {
+        explicit QueryContext(SQL* parent) :
+            m_queryId(0),
+            m_parent(parent),
+            m_target(parent->m_pool.Take()),
+            m_activeQuery(""),
+            m_queryPrepared(false)
+        {
+        }
+
+        virtual ~QueryContext()
+        {
+            m_parent->m_pool.Give(std::move(m_target));
+        }
+
+        bool ExecuteQuery();
+
+        bool Reconnect(int32_t attempts = 1);
+
+        uint32_t m_queryId;
+        SQL* m_parent;
+
+        std::unique_ptr<ITarget> m_target;
+        std::string m_scriptWhenComplete;
+
+        Query m_activeQuery;
+        ResultSet m_activeResults;
+        ResultRow m_activeRow;
+        bool m_queryPrepared;
+        std::chrono::nanoseconds m_duration;
+    };
+
+    std::shared_ptr<QueryContext> m_context;
+
+    std::atomic_uint32_t m_nextQueryId;
+
     bool m_queryMetrics;
-    bool m_queryPrepared;
+
     bool m_utf8;
 };
 
 }
-


### PR DESCRIPTION
- reuse pool<> from redis and move to nwnxlib namespace (is this a good place?)
- wrap all query state into a Context object, which are hopefully self-contained can be passed to threads
- some really iffy code that does double-scheduling to run stuff async and then back on main thread
- untested

fixes #18 