### PR TITLE
add Player_GetGameObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ https://github.com/nwnxee/unified/compare/build8193.34...HEAD
 - Player: UpdateSkyBox();
 - Player: UpdateFogColor();
 - Player: UpdateFogAmount();
+- Player: GetGameObject()
 - Regex: Match()
 
 ### Changed

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -416,6 +416,11 @@ void NWNX_Player_UpdateFogColor(object oPlayer, int nSunFogColor, int nMoonFogCo
 /// @param nMoonFogAmount The int value of Moon Fog amount (range 0-255).
 void NWNX_Player_UpdateFogAmount(object oPlayer, int nSunFogAmount, int nMoonFogAmount);
 
+/// @brief Return's the currently-possessed game object of a player.
+/// @param oPlayer The player object (e.g. from GetFirst/NextPC()).
+/// @return the actual game object of oPlayer, or OBJECT_INVALID on error.
+object NWNX_Player_GetGameObject(object oPlayer);
+
 /// @}
 
 void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable)
@@ -1048,4 +1053,13 @@ void NWNX_Player_UpdateFogAmount(object oPlayer, int nSunFogAmount, int nMoonFog
     NWNX_PushArgumentInt(nSunFogAmount);
     NWNX_PushArgumentObject(oPlayer);
     NWNX_CallFunction(NWNX_Player, sFunc);
+}
+
+object NWNX_Player_GetGameObject(object oPlayer)
+{
+    string sFunc = "GetGameObject";
+
+    NWNX_PushArgumentObject(oPlayer);
+    NWNX_CallFunction(NWNX_Player, sFunc);
+    return NWNX_GetReturnValueObject();
 }

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -1770,3 +1770,25 @@ NWNX_EXPORT ArgumentStack UpdateFogAmount(ArgumentStack&& args)
     }
     return {};
 }
+
+NWNX_EXPORT ArgumentStack GetGameObject(ArgumentStack&& args)
+{
+    if (auto *obj = Utils::PopGameObject(args))
+    {
+        auto *playerList = (CExoLinkedList<CNWSClient>*) Globals::AppManager()->m_pServerExoApp->GetPlayerList();
+        CExoLinkedListPosition pListPosition = playerList->GetHeadPos();
+        while (pListPosition != NULL)
+        {
+            auto pPlayer = (CNWSPlayer *) playerList->GetAtPos(pListPosition);
+
+            if (pPlayer->m_oidPCObject == obj->m_idSelf)
+            {
+                return pPlayer->m_oidNWSObject;
+            }
+
+            playerList->GetNext(pListPosition);
+        }
+    }
+
+    return Constants::OBJECT_INVALID;
+}


### PR DESCRIPTION
This is meant to be used to resolve the possessed creature object when looping GetFirst/NextPC().

I need it for a specific nwnx_chat implementation detail on my server (to determine and rewrite listening), but thought it might be useful upstream too.