### PR TITLE
Add NWNX_Creature_GetIsFlanked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ https://github.com/nwnxee/unified/compare/build8193.34...HEAD
 - Creature: AddCastSpellActions()
 - Creature: GetSpellUsesLeft()
 - Creature: GetMemorizedSpellReadyCount()
-- Creature: GetIsFlanked()
+- Creature: GetIsFlanking()
 - Effect: AccessorizeVisualEffect()
 - Encounter: Destroy()
 - Events: SubscribeEventScriptChunk()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ https://github.com/nwnxee/unified/compare/build8193.34...HEAD
 - Creature: AddCastSpellActions()
 - Creature: GetSpellUsesLeft()
 - Creature: GetMemorizedSpellReadyCount()
+- Creature: GetIsFlanked()
 - Effect: AccessorizeVisualEffect()
 - Encounter: Destroy()
 - Events: SubscribeEventScriptChunk()

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -3429,7 +3429,7 @@ NWNX_EXPORT ArgumentStack GetMemorizedSpellReadyCount(ArgumentStack&& args)
     return 0;
 }
 
-NWNX_EXPORT ArgumentStack GetIsFlanked(ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack GetIsFlanking(ArgumentStack&& args)
 {
     if (auto *pCreature = Utils::PopCreature(args))
     {

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -3428,3 +3428,16 @@ NWNX_EXPORT ArgumentStack GetMemorizedSpellReadyCount(ArgumentStack&& args)
 
     return 0;
 }
+
+NWNX_EXPORT ArgumentStack GetIsFlanked(ArgumentStack&& args)
+{
+    if (auto *pCreature = Utils::PopCreature(args))
+    {
+        if (auto *pTargetCreature = Utils::PopCreature(args))
+        {
+            return pCreature->GetFlanked(pTargetCreature);
+        }
+    }
+
+    return false;
+}

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -1068,8 +1068,8 @@ int NWNX_Creature_GetMemorizedSpellReadyCount(object oCreature, int nSpellID, in
 /// @brief Get whether oCreature is flanking oTargetCreature.
 /// @param oCreature The creature object.
 /// @param oTargetCreature The target creature object.
-/// @return TRUE if oTargetCreature is being flanked by oCreature.
-int NWNX_Creature_GetIsFlanked(object oCreature, object oTargetCreature);
+/// @return TRUE if oCreature is flanking oTargetCreature.
+int NWNX_Creature_GetIsFlanking(object oCreature, object oTargetCreature);
 
 /// @}
 
@@ -2716,9 +2716,9 @@ int NWNX_Creature_GetMemorizedSpellReadyCount(object oCreature, int nSpellID, in
     return NWNX_GetReturnValueInt();
 }
 
-int NWNX_Creature_GetIsFlanked(object oCreature, object oTargetCreature)
+int NWNX_Creature_GetIsFlanking(object oCreature, object oTargetCreature)
 {
-    string sFunc = "GetIsFlanked";
+    string sFunc = "GetIsFlanking";
 
     NWNX_PushArgumentObject(oTargetCreature);
     NWNX_PushArgumentObject(oCreature);

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -1065,6 +1065,12 @@ int NWNX_Creature_GetSpellUsesLeft(object oCreature, int nSpellID, int nMultiCla
 /// @return The number of spell uses left or 0 on error.
 int NWNX_Creature_GetMemorizedSpellReadyCount(object oCreature, int nSpellID, int nMultiClass, int nMetaMagic = METAMAGIC_NONE);
 
+/// @brief Get whether oCreature is flanking oTargetCreature.
+/// @param oCreature The creature object.
+/// @param oTargetCreature The target creature object.
+/// @return TRUE if oTargetCreature is being flanked by oCreature.
+int NWNX_Creature_GetIsFlanked(object oCreature, object oTargetCreature);
+
 /// @}
 
 void NWNX_Creature_AddFeat(object creature, int feat)
@@ -2704,6 +2710,17 @@ int NWNX_Creature_GetMemorizedSpellReadyCount(object oCreature, int nSpellID, in
     NWNX_PushArgumentInt(nMetaMagic);
     NWNX_PushArgumentInt(nMultiClass);
     NWNX_PushArgumentInt(nSpellID);
+    NWNX_PushArgumentObject(oCreature);
+
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+    return NWNX_GetReturnValueInt();
+}
+
+int NWNX_Creature_GetIsFlanked(object oCreature, object oTargetCreature)
+{
+    string sFunc = "GetIsFlanked";
+
+    NWNX_PushArgumentObject(oTargetCreature);
     NWNX_PushArgumentObject(oCreature);
 
     NWNX_CallFunction(NWNX_Creature, sFunc);


### PR DESCRIPTION
Adds NWNX_Creature_GetIsFlanked(oCreature, oTargetCreature), which returns if oCreature is flanking oTargetCreature. Pretty simple, was a little surprised there wasn't already a function for it unless I missed it somewhere.