### PR TITLE
Area: add SetDefaultObjectUiDiscoveryMask()

### DIFF
--- a/NWNXLib/Utils.cpp
+++ b/NWNXLib/Utils.cpp
@@ -526,5 +526,22 @@ CNWSPlayer* PopPlayer(ArgumentStack& args, bool throwOnFail)
     return pPlayer;
 }
 
+int32_t NWScriptObjectTypeToEngineObjectType(int32_t nwscriptObjectType)
+{
+    switch (nwscriptObjectType)
+    {
+        case 1: return Constants::ObjectType::Creature;
+        case 2: return Constants::ObjectType::Item;
+        case 4: return Constants::ObjectType::Trigger;
+        case 8: return Constants::ObjectType::Door;
+        case 16: return Constants::ObjectType::AreaOfEffect;
+        case 32: return Constants::ObjectType::Waypoint;
+        case 64: return Constants::ObjectType::Placeable;
+        case 128: return Constants::ObjectType::Store;
+        case 256: return Constants::ObjectType::Encounter;
+        default: return 0;
+    }
+}
+
 
 }

--- a/NWNXLib/nwnx.hpp
+++ b/NWNXLib/nwnx.hpp
@@ -265,6 +265,8 @@ namespace Utils
     CNWSWaypoint*  PopWaypoint(ArgumentStack& args, bool throwOnFail=false);
     CNWSTrigger*   PopTrigger(ArgumentStack& args, bool throwOnFail=false);
     CNWSDoor*      PopDoor(ArgumentStack& args, bool throwOnFail=false);
+
+    int32_t NWScriptObjectTypeToEngineObjectType(int32_t nwscriptObjectType);
 }
 
 namespace POS

--- a/Plugins/Area/NWScript/nwnx_area.nss
+++ b/Plugins/Area/NWScript/nwnx_area.nss
@@ -342,6 +342,13 @@ void NWNX_Area_SetAreaFlags(object oArea, int nFlags);
 /// @param oArea The area.
 struct NWNX_Area_AreaWind NWNX_Area_GetAreaWind(object oArea);
 
+/// @brief Set the default discoverability mask for objects in an area.
+/// @param oArea The area or OBJECT_INVALID to set a global mask for all areas. Per area masks will override the global mask.
+/// @param nObjectTypes A mask of OBJECT_TYPE_* constants or OBJECT_TYPE_ALL for all suitable object types. Currently only works on Creatures, Doors (Hilite only), Items and Useable Placeables.
+/// @param nMask A mask of OBJECT_UI_DISCOVERY_*
+/// @param bForceUpdate If TRUE, will update the discovery mask of ALL objects in the area or module(if oArea == OBJECT_INVALID), according to the current mask. Use with care.
+void NWNX_Area_SetDefaultObjectUiDiscoveryMask(object oArea, int nObjectTypes, int nMask, int bForceUpdate = FALSE);
+
 /// @}
 
 int NWNX_Area_GetNumberOfPlayersInArea(object area)
@@ -867,4 +874,15 @@ struct NWNX_Area_AreaWind NWNX_Area_GetAreaWind(object oArea)
     data.vDirection.z = NWNX_GetReturnValueFloat();
 
     return data;
+}
+
+void NWNX_Area_SetDefaultObjectUiDiscoveryMask(object oArea, int nObjectTypes, int nMask, int bForceUpdate = FALSE)
+{
+    string sFunc = "SetDefaultObjectUiDiscoveryMask";
+
+    NWNX_PushArgumentInt(bForceUpdate);
+    NWNX_PushArgumentInt(nMask);
+    NWNX_PushArgumentInt(nObjectTypes);
+    NWNX_PushArgumentObject(oArea);
+    NWNX_CallFunction(NWNX_Area, sFunc);
 }

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -421,6 +421,12 @@ void NWNX_Player_UpdateFogAmount(object oPlayer, int nSunFogAmount, int nMoonFog
 /// @return the actual game object of oPlayer, or OBJECT_INVALID on error.
 object NWNX_Player_GetGameObject(object oPlayer);
 
+/// @brief Override the ui discovery mask of oObject for oPlayer only
+/// @param oPlayer The player object.
+/// @param oObject The target object.
+/// @param nMask A mask of OBJECT_UI_DISCOVERY_*, or -1 to clear the override
+void NWNX_Player_SetObjectUiDiscoveryMaskOverride(object oPlayer, object oObject, int nMask);
+
 /// @}
 
 void NWNX_Player_ForcePlaceableExamineWindow(object player, object placeable)
@@ -1062,4 +1068,15 @@ object NWNX_Player_GetGameObject(object oPlayer)
     NWNX_PushArgumentObject(oPlayer);
     NWNX_CallFunction(NWNX_Player, sFunc);
     return NWNX_GetReturnValueObject();
+}
+
+void NWNX_Player_SetObjectUiDiscoveryMaskOverride(object oPlayer, object oObject, int nMask)
+{
+    string sFunc = "SetObjectUiDiscoveryMaskOverride";
+
+    NWNX_PushArgumentInt(nMask);
+    NWNX_PushArgumentObject(oObject);
+    NWNX_PushArgumentObject(oPlayer);
+
+    NWNX_CallFunction(NWNX_Player, sFunc);
 }


### PR DESCRIPTION
A cool function to set the default object ui discovery mask globally or per area