### PR TITLE
Feat: Fix copy/paste bug with RemoveBonusFeat hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ https://github.com/nwnxee/unified/compare/build8193.34...HEAD
 ### Fixed
 - Feat: Fixed an issue with feat usages being reset upon character relog
 - Feat: Fixed an issue with an Ability Score feat counting towards the server capped limit when they should not
+- Feat: Fixed an issue with bonus feats not properly being removed
 - Object: GetLocalVariable() now recognizes variables of type json.
 - Tweaks: Language override tweak now works for area names.
 - Events: Fixed a crash when skipping `NWNX_ON_CLIENT_CONNECT_BEFORE`

--- a/Plugins/Feat/Feat.cpp
+++ b/Plugins/Feat/Feat.cpp
@@ -595,7 +595,7 @@ void Feat::RemoveFeatHook(CNWSCreatureStats *pCreatureStats, uint16_t nFeat)
 int32_t Feat::OnRemoveBonusFeatHook(CNWSEffectListHandler *pEffectListHandler, CNWSObject *pObject, CGameEffect *pEffect)
 {
     if (auto *pCreature = Utils::AsNWSCreature(pObject))
-        AddFeatEffects(pCreature->m_pStats, pEffect->GetInteger(0));
+        RemoveFeatEffects(pCreature->m_pStats, pEffect->GetInteger(0));
 
     return s_OnRemoveBonusFeatHook->CallOriginal<int32_t>(pEffectListHandler, pObject, pEffect);
 }


### PR DESCRIPTION
This is not the desired function to be running when the feat effect should be being removed. 