### PR TITLE
build8193.35: remove json support because it's broken

### DIFF
--- a/Core/NWNXCoreVM.cpp
+++ b/Core/NWNXCoreVM.cpp
@@ -99,7 +99,6 @@ int32_t NWNXCore::GetVarHandler(CNWVirtualMachineCommands* thisPtr, int32_t nCom
         case VMCommand::GetLocalFloat:
         case VMCommand::GetLocalString:
         case VMCommand::GetLocalObject:
-        case VMCommand::GetLocalJson:
             break;
         default:
             return g_core->m_vmGetVarHook->CallOriginal<int32_t>(thisPtr, nCommandId, nParameters);
@@ -180,20 +179,6 @@ int32_t NWNXCore::GetVarHandler(CNWVirtualMachineCommands* thisPtr, int32_t nCom
             success = vm->StackPushObject(oid);
             break;
         }
-        case VMCommand::GetLocalJson:
-        {
-            JsonEngineStructure j;
-            if (nwnx)
-            {
-                j = Events::Pop<JsonEngineStructure>().value_or(j);
-            }
-            else if (vartable)
-            {
-                j = vartable->GetJson(varname);
-            }
-            success = vm->StackPushEngineStructure(VMStructure::Json, &j);
-            break;
-        }
         default:
             ASSERT_FAIL();
     }
@@ -208,7 +193,6 @@ int32_t NWNXCore::SetVarHandler(CNWVirtualMachineCommands* thisPtr, int32_t nCom
         case VMCommand::SetLocalFloat:
         case VMCommand::SetLocalString:
         case VMCommand::SetLocalObject:
-        case VMCommand::SetLocalJson:
             break;
         default:
             return g_core->m_vmSetVarHook->CallOriginal<int32_t>(thisPtr, nCommandId, nParameters);
@@ -294,25 +278,6 @@ int32_t NWNXCore::SetVarHandler(CNWVirtualMachineCommands* thisPtr, int32_t nCom
             {
                 vartable->SetObject(varname, value);
             }
-            break;
-        }
-        case VMCommand::SetLocalJson:
-        {
-            JsonEngineStructure *json;
-            if (!vm->StackPopEngineStructure(VMStructure::Json, (void**)&json))
-                return VMError::StackUnderflow;
-
-            if (nwnx)
-            {
-                Events::Push(*json);
-            }
-            else if (vartable)
-            {
-                vartable->SetJson(varname, *json);
-            }
-
-            delete json;
-
             break;
         }
         default:

--- a/NWNXLib/ScriptVariant.hpp
+++ b/NWNXLib/ScriptVariant.hpp
@@ -2,7 +2,6 @@
 
 #include "nwnx.hpp"
 #include "API/API/CGameEffect.hpp"
-#include "API/API/JsonEngineStructure.hpp"
 
 #include <deque>
 #include <stdexcept>
@@ -24,7 +23,6 @@ constexpr bool is_argument_type()
         || std::is_same_v<T, ObjectID>
         || std::is_same_v<T, std::string>
         || std::is_same_v<T, CGameEffect*>
-        || std::is_same_v<T, JsonEngineStructure>
         || std::is_same_v<T, NullArgument>);
 }
 
@@ -32,7 +30,7 @@ constexpr bool is_argument_type()
 
 struct ScriptVariant
 {
-    using Variant = std::variant<NullArgument, int32_t, float, ObjectID, std::string, CGameEffect*, JsonEngineStructure>;
+    using Variant = std::variant<NullArgument, int32_t, float, ObjectID, std::string, CGameEffect*>;
     Variant m_data;
 
     // Constructors
@@ -77,7 +75,6 @@ struct ScriptVariant
             auto e = Get<CGameEffect*>();
             return e ? std::string("EffectID:") + std::to_string(e->m_nID) : std::string("nullptr effect");
         }
-        else if (Holds<JsonEngineStructure>()) { return std::string("JSON: ") + Get<JsonEngineStructure>().m_json.dump(); }
         return "(unknown argument type)";
     }
 

--- a/Plugins/Regex/NWScript/nwnx_regex.nss
+++ b/Plugins/Regex/NWScript/nwnx_regex.nss
@@ -20,6 +20,7 @@ int NWNX_Regex_Search(string str, string regex);
 string NWNX_Regex_Replace(string str, string regex, string replace = "", int firstOnly = FALSE);
 
 /// @brief Returns all matches in a string that match the regular expression.
+/// @deprecated Please use the basegame RegExpIterate() function!
 /// @param str The string to search.
 /// @param regex The regular expression to use.
 /// @return A json array with json arrays of all (sub)matches. Returns JsonNull() on error.
@@ -49,9 +50,6 @@ string NWNX_Regex_Replace(string str, string regex, string replace="", int first
 
 json NWNX_Regex_Match(string str, string regex)
 {
-    string sFunc = "Match";
-    NWNX_PushArgumentString(regex);
-    NWNX_PushArgumentString(str);
-    NWNX_CallFunction(NWNX_Regex, sFunc);
-    return NWNX_GetReturnValueJson();
+    WriteTimestampedLogEntry("NWNX_Regex_Match() is deprecated. Please use the basegame's RegExpIterate() instead!");
+    return RegExpIterate(regex, str);
 }

--- a/Plugins/Regex/Regex.cpp
+++ b/Plugins/Regex/Regex.cpp
@@ -32,30 +32,3 @@ NWNX_EXPORT ArgumentStack Replace(ArgumentStack&& args)
 
     return retVal;
 }
-
-NWNX_EXPORT ArgumentStack Match(ArgumentStack&& args)
-{
-    const auto str = args.extract<std::string>();
-      ASSERT_OR_THROW(!str.empty());
-    const auto regex = args.extract<std::string>();
-      ASSERT_OR_THROW(!regex.empty());
-
-    std::regex rgx(regex);
-    std::sregex_iterator it(str.begin(), str.end(), rgx);
-    const static std::sregex_iterator end;
-
-    JsonEngineStructure retVal(json::array());
-
-    while (it != end)
-    {
-        json matches = json::array();
-        for (size_t i = 0; i < it->size(); i++)
-        {
-            matches.emplace_back(it->str(i));
-        }
-        retVal.m_json.emplace_back(matches);
-        it++;
-    }
-
-    return retVal;
-}


### PR DESCRIPTION
Only NWNX_Regex_Match() was using it so far and that has a basegame function now. If you really need to push/pop json it's easy to dump/parse it from strings.