### PR TITLE
Update ELC.cpp

### DIFF
--- a/Plugins/ELC/ELC.cpp
+++ b/Plugins/ELC/ELC.cpp
@@ -663,7 +663,32 @@ static auto s_ValidateCharacter = Hooks::HookFunction(API::Functions::_ZN10CNWSP
                     // Check if our first level class is a spellcaster and if their primary casting stat is >= 11
                     if (nLevel == 1 && pClassLeveledUpIn->m_bIsSpellCasterClass)
                     {
-                        if (nAbilityAtLevel[pClassLeveledUpIn->m_nPrimaryAbility] < 11)
+                        uint8_t nCastingAbilityAdjust = 0;
+                        switch (pClassLeveledUpIn->m_nPrimaryAbility)
+                        {
+                            case Constants::Ability::Strength:
+                                nCastingAbilityAdjust = pRace->m_nSTRAdjust;
+                                break;
+                            case Constants::Ability::Dexterity:
+                                nCastingAbilityAdjust = pRace->m_nDEXAdjust;
+                                break;
+                            case Constants::Ability::Constitution:
+                                nCastingAbilityAdjust = pRace->m_nCONAdjust;
+                                break;
+                            case Constants::Ability::Intelligence:
+                                nCastingAbilityAdjust = pRace->m_nINTAdjust;
+                                break;
+                            case Constants::Ability::Wisdom:
+                                nCastingAbilityAdjust = pRace->m_nWISAdjust;
+                                break;
+                            case Constants::Ability::Charisma:
+                                nCastingAbilityAdjust = pRace->m_nCHAAdjust;
+                                break;
+                            default:
+                                nCastingAbilityAdjust = 0;
+                                break;
+                        }
+                        if (nAbilityAtLevel[pClassLeveledUpIn->m_nPrimaryAbility]+nCastingAbilityAdjust < 11)
                         {
                             if (auto strrefFailure = HandleValidationFailure(
                                     ValidationFailureType::Character,


### PR DESCRIPTION
Added racial ability adjustment into minimal ability score for spellcasting check to prevent issue when ELC would consider character with custom race granting wis/int/cha bonus or a custom spellcaster class with str/dex/con as casting ability.
Also note, shouldn't be m_nPrimaryAbility rather m_nSpellcastingAbility ?