### PR TITLE
small documentation additions to nwnx_events.nss and nwnx_item.nss

### DIFF
--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1363,13 +1363,22 @@ _______________________________________
     - NWNX_ON_STORE_REQUEST_SELL_AFTER
 
     `OBJECT_SELF` = The creature buying or selling an item
-
+    
     Event Data Tag        | Type   | Notes |
     ----------------------|--------|-------|
     ITEM                  | object | The item being bought or sold. Convert to object with StringToObject()  |
     STORE                 | object | The store the item is being sold to or bought from. Convert to object with StringToObject() |
     PRICE                 | int    | The buy or sell price |
     RESULT                | int    | TRUE/FALSE whether the request was successful. Only in *_AFTER events.
+    
+    @warning RESULT in NWNX_ON_STORE_REQUEST_BUY_AFTER only fails if it's due to lack of gold.  It will not fail if item does not fit in player's inventory.  If you want to check and fail on that condition, you can do something like this in the NWNX_ON_STORE_REQUEST_BUY_AFTER event:
+    ```c
+	if (!GetBaseItemFitsInInventory(GetBaseItemType(oItem), oPlayer))
+	{
+		NWNX_Events_SetEventResult("0");
+		return;
+	}
+    ```
 
 _______________________________________
     ## Server Send Area Events

--- a/Plugins/Item/NWScript/nwnx_item.nss
+++ b/Plugins/Item/NWScript/nwnx_item.nss
@@ -16,6 +16,7 @@ void NWNX_Item_SetWeight(object oItem, int weight);
 /// @remark Total cost = base_value + additional_value.
 /// @remark Equivalent to SetGoldPieceValue NWNX2 function.
 /// @note Will not persist through saving.
+/// @note This value will also revert if item is identified or player relogs into server.
 /// @param oItem The item object.
 /// @param gold The base gold value.
 void NWNX_Item_SetBaseGoldPieceValue(object oItem, int gold);


### PR DESCRIPTION
nwnx_events.nss

This tries to clarify the expected failure condition for NWNX_ON_STORE_REQUEST_BUY_AFTER and alternative work around if user would like different behavior.

nwnx_item.nss

Minor clarification on conditions that would cause NWNX_Item_SetBaseGoldPieceValue to reset.

Feel free to adjust wording.
