### PR TITLE
Do not reconcile auto map data on first run

### DIFF
--- a/Plugins/Optimizations/ReconcileAutoMap.cpp
+++ b/Plugins/Optimizations/ReconcileAutoMap.cpp
@@ -50,8 +50,12 @@ static void ReconcileAutoMapData(CNWSCreature* pThis)
 {
     uint64_t seq = (uint64_t)s_SeqTable.Get(pThis->m_idSelf);
     if (seq != s_AreaListSeq)
-    {
-        s_ReconcileAutoMapData->CallOriginal<void>(pThis);
+    {   
+        if (seq > 0)
+        {
+            // We only need to reconcile if there's an area list update after we have been initialized.
+            s_ReconcileAutoMapData->CallOriginal<void>(pThis);
+        }
         s_SeqTable.Add(pThis->m_idSelf, (void*) s_AreaListSeq);
     }
 }


### PR DESCRIPTION
The first time an object is loaded, the auto map data is already synced with the server, so we don't need to actually reconcile there.