### PR TITLE
Race: Fixed an issue with unlimited feat usages being set to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ https://github.com/nwnxee/unified/compare/build8193.34...HEAD
 - N/A
 
 ### Fixed
-- Feat: Fixed an issue with feat usages being reset upon character relog
+- Race: Fixed an issue with feat usages being reset upon character relog
 - Feat: Fixed an issue with an Ability Score feat counting towards the server capped limit when they should not
 - Object: GetLocalVariable() now recognizes variables of type json.
 - Tweaks: Language override tweak now works for area names.

--- a/Plugins/Race/Race.cpp
+++ b/Plugins/Race/Race.cpp
@@ -669,7 +669,8 @@ int32_t Race::ValidateCharacterHook(CNWSPlayer *pPlayer, int32_t *bFailedServerR
         {
             pLevelStats->AddFeat(feat);
         }
-        featUses.emplace(featId, pCreature->m_pStats->GetFeatRemainingUses(featId));
+        if (Globals::Rules()->GetFeat(featId)->m_nUsesPerDay)
+            featUses.emplace(featId, pCreature->m_pStats->GetFeatRemainingUses(featId));
         pCreature->m_pStats->RemoveFeat(featId);
     }
 
@@ -684,7 +685,8 @@ int32_t Race::ValidateCharacterHook(CNWSPlayer *pPlayer, int32_t *bFailedServerR
         auto *pLevelStats = pCreature->m_pStats->m_lstLevelStats.element[featLevel-1];
         pLevelStats->AddFeat(featId);
         pCreature->m_pStats->AddFeat(featId);
-        pCreature->m_pStats->SetFeatRemainingUses(featId, featUses[featId]);
+        if (Globals::Rules()->GetFeat(featId)->m_nUsesPerDay)
+            pCreature->m_pStats->SetFeatRemainingUses(featId, featUses[featId]);
     }
 
     return retVal;


### PR DESCRIPTION
Note: The CHANGELOG entry was correctly switched to Race as the original fix was in Race, this just fixes the fix for unlimited feats from #1498 