### PR TITLE
SWIG - 8193.35: Add workaround for namespace usage

### DIFF
--- a/Plugins/SWIG/SWIG_DotNET/NamespaceUsings.i
+++ b/Plugins/SWIG/SWIG_DotNET/NamespaceUsings.i
@@ -1,0 +1,3 @@
+%{
+using namespace Task;
+%}

--- a/Plugins/SWIG/generate.sh
+++ b/Plugins/SWIG/generate.sh
@@ -12,6 +12,8 @@ echo "%{" > $NWNXLIB_SWG
 find ../../../NWNXLib/API -type f -name '*.hpp' "${FIND_ARGS[@]}" -printf '#include "%P"\n' | sort >> $NWNXLIB_SWG
 echo "%}" >> $NWNXLIB_SWG
 
+echo "%include NamespaceUsings.i" >> $NWNXLIB_SWG
+
 for include in "${FIRST_INCLUDES[@]}"
 do
     echo "%include \"$include\"" >> $NWNXLIB_SWG


### PR DESCRIPTION
SWIG fails to use the correct namespace when generating wrappers for Task::CExoTaskManager:
```
API_NWNXLibCSHARP_wrap.cxx:185363:3: error: ‘CExoTaskManager’ was not declared in this scope; did you mean ‘Task::CExoTaskManager’?
185363 |   CExoTaskManager *arg1 = (CExoTaskManager *) 0 ;
```
I added a new file that's parsed by the generator to hopefully make it easier to use namespaces during autogen.