### PR TITLE
core: rename Events->ScriptAPI, strip prefix for all ArgumentStack locations

### DIFF
--- a/Core/NWNXCoreVM.cpp
+++ b/Core/NWNXCoreVM.cpp
@@ -129,7 +129,7 @@ int32_t NWNXCore::GetVarHandler(CNWVirtualMachineCommands* thisPtr, int32_t nCom
             int32_t n = 0;
             if (nwnx)
             {
-                n = Events::Pop<int32_t>().value_or(n);
+                n = ScriptAPI::Pop<int32_t>().value_or(n);
             }
             else if (vartable)
             {
@@ -143,7 +143,7 @@ int32_t NWNXCore::GetVarHandler(CNWVirtualMachineCommands* thisPtr, int32_t nCom
             float f = 0.0f;
             if (nwnx)
             {
-                f = Events::Pop<float>().value_or(f);
+                f = ScriptAPI::Pop<float>().value_or(f);
             }
             else if (vartable)
             {
@@ -157,7 +157,7 @@ int32_t NWNXCore::GetVarHandler(CNWVirtualMachineCommands* thisPtr, int32_t nCom
             CExoString str = "";
             if (nwnx)
             {
-                str = Events::Pop<std::string>().value_or(str);
+                str = ScriptAPI::Pop<std::string>().value_or(str);
             }
             else if (vartable)
             {
@@ -171,7 +171,7 @@ int32_t NWNXCore::GetVarHandler(CNWVirtualMachineCommands* thisPtr, int32_t nCom
             ObjectID oid = Constants::OBJECT_INVALID;
             if (nwnx)
             {
-                oid = Events::Pop<ObjectID>().value_or(oid);
+                oid = ScriptAPI::Pop<ObjectID>().value_or(oid);
             }
             else if (vartable)
             {
@@ -185,7 +185,7 @@ int32_t NWNXCore::GetVarHandler(CNWVirtualMachineCommands* thisPtr, int32_t nCom
             JsonEngineStructure j;
             if (nwnx)
             {
-                j = Events::Pop<JsonEngineStructure>().value_or(j);
+                j = ScriptAPI::Pop<JsonEngineStructure>().value_or(j);
             }
             else if (vartable)
             {
@@ -240,7 +240,7 @@ int32_t NWNXCore::SetVarHandler(CNWVirtualMachineCommands* thisPtr, int32_t nCom
 
             if (nwnx)
             {
-                Events::Push(value);
+                ScriptAPI::Push(value);
             }
             else if (vartable)
             {
@@ -256,7 +256,7 @@ int32_t NWNXCore::SetVarHandler(CNWVirtualMachineCommands* thisPtr, int32_t nCom
 
             if (nwnx)
             {
-                Events::Push(value);
+                ScriptAPI::Push(value);
             }
             else if (vartable)
             {
@@ -272,7 +272,7 @@ int32_t NWNXCore::SetVarHandler(CNWVirtualMachineCommands* thisPtr, int32_t nCom
 
             if (nwnx)
             {
-                Events::Push(std::string(value.CStr()));
+                ScriptAPI::Push(std::string(value.CStr()));
             }
             else if (vartable)
             {
@@ -288,7 +288,7 @@ int32_t NWNXCore::SetVarHandler(CNWVirtualMachineCommands* thisPtr, int32_t nCom
 
             if (nwnx)
             {
-                Events::Push(value);
+                ScriptAPI::Push(value);
             }
             else if (vartable)
             {
@@ -304,7 +304,7 @@ int32_t NWNXCore::SetVarHandler(CNWVirtualMachineCommands* thisPtr, int32_t nCom
 
             if (nwnx)
             {
-                Events::Push(*json);
+                ScriptAPI::Push(*json);
             }
             else if (vartable)
             {
@@ -342,11 +342,11 @@ int32_t NWNXCore::TagEffectHandler(CNWVirtualMachineCommands* thisPtr, int32_t n
         if (nwnx->operation == "PUSH")
         {
             bSkipDelete = true;
-            Events::Push(pEffect);
+            ScriptAPI::Push(pEffect);
         }
         else if (nwnx->operation == "POP")
         {
-            if (auto res = Events::Pop<CGameEffect*>())
+            if (auto res = ScriptAPI::Pop<CGameEffect*>())
             {
                 Utils::DestroyGameEffect(pEffect);
                 pEffect = *res;
@@ -393,11 +393,11 @@ int32_t NWNXCore::TagItemPropertyHandler(CNWVirtualMachineCommands* thisPtr, int
         if (nwnx->operation == "PUSH")
         {
             bSkipDelete = true;
-            Events::Push(pItemProperty);
+            ScriptAPI::Push(pItemProperty);
         }
         else if (nwnx->operation == "POP")
         {
-            if (auto res = Events::Pop<CGameEffect*>())
+            if (auto res = ScriptAPI::Pop<CGameEffect*>())
             {
                 Utils::DestroyGameEffect(pItemProperty);
                 pItemProperty = *res;
@@ -437,7 +437,7 @@ int32_t NWNXCore::PlaySoundHandler(CNWVirtualMachineCommands* thisPtr, int32_t n
     {
         ASSERT(nwnx->operation == "CALL"); // This one is used only for CALL ops
         if (g_core->m_ScriptChunkRecursion == 0)
-            Events::Call(nwnx->plugin, nwnx->event);
+            ScriptAPI::Call(nwnx->plugin, nwnx->event);
         else
             LOG_NOTICE("NWNX function '%s_%s' in ExecuteScriptChunk() was blocked due to configuration", nwnx->plugin, nwnx->event);
     }

--- a/NWNXLib/CMakeLists.txt
+++ b/NWNXLib/CMakeLists.txt
@@ -24,7 +24,7 @@ nwnxlib_add(
     "Encoding.cpp"
     "Plugin.cpp"
     "Commands.cpp"
-    "Events.cpp"
+    "ScriptAPI.cpp"
     "MessageBus.cpp"
     "Hooks.cpp"
     "Tasks.cpp"

--- a/NWNXLib/ScriptAPI.cpp
+++ b/NWNXLib/ScriptAPI.cpp
@@ -8,15 +8,15 @@
 #include <sstream>
 
 
-namespace NWNXLib::Events
+namespace NWNXLib::ScriptAPI
 {
 ArgumentStack s_arguments;
 ArgumentStack s_returns;
 
-using PluginEventMap = std::unordered_map<std::string, Events::FunctionCallback>;
+using PluginEventMap = std::unordered_map<std::string, ScriptAPI::FunctionCallback>;
 static std::unordered_map<std::string, PluginEventMap> s_eventMap;
 
-std::optional<Events::FunctionCallback> GetEventCallback(const std::string& pluginName, const std::string& eventName)
+std::optional<ScriptAPI::FunctionCallback> GetEventCallback(const std::string& pluginName, const std::string& eventName)
 {
     auto& events = s_eventMap[pluginName];
     auto it = events.find(eventName);

--- a/NWNXLib/ScriptAPI.hpp
+++ b/NWNXLib/ScriptAPI.hpp
@@ -12,14 +12,14 @@
 #include <vector>
 #include <optional>
 
-namespace NWNXLib::Events
+namespace NWNXLib::ScriptAPI
 {
     extern ArgumentStack s_arguments;
     extern ArgumentStack s_returns;
 
     template <typename T> void Push(T&& value)
     {
-        s_arguments.push(Events::Argument(std::forward<T>(value)));
+        s_arguments.push(ScriptAPI::Argument(std::forward<T>(value)));
         LOG_DEBUG("Pushing argument '%s'", s_arguments.top());
     }
 

--- a/NWNXLib/nwnx.hpp
+++ b/NWNXLib/nwnx.hpp
@@ -50,7 +50,7 @@ namespace Config
 
 struct ScriptVariant;
 struct ScriptVariantStack;
-namespace Events
+namespace ScriptAPI
 {
     using Argument = ScriptVariant;
     using ArgumentStack = ScriptVariantStack;
@@ -62,7 +62,7 @@ namespace Events
     template <typename T> static std::optional<T> Pop();
     void Call(const std::string& pluginName, const std::string& eventName);
 }
-using ArgumentStack = Events::ArgumentStack;
+using ArgumentStack = ScriptVariantStack;
 
 namespace Hooks
 {
@@ -301,7 +301,7 @@ namespace Tasks
 #include "Assert.hpp"
 #include "ScriptVariant.hpp"
 #include "Config.hpp"
-#include "Events.hpp"
+#include "ScriptAPI.hpp"
 #include "Utils.hpp"
 
 namespace NWNXLib

--- a/Plugins/Administration/Administration.cpp
+++ b/Plugins/Administration/Administration.cpp
@@ -54,14 +54,14 @@ static CExoLinkedListNode* FindTURD(std::string playerName, std::string characte
     return foundNode;
 }
 
-NWNX_EXPORT Events::ArgumentStack GetPlayerPassword(Events::ArgumentStack&&)
+NWNX_EXPORT ArgumentStack GetPlayerPassword(ArgumentStack&&)
 {
     const CExoString password = Globals::AppManager()->m_pServerExoApp->GetNetLayer()->GetPlayerPassword();
     LOG_DEBUG("Returned player password '%s'.", password.m_sString);
     return std::string(password.m_sString ? password.m_sString : "");
 }
 
-NWNX_EXPORT Events::ArgumentStack SetPlayerPassword(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack SetPlayerPassword(ArgumentStack&& args)
 {
     const auto newPass = args.extract<std::string>();
     LOG_NOTICE("Set player password to '%s'.", newPass);
@@ -69,21 +69,21 @@ NWNX_EXPORT Events::ArgumentStack SetPlayerPassword(Events::ArgumentStack&& args
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack ClearPlayerPassword(Events::ArgumentStack&&)
+NWNX_EXPORT ArgumentStack ClearPlayerPassword(ArgumentStack&&)
 {
     LOG_NOTICE("Cleared player password.");
     Globals::AppManager()->m_pServerExoApp->GetNetLayer()->SetPlayerPassword("");
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack GetDMPassword(Events::ArgumentStack&&)
+NWNX_EXPORT ArgumentStack GetDMPassword(ArgumentStack&&)
 {
     const CExoString password = Globals::AppManager()->m_pServerExoApp->GetNetLayer()->GetGameMasterPassword();
     LOG_DEBUG("Returned DM password '%s'.", password.m_sString);
     return std::string(password.m_sString ? password.m_sString : "");
 }
 
-NWNX_EXPORT Events::ArgumentStack SetDMPassword(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack SetDMPassword(ArgumentStack&& args)
 {
     const auto newPass = args.extract<std::string>();
     LOG_NOTICE("Set DM password to '%s'.", newPass);
@@ -91,14 +91,14 @@ NWNX_EXPORT Events::ArgumentStack SetDMPassword(Events::ArgumentStack&& args)
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack ShutdownServer(Events::ArgumentStack&&)
+NWNX_EXPORT ArgumentStack ShutdownServer(ArgumentStack&&)
 {
     LOG_NOTICE("Shutting down the server!");
     *Globals::ExitProgram() = true;
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack DeletePlayerCharacter(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack DeletePlayerCharacter(ArgumentStack&& args)
 {
     const auto objectId = args.extract<ObjectID>();
     const bool bPreserveBackup = !!args.extract<int32_t>();
@@ -185,7 +185,7 @@ NWNX_EXPORT Events::ArgumentStack DeletePlayerCharacter(Events::ArgumentStack&& 
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack AddBannedIP(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack AddBannedIP(ArgumentStack&& args)
 {
     const auto ip = args.extract<std::string>();
     LOG_NOTICE("Banning IP %s", ip);
@@ -193,7 +193,7 @@ NWNX_EXPORT Events::ArgumentStack AddBannedIP(Events::ArgumentStack&& args)
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack RemoveBannedIP(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack RemoveBannedIP(ArgumentStack&& args)
 {
     const auto ip = args.extract<std::string>();
     LOG_NOTICE("Unbanning IP %s", ip);
@@ -201,7 +201,7 @@ NWNX_EXPORT Events::ArgumentStack RemoveBannedIP(Events::ArgumentStack&& args)
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack AddBannedCDKey(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack AddBannedCDKey(ArgumentStack&& args)
 {
     const auto key = args.extract<std::string>();
     LOG_NOTICE("Banning CDKey %s", key);
@@ -209,7 +209,7 @@ NWNX_EXPORT Events::ArgumentStack AddBannedCDKey(Events::ArgumentStack&& args)
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack RemoveBannedCDKey(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack RemoveBannedCDKey(ArgumentStack&& args)
 {
     const auto key = args.extract<std::string>();
     LOG_NOTICE("Unbanning CDKey %s", key);
@@ -217,7 +217,7 @@ NWNX_EXPORT Events::ArgumentStack RemoveBannedCDKey(Events::ArgumentStack&& args
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack AddBannedPlayerName(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack AddBannedPlayerName(ArgumentStack&& args)
 {
     const auto playername = args.extract<std::string>();
     LOG_NOTICE("Banning Player name %s", playername);
@@ -225,7 +225,7 @@ NWNX_EXPORT Events::ArgumentStack AddBannedPlayerName(Events::ArgumentStack&& ar
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack RemoveBannedPlayerName(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack RemoveBannedPlayerName(ArgumentStack&& args)
 {
     const auto playername = args.extract<std::string>();
     LOG_NOTICE("Unbanning Player name %s", playername);
@@ -233,13 +233,13 @@ NWNX_EXPORT Events::ArgumentStack RemoveBannedPlayerName(Events::ArgumentStack&&
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack GetBannedList(Events::ArgumentStack&&)
+NWNX_EXPORT ArgumentStack GetBannedList(ArgumentStack&&)
 {
     std::string list = Globals::AppManager()->m_pServerExoApp->GetBannedListString().CStr();
     return list;
 }
 
-NWNX_EXPORT Events::ArgumentStack SetModuleName(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack SetModuleName(ArgumentStack&& args)
 {
     const auto newName = args.extract<std::string>();
     LOG_NOTICE("Set module name to '%s'.", newName);
@@ -247,7 +247,7 @@ NWNX_EXPORT Events::ArgumentStack SetModuleName(Events::ArgumentStack&& args)
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack SetServerName(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack SetServerName(ArgumentStack&& args)
 {
     const auto newName = args.extract<std::string>();
     LOG_NOTICE("Set server name to '%s'.", newName);
@@ -255,13 +255,13 @@ NWNX_EXPORT Events::ArgumentStack SetServerName(Events::ArgumentStack&& args)
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack GetServerName(Events::ArgumentStack&&)
+NWNX_EXPORT ArgumentStack GetServerName(ArgumentStack&&)
 {
     CExoString serverName = Globals::AppManager()->m_pServerExoApp->GetNetLayer()->GetSessionName();
     return serverName.CStr();
 }
 
-NWNX_EXPORT Events::ArgumentStack GetPlayOption(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack GetPlayOption(ArgumentStack&& args)
 {
     int32_t retVal = -1;
 
@@ -391,7 +391,7 @@ NWNX_EXPORT Events::ArgumentStack GetPlayOption(Events::ArgumentStack&& args)
     return retVal;
 }
 
-NWNX_EXPORT Events::ArgumentStack SetPlayOption(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack SetPlayOption(ArgumentStack&& args)
 {
     const auto option = args.extract<int32_t>();
     const auto value = args.extract<int32_t>();
@@ -522,7 +522,7 @@ NWNX_EXPORT Events::ArgumentStack SetPlayOption(Events::ArgumentStack&& args)
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack DeleteTURD(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack DeleteTURD(ArgumentStack&& args)
 {
     int32_t retVal = false;
     const auto playerName = args.extract<std::string>();
@@ -543,7 +543,7 @@ NWNX_EXPORT Events::ArgumentStack DeleteTURD(Events::ArgumentStack&& args)
     return retVal;
 }
 
-NWNX_EXPORT Events::ArgumentStack GetDebugValue(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack GetDebugValue(ArgumentStack&& args)
 {
     int32_t retVal = -1;
 
@@ -577,7 +577,7 @@ NWNX_EXPORT Events::ArgumentStack GetDebugValue(Events::ArgumentStack&& args)
     return retVal;
 }
 
-NWNX_EXPORT Events::ArgumentStack SetDebugValue(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack SetDebugValue(ArgumentStack&& args)
 {
     const auto debugType = args.extract<int32_t>();
      ASSERT_OR_THROW(debugType >= 0);
@@ -612,20 +612,20 @@ NWNX_EXPORT Events::ArgumentStack SetDebugValue(Events::ArgumentStack&& args)
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack ReloadRules(Events::ArgumentStack&&)
+NWNX_EXPORT ArgumentStack ReloadRules(ArgumentStack&&)
 {
     LOG_NOTICE("Reloading rules!");
     Globals::Rules()->ReloadAll();
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack GetMinLevel(Events::ArgumentStack&&)
+NWNX_EXPORT ArgumentStack GetMinLevel(ArgumentStack&&)
 {
     auto *pServerInfo = Globals::AppManager()->m_pServerExoApp->GetServerInfo();
     return pServerInfo->m_JoiningRestrictions.nMinLevel;
 }
 
-NWNX_EXPORT Events::ArgumentStack SetMinLevel(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack SetMinLevel(ArgumentStack&& args)
 {
     const auto nLevel = args.extract<int32_t>();
     ASSERT_OR_THROW(nLevel >= 1);
@@ -636,13 +636,13 @@ NWNX_EXPORT Events::ArgumentStack SetMinLevel(Events::ArgumentStack&& args)
     return {};
 }
 
-NWNX_EXPORT Events::ArgumentStack GetMaxLevel(Events::ArgumentStack&&)
+NWNX_EXPORT ArgumentStack GetMaxLevel(ArgumentStack&&)
 {
     auto *pServerInfo = Globals::AppManager()->m_pServerExoApp->GetServerInfo();
     return pServerInfo->m_JoiningRestrictions.nMaxLevel;
 }
 
-NWNX_EXPORT Events::ArgumentStack SetMaxLevel(Events::ArgumentStack&& args)
+NWNX_EXPORT ArgumentStack SetMaxLevel(ArgumentStack&& args)
 {
     const auto nLevel = args.extract<int32_t>();
     ASSERT_OR_THROW(nLevel >= 1);

--- a/Plugins/Chat/Chat.cpp
+++ b/Plugins/Chat/Chat.cpp
@@ -153,7 +153,7 @@ static Hooks::Hook s_SendServerToPlayerChatMessageHook = Hooks::HookFunction(
             return retVal;
         }, Hooks::Order::Late);
 
-NWNX_EXPORT ArgumentStack SendMessage(Events::ArgumentStack &&args)
+NWNX_EXPORT ArgumentStack SendMessage(ArgumentStack &&args)
 {
     int32_t retVal = false;
     const auto channel = static_cast<Constants::ChatChannel::TYPE>(args.extract<int32_t>());
@@ -246,42 +246,42 @@ NWNX_EXPORT ArgumentStack SendMessage(Events::ArgumentStack &&args)
         }
     }
 
-    return Events::Arguments(retVal);
+    return ScriptAPI::Arguments(retVal);
 }
 
-NWNX_EXPORT ArgumentStack RegisterChatScript(Events::ArgumentStack &&args)
+NWNX_EXPORT ArgumentStack RegisterChatScript(ArgumentStack &&args)
 {
     s_ChatScript = args.extract<std::string>();
     return {};
 }
 
-NWNX_EXPORT ArgumentStack SkipMessage(Events::ArgumentStack &&)
+NWNX_EXPORT ArgumentStack SkipMessage(ArgumentStack &&)
 {
     s_SkipMessage = true;
     return {};
 }
 
-NWNX_EXPORT ArgumentStack GetChannel(Events::ArgumentStack &&)
+NWNX_EXPORT ArgumentStack GetChannel(ArgumentStack &&)
 {
     return static_cast<int32_t>(s_ActiveChannel);
 }
 
-NWNX_EXPORT ArgumentStack GetMessage(Events::ArgumentStack &&)
+NWNX_EXPORT ArgumentStack GetMessage(ArgumentStack &&)
 {
     return s_ActiveMessage;
 }
 
-NWNX_EXPORT ArgumentStack GetSender(Events::ArgumentStack &&)
+NWNX_EXPORT ArgumentStack GetSender(ArgumentStack &&)
 {
     return s_ActiveSenderObjectId;
 }
 
-NWNX_EXPORT ArgumentStack GetTarget(Events::ArgumentStack &&)
+NWNX_EXPORT ArgumentStack GetTarget(ArgumentStack &&)
 {
     return s_ActiveTargetObjectId;
 }
 
-NWNX_EXPORT ArgumentStack SetChatHearingDistance(Events::ArgumentStack &&args)
+NWNX_EXPORT ArgumentStack SetChatHearingDistance(ArgumentStack &&args)
 {
     const auto distance = args.extract<float>();
       ASSERT_OR_THROW(distance >= 0.0f);
@@ -312,7 +312,7 @@ NWNX_EXPORT ArgumentStack SetChatHearingDistance(Events::ArgumentStack &&args)
     return {};
 }
 
-NWNX_EXPORT ArgumentStack GetChatHearingDistance(Events::ArgumentStack &&args)
+NWNX_EXPORT ArgumentStack GetChatHearingDistance(ArgumentStack &&args)
 {
     const auto playerOid = args.extract<ObjectID>();
     const auto channel = (Constants::ChatChannel::TYPE)args.extract<int32_t>();

--- a/Plugins/Damage/Damage.cpp
+++ b/Plugins/Damage/Damage.cpp
@@ -30,7 +30,7 @@ Damage::Damage(Services::ProxyServiceList* services)
 {
 
 #define REGISTER(func) \
-    Events::RegisterEvent(PLUGIN_NAME, #func, \
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, #func, \
         [this](ArgumentStack&& args){ return func(std::move(args)); })
 
     REGISTER(SetEventScript);
@@ -56,9 +56,9 @@ Damage::~Damage()
 
 ArgumentStack Damage::SetEventScript(ArgumentStack&& args)
 {
-    const auto event = Events::ExtractArgument<std::string>(args);
-    const auto script = Events::ExtractArgument<std::string>(args);
-    auto oidOwner = Events::ExtractArgument<ObjectID>(args);
+    const auto event = ScriptAPI::ExtractArgument<std::string>(args);
+    const auto script = ScriptAPI::ExtractArgument<std::string>(args);
+    auto oidOwner = ScriptAPI::ExtractArgument<ObjectID>(args);
 
     if (oidOwner == Constants::OBJECT_INVALID)
     {
@@ -80,7 +80,7 @@ ArgumentStack Damage::SetEventScript(ArgumentStack&& args)
         }
     }
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 std::string Damage::GetEventScript(CNWSObject *pObject, const std::string &event)
@@ -97,9 +97,9 @@ ArgumentStack Damage::GetDamageEventData(ArgumentStack&&)
 
     for (int k = 12; k >= 0; k--)
     {
-        Events::InsertArgument(stack, m_DamageData.vDamage[k]);
+        ScriptAPI::InsertArgument(stack, m_DamageData.vDamage[k]);
     }
-    Events::InsertArgument(stack, m_DamageData.oidDamager);
+    ScriptAPI::InsertArgument(stack, m_DamageData.oidDamager);
 
     return stack;
 }
@@ -110,7 +110,7 @@ ArgumentStack Damage::SetDamageEventData(ArgumentStack&& args)
 
     for (int k = 0; k < 13; k++)
     {
-        m_DamageData.vDamage[k] = Events::ExtractArgument<int32_t>(args);
+        m_DamageData.vDamage[k] = ScriptAPI::ExtractArgument<int32_t>(args);
     }
 
     return stack;
@@ -143,19 +143,19 @@ ArgumentStack Damage::GetAttackEventData(ArgumentStack&&)
 {
     ArgumentStack stack;
 
-    Events::InsertArgument(stack, m_AttackData.nToHitModifier);
-    Events::InsertArgument(stack, m_AttackData.nToHitRoll);
-    Events::InsertArgument(stack, m_AttackData.nAttackType);
-    Events::InsertArgument(stack, m_AttackData.bKillingBlow);
-    Events::InsertArgument(stack, m_AttackData.nSneakAttack);
-    Events::InsertArgument(stack, m_AttackData.nWeaponAttackType);
-    Events::InsertArgument(stack, m_AttackData.nAttackResult);
-    Events::InsertArgument(stack, m_AttackData.nAttackNumber);
+    ScriptAPI::InsertArgument(stack, m_AttackData.nToHitModifier);
+    ScriptAPI::InsertArgument(stack, m_AttackData.nToHitRoll);
+    ScriptAPI::InsertArgument(stack, m_AttackData.nAttackType);
+    ScriptAPI::InsertArgument(stack, m_AttackData.bKillingBlow);
+    ScriptAPI::InsertArgument(stack, m_AttackData.nSneakAttack);
+    ScriptAPI::InsertArgument(stack, m_AttackData.nWeaponAttackType);
+    ScriptAPI::InsertArgument(stack, m_AttackData.nAttackResult);
+    ScriptAPI::InsertArgument(stack, m_AttackData.nAttackNumber);
     for (int k = 12; k >= 0; k--)
     {
-        Events::InsertArgument(stack, m_AttackData.vDamage[k]);
+        ScriptAPI::InsertArgument(stack, m_AttackData.vDamage[k]);
     }
-    Events::InsertArgument(stack, m_AttackData.oidTarget);
+    ScriptAPI::InsertArgument(stack, m_AttackData.oidTarget);
 
     return stack;
 }
@@ -166,9 +166,9 @@ ArgumentStack Damage::SetAttackEventData(ArgumentStack&& args)
 
     for (int k = 0; k < 13; k++)
     {
-        m_AttackData.vDamage[k] = Events::ExtractArgument<int32_t>(args);
+        m_AttackData.vDamage[k] = ScriptAPI::ExtractArgument<int32_t>(args);
     }
-    m_AttackData.nAttackResult = Events::ExtractArgument<int32_t>(args);
+    m_AttackData.nAttackResult = ScriptAPI::ExtractArgument<int32_t>(args);
 
     return stack;
 }
@@ -230,18 +230,18 @@ ArgumentStack Damage::DealDamage(ArgumentStack&& args)
     std::bitset<13> positive;
 
     // read input
-    auto oidSource = Events::ExtractArgument<ObjectID>(args);
-    auto oidTarget = Events::ExtractArgument<ObjectID>(args);
+    auto oidSource = ScriptAPI::ExtractArgument<ObjectID>(args);
+    auto oidTarget = ScriptAPI::ExtractArgument<ObjectID>(args);
 
     for (int k = 0; k < 12; k++)
     {
-        vDamage[k] = Events::ExtractArgument<int32_t>(args);
+        vDamage[k] = ScriptAPI::ExtractArgument<int32_t>(args);
         // need to distinguish between no damage dealt, and damage reduced to 0
         positive[k] = vDamage[k] > 0;
     }
-    int damagePower = Events::ExtractArgument<int32_t>(args);
+    int damagePower = ScriptAPI::ExtractArgument<int32_t>(args);
 
-    int range = Events::ExtractArgument<int32_t>(args);
+    int range = ScriptAPI::ExtractArgument<int32_t>(args);
 
     CNWSCreature *pSource = Globals::AppManager()->m_pServerExoApp->GetCreatureByGameObjectID(oidSource);
     CNWSObject *pTarget = Utils::AsNWSObject(Globals::AppManager()->m_pServerExoApp->GetGameObject(oidTarget));
@@ -278,7 +278,7 @@ ArgumentStack Damage::DealDamage(ArgumentStack&& args)
 
     pTarget->ApplyEffect(pEffect, false, true);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 }

--- a/Plugins/Damage/Damage.hpp
+++ b/Plugins/Damage/Damage.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "nwnx.hpp"
-using ArgumentStack = NWNXLib::Events::ArgumentStack;
 
 struct DamageDataStr
 {
@@ -25,6 +24,7 @@ struct AttackDataStr
 };
 
 namespace Damage {
+using NWNXLib::ArgumentStack;
 
 class Damage : public NWNXLib::Plugin
 {

--- a/Plugins/DotNET/DotNETExports.cpp
+++ b/Plugins/DotNET/DotNETExports.cpp
@@ -485,63 +485,63 @@ static void NWNXSetFunction(const char* plugin, const char* function)
 
 static void NWNXPushInt(int32_t n)
 {
-    Events::Push(n);
+    ScriptAPI::Push(n);
 }
 
 static void NWNXPushFloat(float f)
 {
-    Events::Push(f);
+    ScriptAPI::Push(f);
 }
 
 static void NWNXPushObject(uint32_t o)
 {
-    Events::Push((ObjectID)o);
+    ScriptAPI::Push((ObjectID)o);
 }
 
 static void NWNXPushString(const char* s)
 {
-    Events::Push(String::FromUTF8(s));
+    ScriptAPI::Push(String::FromUTF8(s));
 }
 
 static void NWNXPushRawString(const char* s)
 {
-    Events::Push<std::string>(s);
+    ScriptAPI::Push<std::string>(s);
 }
 
 static void NWNXPushEffect(CGameEffect* e)
 {
-    Events::Push(e);
+    ScriptAPI::Push(e);
 }
 
 static void NWNXPushItemProperty(CGameEffect* ip)
 {
-    Events::Push(ip);
+    ScriptAPI::Push(ip);
 }
 
 static int32_t NWNXPopInt()
 {
-    return Events::Pop<int32_t>().value_or(0);
+    return ScriptAPI::Pop<int32_t>().value_or(0);
 }
 
 static float NWNXPopFloat()
 {
-    return Events::Pop<float>().value_or(0.0f);
+    return ScriptAPI::Pop<float>().value_or(0.0f);
 }
 
 static uint32_t NWNXPopObject()
 {
-    return Events::Pop<ObjectID>().value_or(Constants::OBJECT_INVALID);
+    return ScriptAPI::Pop<ObjectID>().value_or(Constants::OBJECT_INVALID);
 }
 
 static const char* NWNXPopString()
 {
-    auto str = Events::Pop<std::string>().value_or(std::string{""});
+    auto str = ScriptAPI::Pop<std::string>().value_or(std::string{""});
     return strdup(String::ToUTF8(str).c_str());
 }
 
 static const char* NWNXPopRawString()
 {
-    auto value = Events::Pop<std::string>();
+    auto value = ScriptAPI::Pop<std::string>();
 
     static std::string retVal;
     if (value.has_value())
@@ -557,17 +557,17 @@ static const char* NWNXPopRawString()
 
 static CGameEffect* NWNXPopEffect()
 {
-    return Events::Pop<CGameEffect*>().value_or(nullptr);
+    return ScriptAPI::Pop<CGameEffect*>().value_or(nullptr);
 }
 
 static CGameEffect* NWNXPopItemProperty()
 {
-    return Events::Pop<CGameEffect*>().value_or(nullptr);
+    return ScriptAPI::Pop<CGameEffect*>().value_or(nullptr);
 }
 
 static void NWNXCallFunction()
 {
-    Events::Call(s_nwnxActivePlugin, s_nwnxActiveFunction);
+    ScriptAPI::Call(s_nwnxActivePlugin, s_nwnxActiveFunction);
 }
 
 static NWNXLib::API::Globals::NWNXExportedGlobals GetNWNXExportedGlobals()

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -10,7 +10,6 @@ namespace Events {
 using namespace NWNXLib;
 using namespace NWNXLib::API;
 using namespace NWNXLib::API::Constants;
-using ArgumentStack = NWNXLib::Events::ArgumentStack;
 
 struct EventParams
 {

--- a/Plugins/Feat/Feat.cpp
+++ b/Plugins/Feat/Feat.cpp
@@ -48,7 +48,7 @@ Feat::Feat(Services::ProxyServiceList* services)
     : Plugin(services)
 {
 #define REGISTER(func) \
-    Events::RegisterEvent(PLUGIN_NAME, #func, \
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, #func, \
         [this](ArgumentStack&& args){ return func(std::move(args)); })
 
     REGISTER(SetFeatModifier);
@@ -908,17 +908,17 @@ bool Feat::DoFeatModifier(int32_t featId, FeatModifier featMod, int32_t param1, 
 
 ArgumentStack Feat::SetFeatModifier(ArgumentStack&& args)
 {
-    auto featId = Events::ExtractArgument<int>(args);
-    auto featMod = static_cast<FeatModifier>(Events::ExtractArgument<int>(args));
-    auto param1 = Events::ExtractArgument<int>(args);
-    auto param2 = Events::ExtractArgument<int>(args);
-    auto param3 = Events::ExtractArgument<int>(args);
-    auto param4 = Events::ExtractArgument<int>(args);
+    auto featId = ScriptAPI::ExtractArgument<int>(args);
+    auto featMod = static_cast<FeatModifier>(ScriptAPI::ExtractArgument<int>(args));
+    auto param1 = ScriptAPI::ExtractArgument<int>(args);
+    auto param2 = ScriptAPI::ExtractArgument<int>(args);
+    auto param3 = ScriptAPI::ExtractArgument<int>(args);
+    auto param4 = ScriptAPI::ExtractArgument<int>(args);
 
     if (DoFeatModifier(featId, featMod, param1, param2, param3, param4) && !g_plugin->m_Feats.count(featId))
         g_plugin->m_Feats.insert(featId);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 }

--- a/Plugins/Feat/Feat.hpp
+++ b/Plugins/Feat/Feat.hpp
@@ -8,7 +8,7 @@ using namespace std;
 using namespace NWNXLib::API;
 using namespace NWNXLib::Services;
 
-using ArgumentStack = NWNXLib::Events::ArgumentStack;
+using ArgumentStack = NWNXLib::ArgumentStack;
 
 namespace Feat {
 

--- a/Plugins/ItemProperty/ItemProperty.cpp
+++ b/Plugins/ItemProperty/ItemProperty.cpp
@@ -49,26 +49,26 @@ NWNX_EXPORT ArgumentStack PackIP(ArgumentStack&& args)
     ip->SetInteger(8, usable);
     ip->SetString(0, tag.c_str());
 
-    return Events::Arguments(ip);
+    return ScriptAPI::Arguments(ip);
 }
 NWNX_EXPORT ArgumentStack UnpackIP(ArgumentStack&& args)
 {
     ArgumentStack stack;
     auto ip = args.extract<CGameEffect*>();
 
-    Events::InsertArgument(stack, ip->GetString(0).CStr());
-    Events::InsertArgument(stack, (ObjectID)ip->m_oidCreator);
-    Events::InsertArgument(stack, (int32_t)ip->m_nSpellId);
-    Events::InsertArgument(stack, ip->GetInteger(8));
-    Events::InsertArgument(stack, ip->GetInteger(7));
-    Events::InsertArgument(stack, ip->GetInteger(6));
-    Events::InsertArgument(stack, ip->GetInteger(5));
-    Events::InsertArgument(stack, ip->GetInteger(4));
-    Events::InsertArgument(stack, ip->GetInteger(3));
-    Events::InsertArgument(stack, ip->GetInteger(2));
-    Events::InsertArgument(stack, ip->GetInteger(1));
-    Events::InsertArgument(stack, ip->GetInteger(0));
-    Events::InsertArgument(stack, std::to_string(ip->m_nItemPropertySourceId));
+    ScriptAPI::InsertArgument(stack, ip->GetString(0).CStr());
+    ScriptAPI::InsertArgument(stack, (ObjectID)ip->m_oidCreator);
+    ScriptAPI::InsertArgument(stack, (int32_t)ip->m_nSpellId);
+    ScriptAPI::InsertArgument(stack, ip->GetInteger(8));
+    ScriptAPI::InsertArgument(stack, ip->GetInteger(7));
+    ScriptAPI::InsertArgument(stack, ip->GetInteger(6));
+    ScriptAPI::InsertArgument(stack, ip->GetInteger(5));
+    ScriptAPI::InsertArgument(stack, ip->GetInteger(4));
+    ScriptAPI::InsertArgument(stack, ip->GetInteger(3));
+    ScriptAPI::InsertArgument(stack, ip->GetInteger(2));
+    ScriptAPI::InsertArgument(stack, ip->GetInteger(1));
+    ScriptAPI::InsertArgument(stack, ip->GetInteger(0));
+    ScriptAPI::InsertArgument(stack, std::to_string(ip->m_nItemPropertySourceId));
 
     Utils::DestroyGameEffect(ip);
     return stack;
@@ -89,15 +89,15 @@ NWNX_EXPORT ArgumentStack GetActiveProperty(ArgumentStack&& args)
 
     ArgumentStack stack;
 
-    Events::InsertArgument(stack, ip->m_sCustomTag.CStr());
-    Events::InsertArgument(stack, ip->m_bUseable);
-    Events::InsertArgument(stack, ip->m_nChanceOfAppearing);
-    Events::InsertArgument(stack, ip->m_nUsesPerDay);
-    Events::InsertArgument(stack, ip->m_nParam1Value);
-    Events::InsertArgument(stack, ip->m_nParam1);
-    Events::InsertArgument(stack, ip->m_nCostTableValue);
-    Events::InsertArgument(stack, ip->m_nCostTable);
-    Events::InsertArgument(stack, ip->m_nSubType);
-    Events::InsertArgument(stack, ip->m_nPropertyName);
+    ScriptAPI::InsertArgument(stack, ip->m_sCustomTag.CStr());
+    ScriptAPI::InsertArgument(stack, ip->m_bUseable);
+    ScriptAPI::InsertArgument(stack, ip->m_nChanceOfAppearing);
+    ScriptAPI::InsertArgument(stack, ip->m_nUsesPerDay);
+    ScriptAPI::InsertArgument(stack, ip->m_nParam1Value);
+    ScriptAPI::InsertArgument(stack, ip->m_nParam1);
+    ScriptAPI::InsertArgument(stack, ip->m_nCostTableValue);
+    ScriptAPI::InsertArgument(stack, ip->m_nCostTable);
+    ScriptAPI::InsertArgument(stack, ip->m_nSubType);
+    ScriptAPI::InsertArgument(stack, ip->m_nPropertyName);
     return stack;
 }

--- a/Plugins/Lua/Lua.cpp
+++ b/Plugins/Lua/Lua.cpp
@@ -126,9 +126,9 @@ namespace Lua {
         }
 
         // bind events
-        Events::RegisterEvent(PLUGIN_NAME, "Eval", std::bind(&Lua::Eval, this, std::placeholders::_1));
-        Events::RegisterEvent(PLUGIN_NAME, "EvalVoid", std::bind(&Lua::EvalVoid, this, std::placeholders::_1));
-        Events::RegisterEvent(PLUGIN_NAME, "RunEvent", std::bind(&Lua::RunEvent, this, std::placeholders::_1));
+        ScriptAPI::RegisterEvent(PLUGIN_NAME, "Eval", std::bind(&Lua::Eval, this, std::placeholders::_1));
+        ScriptAPI::RegisterEvent(PLUGIN_NAME, "EvalVoid", std::bind(&Lua::EvalVoid, this, std::placeholders::_1));
+        ScriptAPI::RegisterEvent(PLUGIN_NAME, "RunEvent", std::bind(&Lua::RunEvent, this, std::placeholders::_1));
 
         // RunScript hook
         if(!runScriptTable.empty())
@@ -184,10 +184,10 @@ namespace Lua {
     }
 
     // Eval Lua code and returns the result
-    Events::ArgumentStack Lua::Eval(Events::ArgumentStack&& args)
+    ArgumentStack Lua::Eval(ArgumentStack&& args)
     {
-        const auto code = Events::ExtractArgument<std::string>(args);
-        Events::ArgumentStack stack;
+        const auto code = ScriptAPI::ExtractArgument<std::string>(args);
+        ArgumentStack stack;
 
         SetObjectSelf();
 
@@ -196,27 +196,27 @@ namespace Lua {
         if(luaL_dostring(m_luaInstance, code.c_str()))
         {
             LOG_ERROR("Error on Eval: %s", lua_tostring(m_luaInstance, -1));
-            Events::InsertArgument(stack, std::string(""));
+            ScriptAPI::InsertArgument(stack, std::string(""));
         }
         else if(lua_gettop(m_luaInstance))
         {
             size_t iLength = 0;
             const char *returnStr = lua_tolstring(m_luaInstance, -1, &iLength);
-            Events::InsertArgument(stack, std::string(returnStr, iLength));
+            ScriptAPI::InsertArgument(stack, std::string(returnStr, iLength));
         }
         else
         {
-            Events::InsertArgument(stack, std::string(""));
+            ScriptAPI::InsertArgument(stack, std::string(""));
         }
         lua_settop(m_luaInstance, 0);
         return stack;
     }
 
     // Eval Lua code without result
-    Events::ArgumentStack Lua::EvalVoid(Events::ArgumentStack&& args)
+    ArgumentStack Lua::EvalVoid(ArgumentStack&& args)
     {
-        const auto code = Events::ExtractArgument<std::string>(args);
-        Events::ArgumentStack stack;
+        const auto code = ScriptAPI::ExtractArgument<std::string>(args);
+        ArgumentStack stack;
 
         SetObjectSelf();
 
@@ -258,12 +258,12 @@ namespace Lua {
     }
 
     // Call the event function
-    Events::ArgumentStack Lua::RunEvent(Events::ArgumentStack&& args)
+    ArgumentStack Lua::RunEvent(ArgumentStack&& args)
     {
-        const auto eventStr = Events::ExtractArgument<std::string>(args);
-        const auto objectId = Events::ExtractArgument<ObjectID>(args);
-        const auto extraStr = Events::ExtractArgument<std::string>(args);
-        Events::ArgumentStack stack;
+        const auto eventStr = ScriptAPI::ExtractArgument<std::string>(args);
+        const auto objectId = ScriptAPI::ExtractArgument<ObjectID>(args);
+        const auto extraStr = ScriptAPI::ExtractArgument<std::string>(args);
+        ArgumentStack stack;
 
         SetObjectSelf();
 

--- a/Plugins/Lua/Lua.hpp
+++ b/Plugins/Lua/Lua.hpp
@@ -22,9 +22,9 @@ namespace Lua {
 	    Lua(NWNXLib::Services::ProxyServiceList* services);
 	    virtual ~Lua();
 	    lua_State *m_luaInstance;
-	    Events::ArgumentStack Eval(Events::ArgumentStack&& args);
-	    Events::ArgumentStack EvalVoid(Events::ArgumentStack&& args);
-	    Events::ArgumentStack RunEvent(Events::ArgumentStack&& args);
+	    ArgumentStack Eval(ArgumentStack&& args);
+	    ArgumentStack EvalVoid(ArgumentStack&& args);
+	    ArgumentStack RunEvent(ArgumentStack&& args);
 	    void OnToken(ObjectID oid, char* token);
 	    bool OnScript(const char* scriptName, ObjectID objId, bool valid);
 	private:

--- a/Plugins/Optimizations/CacheScriptChunks.cpp
+++ b/Plugins/Optimizations/CacheScriptChunks.cpp
@@ -84,7 +84,7 @@ void CacheScriptChunks()
 }
 
 // No nwscript export, call it manually.
-extern "C" Events::ArgumentStack FlushCachedChunks(Events::ArgumentStack&& args)
+extern "C" ArgumentStack FlushCachedChunks(ArgumentStack&& args)
 {
     const auto scriptChunk = args.extract<std::string>();
 

--- a/Plugins/Optimizations/LuoLookup.cpp
+++ b/Plugins/Optimizations/LuoLookup.cpp
@@ -346,7 +346,7 @@ static BOOL SendServerToPlayerGameObjUpdate(CNWSMessage* msg, CNWSPlayer *pPlaye
 }
 
 // No nwscript export, call it manually.
-extern "C" Events::ArgumentStack SetObjectUpdateDistance(Events::ArgumentStack&& args)
+extern "C" ArgumentStack SetObjectUpdateDistance(ArgumentStack&& args)
 {
     const auto dist = args.extract<float>();
     const auto objtype = args.extract<int32_t>();

--- a/Plugins/Profiler/Profiler.cpp
+++ b/Plugins/Profiler/Profiler.cpp
@@ -159,31 +159,31 @@ Profiler::Profiler(Services::ProxyServiceList* services)
             });
     }
 
-    Events::RegisterEvent(PLUGIN_NAME, "PushPerfScope",
-        [this](Events::ArgumentStack&& args)
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, "PushPerfScope",
+        [this](ArgumentStack&& args)
         {
-            std::string scopeName = Events::ExtractArgument<std::string>(args);
+            std::string scopeName = ScriptAPI::ExtractArgument<std::string>(args);
 
             NWNXLib::Services::MetricData::Tags tags;
 
             while (!args.empty())
             {
                 ASSERT(args.size() >= 2);
-                std::string tag = Events::ExtractArgument<std::string>(args);
-                std::string value = Events::ExtractArgument<std::string>(args);
+                std::string tag = ScriptAPI::ExtractArgument<std::string>(args);
+                std::string value = ScriptAPI::ExtractArgument<std::string>(args);
                 tags.emplace_back(std::make_pair(std::move(tag), std::move(value)));
             }
 
             PushPerfScope(std::move(scopeName), std::move(tags));
-            return Events::Arguments();
+            return ScriptAPI::Arguments();
         });
 
 
-    Events::RegisterEvent(PLUGIN_NAME, "PopPerfScope",
-        [this](Events::ArgumentStack&&)
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, "PopPerfScope",
+        [this](ArgumentStack&&)
         {
             PopPerfScope();
-            return Events::Arguments();
+            return ScriptAPI::Arguments();
         });
 }
 

--- a/Plugins/Race/Race.cpp
+++ b/Plugins/Race/Race.cpp
@@ -62,7 +62,7 @@ Race::Race(Services::ProxyServiceList* services)
     : Plugin(services)
 {
 #define REGISTER(func) \
-    Events::RegisterEvent(PLUGIN_NAME, #func, \
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, #func, \
         [this](ArgumentStack&& args){ return func(std::move(args)); })
 
     REGISTER(SetRacialModifier);
@@ -1155,28 +1155,28 @@ void Race::SetRaceModifier(int32_t raceId, RaceModifier raceMod, int32_t param1,
 
 ArgumentStack Race::SetRacialModifier(ArgumentStack&& args)
 {
-    auto raceId = Events::ExtractArgument<int>(args);
-    auto raceMod = static_cast<RaceModifier>(Events::ExtractArgument<int>(args));
-    auto param1 = Events::ExtractArgument<int>(args);
-    auto param2 = Events::ExtractArgument<int>(args);
-    auto param3 = Events::ExtractArgument<int>(args);
+    auto raceId = ScriptAPI::ExtractArgument<int>(args);
+    auto raceMod = static_cast<RaceModifier>(ScriptAPI::ExtractArgument<int>(args));
+    auto param1 = ScriptAPI::ExtractArgument<int>(args);
+    auto param2 = ScriptAPI::ExtractArgument<int>(args);
+    auto param3 = ScriptAPI::ExtractArgument<int>(args);
 
     SetRaceModifier(raceId, raceMod, param1, param2, param3);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Race::GetParentRace(ArgumentStack&& args)
 {
-    auto raceId = Events::ExtractArgument<int>(args);
+    auto raceId = ScriptAPI::ExtractArgument<int>(args);
     auto parentRace = g_plugin->m_RaceParent[raceId] == RacialType::Invalid ? raceId : g_plugin->m_RaceParent[raceId];
-    return Events::Arguments(parentRace);
+    return ScriptAPI::Arguments(parentRace);
 }
 
 ArgumentStack Race::SetFavoredEnemyFeat(ArgumentStack&& args)
 {
-    auto raceId = Events::ExtractArgument<int>(args);
-    auto featId = Events::ExtractArgument<int>(args);
+    auto raceId = ScriptAPI::ExtractArgument<int>(args);
+    auto featId = ScriptAPI::ExtractArgument<int>(args);
 
     CNWFeat *pFeat = Globals::Rules()->GetFeat(featId);
     ASSERT_OR_THROW(pFeat);
@@ -1185,7 +1185,7 @@ ArgumentStack Race::SetFavoredEnemyFeat(ArgumentStack&& args)
 
     LOG_INFO("%s: Setting Favored Enemy Feat to %s.", Globals::Rules()->m_lstRaces[raceId].GetNameText().CStr(), pFeat->GetNameText().CStr());
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 int32_t Race::GetAttackModifierVersusHook(CNWSCreatureStats* pStats, CNWSCreature* pCreature)

--- a/Plugins/Race/Race.hpp
+++ b/Plugins/Race/Race.hpp
@@ -9,7 +9,7 @@ using namespace std;
 using namespace NWNXLib::API;
 using namespace NWNXLib::Services;
 
-using ArgumentStack = NWNXLib::Events::ArgumentStack;
+using ArgumentStack = NWNXLib::ArgumentStack;
 
 namespace Race {
 

--- a/Plugins/Redis/NWScript.cpp
+++ b/Plugins/Redis/NWScript.cpp
@@ -32,8 +32,8 @@ void Redis::RegisterWithNWScript()
 {
     // NWScript: Executes a raw redis command with a variable argument list.
     // Returns a opaque identifier you can use to access the result
-    Events::RegisterEvent(PLUGIN_NAME, "Deferred",
-            [&](Events::ArgumentStack && arg)
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, "Deferred",
+            [&](ArgumentStack && arg)
             {
                 std::vector<std::string> v;
                 while (!arg.empty())
@@ -51,14 +51,14 @@ void Redis::RegisterWithNWScript()
                 s_results.emplace_back(ret);
 
                 // We return the assigned opaque value. Ignore that this is an array index.
-                return Events::Arguments(static_cast<int32_t>(s_results.size() - 1));
+                return ScriptAPI::Arguments(static_cast<int32_t>(s_results.size() - 1));
             });
 
     // NWScript: Returns the last query result type as a int.
-    Events::RegisterEvent(PLUGIN_NAME, "GetResultType",
-            [&](Events::ArgumentStack && arg)
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, "GetResultType",
+            [&](ArgumentStack && arg)
             {
-                const auto resultId = static_cast<uint32_t>(Events::ExtractArgument<int32_t>(arg));
+                const auto resultId = static_cast<uint32_t>(ScriptAPI::ExtractArgument<int32_t>(arg));
 
                 int type = 0;
                 if (resultId < s_results.size())
@@ -70,15 +70,15 @@ void Redis::RegisterWithNWScript()
                     LOG_ERROR("Result %d was not found. This is a error on your side.", resultId);
                 }
 
-                return Events::Arguments(type);
+                return ScriptAPI::Arguments(type);
             });
 
     // NWScript: Get list length of result. Returns 0 if not a list.
     // N.B: Redis can return multi-list results. This is not handled here
-    Events::RegisterEvent(PLUGIN_NAME, "GetResultArrayLength",
-            [&](Events::ArgumentStack && arg)
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, "GetResultArrayLength",
+            [&](ArgumentStack && arg)
             {
-                const auto resultId = static_cast<uint32_t>(Events::ExtractArgument<int32_t>(arg));
+                const auto resultId = static_cast<uint32_t>(ScriptAPI::ExtractArgument<int32_t>(arg));
 
                 int32_t len = 0;
                 if (resultId < s_results.size() && s_results[resultId].is_array())
@@ -91,15 +91,15 @@ void Redis::RegisterWithNWScript()
                               "This is a error on your side.", resultId);
                 }
 
-                return Events::Arguments(len);
+                return ScriptAPI::Arguments(len);
             });
 
     // NWScript: Get array element as a new result.
-    Events::RegisterEvent(PLUGIN_NAME, "GetResultArrayElement",
-            [&](Events::ArgumentStack && arg)
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, "GetResultArrayElement",
+            [&](ArgumentStack && arg)
             {
-                const auto arrayIndex = static_cast<uint32_t>(Events::ExtractArgument<int32_t>(arg));
-                const auto resultId = static_cast<uint32_t>(Events::ExtractArgument<int32_t>(arg));
+                const auto arrayIndex = static_cast<uint32_t>(ScriptAPI::ExtractArgument<int32_t>(arg));
+                const auto resultId = static_cast<uint32_t>(ScriptAPI::ExtractArgument<int32_t>(arg));
 
                 int32_t newResultId = 0;
                 std::string ret;
@@ -117,14 +117,14 @@ void Redis::RegisterWithNWScript()
                               "This is a error on your side.", resultId, arrayIndex);
                 }
 
-                return Events::Arguments(newResultId);
+                return ScriptAPI::Arguments(newResultId);
             });
 
     // NWScript: Get a result force-cast to string.
-    Events::RegisterEvent(PLUGIN_NAME, "GetResultAsString",
-            [&](Events::ArgumentStack && arg)
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, "GetResultAsString",
+            [&](ArgumentStack && arg)
             {
-                const auto resultId = static_cast<uint32_t>(Events::ExtractArgument<int32_t>(arg));
+                const auto resultId = static_cast<uint32_t>(ScriptAPI::ExtractArgument<int32_t>(arg));
 
                 std::string ret;
 
@@ -139,15 +139,15 @@ void Redis::RegisterWithNWScript()
                               "This is a error on your side.", resultId);
                 }
 
-                return Events::Arguments(ret);
+                return ScriptAPI::Arguments(ret);
             });
 
     // NWScript: Get the last pubsub message.
     // Values returned: channel, message
-    Events::RegisterEvent(PLUGIN_NAME, "GetPubSubData",
-            [&](Events::ArgumentStack &&)
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, "GetPubSubData",
+            [&](ArgumentStack &&)
             {
-                return Events::Arguments(m_internal->m_last_pubsub_channel, m_internal->m_last_pubsub_message);
+                return ScriptAPI::Arguments(m_internal->m_last_pubsub_channel, m_internal->m_last_pubsub_message);
             });
 }
 

--- a/Plugins/Rename/Rename.cpp
+++ b/Plugins/Rename/Rename.cpp
@@ -56,7 +56,7 @@ Rename::Rename(Services::ProxyServiceList* services)
   : Plugin(services)
 {
 #define REGISTER(func)              \
-    Events::RegisterEvent(PLUGIN_NAME, #func, std::bind(&Rename::func, this, std::placeholders::_1))
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, #func, std::bind(&Rename::func, this, std::placeholders::_1))
 
     REGISTER(SetPCNameOverride);
     REGISTER(GetPCNameOverride);
@@ -562,7 +562,7 @@ bool Rename::IsCreatureInLastUpdateObjectList(CNWSPlayer *player, ObjectID creat
 
 ArgumentStack Rename::SetPCNameOverride(ArgumentStack&& args)
 {
-    auto targetOid = Events::ExtractArgument<ObjectID>(args);
+    auto targetOid = ScriptAPI::ExtractArgument<ObjectID>(args);
     if (auto *targetPlayer = player(targetOid))
     {
         auto *server = Globals::AppManager()->m_pServerExoApp;
@@ -570,13 +570,13 @@ ArgumentStack Rename::SetPCNameOverride(ArgumentStack&& args)
         if (targetCreature == nullptr)
         {
             LOG_ERROR("No creature object found for Player ID '0x%08x', oidNWSObject '%x'", targetPlayer->m_nPlayerID, targetOid);
-            return Events::Arguments();
+            return ScriptAPI::Arguments();
         }
-        const auto newName = Events::ExtractArgument<std::string>(args);
-        const auto sPrefix = Events::ExtractArgument<std::string>(args);
-        const auto sSuffix = Events::ExtractArgument<std::string>(args);
-        auto bPlayerNameState = Events::ExtractArgument<int>(args);
-        const auto observerOid = Events::ExtractArgument<ObjectID>(args);
+        const auto newName = ScriptAPI::ExtractArgument<std::string>(args);
+        const auto sPrefix = ScriptAPI::ExtractArgument<std::string>(args);
+        const auto sSuffix = ScriptAPI::ExtractArgument<std::string>(args);
+        auto bPlayerNameState = ScriptAPI::ExtractArgument<int>(args);
+        const auto observerOid = ScriptAPI::ExtractArgument<ObjectID>(args);
 
         if (bPlayerNameState != NWNX_RENAME_PLAYERNAME_DEFAULT && observerOid != Constants::OBJECT_INVALID)
         {
@@ -597,7 +597,7 @@ ArgumentStack Rename::SetPCNameOverride(ArgumentStack&& args)
         if (observerPlayerId == Constants::PLAYERID_INVALIDID)
         {
             LOG_ERROR("The target observer '0x%08x' is not a valid player.", observerPlayerId);
-            return Events::Arguments();
+            return ScriptAPI::Arguments();
         }
 
         std::string fullDisplayName = sPrefix + newName + sSuffix; //put together the floaty/chat/hover name
@@ -621,17 +621,17 @@ ArgumentStack Rename::SetPCNameOverride(ArgumentStack&& args)
         auto &v = m_RenameAddedToPlayerList;
         if (m_RenameOnPlayerList && v.find(targetPlayer->m_oidNWSObject) == v.end())
         {
-            return Events::Arguments();
+            return ScriptAPI::Arguments();
         }
 
         SendNameUpdate(targetCreature, observerPlayerId);
     }
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Rename::GetPCNameOverride(ArgumentStack &&args)
 {
-    auto targetOid = Events::ExtractArgument<ObjectID>(args);
+    auto targetOid = ScriptAPI::ExtractArgument<ObjectID>(args);
     std::string retVal;
     if (auto *targetPlayer = player(targetOid))
     {
@@ -639,22 +639,22 @@ ArgumentStack Rename::GetPCNameOverride(ArgumentStack &&args)
         if (!targetCreature)
         {
             LOG_ERROR("No creature object found for Player %x, oidNWSObject %x", targetPlayer->m_nPlayerID, targetOid);
-            return Events::Arguments();
+            return ScriptAPI::Arguments();
         }
-        auto observerOid = Events::ExtractArgument<ObjectID>(args);
+        auto observerOid = ScriptAPI::ExtractArgument<ObjectID>(args);
         if(m_RenamePlayerNames[targetOid].find(observerOid) != m_RenamePlayerNames[targetOid].end())
             retVal = std::get<0>(m_RenamePlayerNames[targetOid][observerOid]).CStr();
         else if(m_RenamePlayerNames[targetOid].find(Constants::OBJECT_INVALID) != m_RenamePlayerNames[targetOid].end())
             retVal = std::get<0>(m_RenamePlayerNames[targetOid][Constants::OBJECT_INVALID]).CStr();
     }
-    return Events::Arguments(retVal);
+    return ScriptAPI::Arguments(retVal);
 }
 
 ArgumentStack Rename::ClearPCNameOverride(ArgumentStack &&args)
 {
-    auto playerOid = Events::ExtractArgument<ObjectID>(args);
-    auto observerOid = Events::ExtractArgument<ObjectID>(args);
-    bool bClearAll = Events::ExtractArgument<int32_t>(args);
+    auto playerOid = ScriptAPI::ExtractArgument<ObjectID>(args);
+    auto observerOid = ScriptAPI::ExtractArgument<ObjectID>(args);
+    bool bClearAll = ScriptAPI::ExtractArgument<int32_t>(args);
     auto *server = Globals::AppManager()->m_pServerExoApp;
 
     const auto observerPlayerId =
@@ -664,7 +664,7 @@ ArgumentStack Rename::ClearPCNameOverride(ArgumentStack &&args)
     if (observerPlayerId == Constants::PLAYERID_INVALIDID)
     {
         LOG_ERROR("The target observer '0x%08x' is not a valid player.", observerPlayerId);
-        return Events::Arguments();
+        return ScriptAPI::Arguments();
     }
 
     //clears global override for target PC
@@ -702,7 +702,7 @@ ArgumentStack Rename::ClearPCNameOverride(ArgumentStack &&args)
         m_RenamePlayerNames[playerOid].erase(observerOid);
         SendNameUpdate(targetCreature, observerPlayerId);
     }
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 }

--- a/Plugins/Rename/Rename.hpp
+++ b/Plugins/Rename/Rename.hpp
@@ -6,7 +6,7 @@
 using namespace NWNXLib;
 using namespace NWNXLib::API;
 
-using ArgumentStack = NWNXLib::Events::ArgumentStack;
+using ArgumentStack = NWNXLib::ArgumentStack;
 
 namespace Rename {
 

--- a/Plugins/Reveal/Reveal.cpp
+++ b/Plugins/Reveal/Reveal.cpp
@@ -32,7 +32,7 @@ Reveal::Reveal(Services::ProxyServiceList* services)
   : Plugin(services)
 {
 #define REGISTER(func)              \
-    Events::RegisterEvent(PLUGIN_NAME, #func, \
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, #func, \
         [this](ArgumentStack&& args){ return func(std::move(args)); })
 
     REGISTER(RevealTo);
@@ -82,26 +82,26 @@ int32_t Reveal::HookStealthDetection(CNWSCreature* pObserverCreature, CNWSCreatu
 
 ArgumentStack Reveal::RevealTo(ArgumentStack&& args)
 {
-    auto stealtherID = Events::ExtractArgument<ObjectID>(args);
-    auto observerID = Events::ExtractArgument<ObjectID>(args);
-    auto detectionVector = Events::ExtractArgument<int>(args);
+    auto stealtherID = ScriptAPI::ExtractArgument<ObjectID>(args);
+    auto observerID = ScriptAPI::ExtractArgument<ObjectID>(args);
+    auto detectionVector = ScriptAPI::ExtractArgument<int>(args);
 
     auto stealther = Utils::GetGameObject(stealtherID);
     stealther->nwnxSet(revealKey + Utils::ObjectIDToString(observerID), true); //store stealth to observer reveal map
     stealther->nwnxSet(detectionKey + Utils::ObjectIDToString(observerID), detectionVector); //store the means through which detection happens
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Reveal::SetRevealToParty(ArgumentStack&& args)
 {
-    auto stealtherID = Events::ExtractArgument<ObjectID>(args);
-    auto revealToPartyState = Events::ExtractArgument<int>(args);
-    auto detectionVector = Events::ExtractArgument<int>(args);
+    auto stealtherID = ScriptAPI::ExtractArgument<ObjectID>(args);
+    auto revealToPartyState = ScriptAPI::ExtractArgument<int>(args);
+    auto detectionVector = ScriptAPI::ExtractArgument<int>(args);
 
     auto stealther = Utils::GetGameObject(stealtherID);
     stealther->nwnxSet(revealKey + "PARTY", revealToPartyState, true); //store party reveal state
     stealther->nwnxSet(detectionKey + "PARTY", detectionVector, true); //store the means through which detection happens
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 }

--- a/Plugins/Reveal/Reveal.hpp
+++ b/Plugins/Reveal/Reveal.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "nwnx.hpp"
-using ArgumentStack = NWNXLib::Events::ArgumentStack;
+using ArgumentStack = NWNXLib::ArgumentStack;
 
 namespace Reveal {
 

--- a/Plugins/Ruby/Ruby.cpp
+++ b/Plugins/Ruby/Ruby.cpp
@@ -38,7 +38,7 @@ Ruby::Ruby(Services::ProxyServiceList* services)
         SafeRequire(*preloadScript);
     }
 
-    Events::RegisterEvent(PLUGIN_NAME, "Evaluate", std::bind(&Ruby::Evaluate, this, std::placeholders::_1));
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, "Evaluate", std::bind(&Ruby::Evaluate, this, std::placeholders::_1));
 }
 
 Ruby::~Ruby()
@@ -46,9 +46,9 @@ Ruby::~Ruby()
 
 }
 
-Events::ArgumentStack Ruby::Evaluate(Events::ArgumentStack&& args)
+ArgumentStack Ruby::Evaluate(ArgumentStack&& args)
 {
-    const auto code = Events::ExtractArgument<std::string>(args);
+    const auto code = ScriptAPI::ExtractArgument<std::string>(args);
 
     const auto evaluate = [this](const std::string& evalCode) -> const char*
     {
@@ -104,7 +104,7 @@ Events::ArgumentStack Ruby::Evaluate(Events::ArgumentStack&& args)
 
     LOG_INFO("Evaluated Ruby. Ruby ID: '%i', code: '%s', got return value '%s'.", evaluationId, code, retString);
 
-    return Events::Arguments(std::string(retString));
+    return ScriptAPI::Arguments(std::string(retString));
 }
 
 void Ruby::SafeRequire(const std::string& script)

--- a/Plugins/Ruby/Ruby.hpp
+++ b/Plugins/Ruby/Ruby.hpp
@@ -9,7 +9,7 @@ public:
     Ruby(NWNXLib::Services::ProxyServiceList* services);
     virtual ~Ruby();
 
-    NWNXLib::Events::ArgumentStack Evaluate(NWNXLib::Events::ArgumentStack&& args);
+    NWNXLib::ArgumentStack Evaluate(NWNXLib::ArgumentStack&& args);
 
 private:
     bool m_evaluateMetrics;

--- a/Plugins/SQL/SQL.cpp
+++ b/Plugins/SQL/SQL.cpp
@@ -31,7 +31,7 @@ SQL::SQL(Services::ProxyServiceList* services)
 {
 
 #define REGISTER(func) \
-    Events::RegisterEvent(PLUGIN_NAME, #func, \
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, #func, \
         [this](ArgumentStack&& args){ return func(std::move(args)); })
 
     REGISTER(PrepareQuery);
@@ -133,7 +133,7 @@ bool SQL::Reconnect(int32_t attempts)
     return m_target->IsConnected();
 }
 
-Events::ArgumentStack SQL::PrepareQuery(Events::ArgumentStack&& args)
+ArgumentStack SQL::PrepareQuery(ArgumentStack&& args)
 {
     m_activeQuery = args.extract<std::string>();
 
@@ -154,7 +154,7 @@ Events::ArgumentStack SQL::PrepareQuery(Events::ArgumentStack&& args)
     return m_queryPrepared;
 }
 
-Events::ArgumentStack SQL::ExecutePreparedQuery(Events::ArgumentStack&&)
+ArgumentStack SQL::ExecutePreparedQuery(ArgumentStack&&)
 {
     if (!m_queryPrepared)
     {
@@ -240,12 +240,12 @@ Events::ArgumentStack SQL::ExecutePreparedQuery(Events::ArgumentStack&&)
     return querySucceeded ? queryId : 0;
 }
 
-Events::ArgumentStack SQL::ReadyToReadNextRow(Events::ArgumentStack&&)
+ArgumentStack SQL::ReadyToReadNextRow(ArgumentStack&&)
 {
     return m_activeResults.empty() ? 0 : 1;
 }
 
-Events::ArgumentStack SQL::ReadNextRow(Events::ArgumentStack&&)
+ArgumentStack SQL::ReadNextRow(ArgumentStack&&)
 {
     if (m_activeResults.empty())
     {
@@ -257,7 +257,7 @@ Events::ArgumentStack SQL::ReadNextRow(Events::ArgumentStack&&)
     return {};
 }
 
-Events::ArgumentStack SQL::ReadDataInActiveRow(Events::ArgumentStack&& args)
+ArgumentStack SQL::ReadDataInActiveRow(ArgumentStack&& args)
 {
     const size_t column = args.extract<int32_t>();
 
@@ -266,9 +266,9 @@ Events::ArgumentStack SQL::ReadDataInActiveRow(Events::ArgumentStack&& args)
         throw std::runtime_error("Trying to access column outside of range.");
     }
 
-    return Events::Arguments(m_utf8 ? String::FromUTF8(m_activeRow[column]) : m_activeRow[column]);
+    return ScriptAPI::Arguments(m_utf8 ? String::FromUTF8(m_activeRow[column]) : m_activeRow[column]);
 }
-Events::ArgumentStack SQL::PreparedInt(Events::ArgumentStack&& args)
+ArgumentStack SQL::PreparedInt(ArgumentStack&& args)
 {
     const auto position = args.extract<int32_t>();
     const auto value = args.extract<int32_t>();
@@ -282,7 +282,7 @@ Events::ArgumentStack SQL::PreparedInt(Events::ArgumentStack&& args)
     }
     return {};
 }
-Events::ArgumentStack SQL::PreparedString(Events::ArgumentStack&& args)
+ArgumentStack SQL::PreparedString(ArgumentStack&& args)
 {
     const auto position = args.extract<int32_t>();
     const auto value = args.extract<std::string>();
@@ -296,7 +296,7 @@ Events::ArgumentStack SQL::PreparedString(Events::ArgumentStack&& args)
     }
     return {};
 }
-Events::ArgumentStack SQL::PreparedFloat(Events::ArgumentStack&& args)
+ArgumentStack SQL::PreparedFloat(ArgumentStack&& args)
 {
     const auto position = args.extract<int32_t>();
     const auto value = args.extract<float>();
@@ -310,7 +310,7 @@ Events::ArgumentStack SQL::PreparedFloat(Events::ArgumentStack&& args)
     }
     return {};
 }
-Events::ArgumentStack SQL::PreparedObjectId(Events::ArgumentStack&& args)
+ArgumentStack SQL::PreparedObjectId(ArgumentStack&& args)
 {
     auto position = args.extract<int32_t>();
     auto value = args.extract<ObjectID>();
@@ -326,7 +326,7 @@ Events::ArgumentStack SQL::PreparedObjectId(Events::ArgumentStack&& args)
     }
     return {};
 }
-Events::ArgumentStack SQL::PreparedObjectFull(Events::ArgumentStack&& args)
+ArgumentStack SQL::PreparedObjectFull(ArgumentStack&& args)
 {
     auto position = args.extract<int32_t>();
     auto value = args.extract<ObjectID>();
@@ -349,7 +349,7 @@ Events::ArgumentStack SQL::PreparedObjectFull(Events::ArgumentStack&& args)
     }
     return {};
 }
-Events::ArgumentStack SQL::PreparedNULL(Events::ArgumentStack&& args)
+ArgumentStack SQL::PreparedNULL(ArgumentStack&& args)
 {
     auto position = args.extract<int32_t>();
 
@@ -364,7 +364,7 @@ Events::ArgumentStack SQL::PreparedNULL(Events::ArgumentStack&& args)
     return {};
 }
 
-Events::ArgumentStack SQL::ReadFullObjectInActiveRow(Events::ArgumentStack&& args)
+ArgumentStack SQL::ReadFullObjectInActiveRow(ArgumentStack&& args)
 {
     const size_t column = args.extract<int32_t>();
     const auto owner = args.extract<ObjectID>();
@@ -405,29 +405,29 @@ Events::ArgumentStack SQL::ReadFullObjectInActiveRow(Events::ArgumentStack&& arg
     return retval;
 }
 
-Events::ArgumentStack SQL::GetAffectedRows(Events::ArgumentStack&&)
+ArgumentStack SQL::GetAffectedRows(ArgumentStack&&)
 {
     return m_target->GetAffectedRows();
 }
 
-Events::ArgumentStack SQL::GetDatabaseType(Events::ArgumentStack&&)
+ArgumentStack SQL::GetDatabaseType(ArgumentStack&&)
 {
     return Config::Get<std::string>("TYPE", "MYSQL");
 }
 
-Events::ArgumentStack SQL::DestroyPreparedQuery(Events::ArgumentStack&&)
+ArgumentStack SQL::DestroyPreparedQuery(ArgumentStack&&)
 {
     m_target->DestroyPreparedQuery();
     m_queryPrepared = false;
     return {};
 }
 
-Events::ArgumentStack SQL::GetLastError(Events::ArgumentStack&&)
+ArgumentStack SQL::GetLastError(ArgumentStack&&)
 {
     return m_target->GetLastError(true);
 }
 
-Events::ArgumentStack SQL::GetPreparedQueryParamCount(Events::ArgumentStack&&)
+ArgumentStack SQL::GetPreparedQueryParamCount(ArgumentStack&&)
 {
     return m_queryPrepared ? m_target->GetPreparedQueryParamCount() : -1;
 }

--- a/Plugins/SQL/SQL.hpp
+++ b/Plugins/SQL/SQL.hpp
@@ -5,7 +5,7 @@
 
 #include <memory>
 
-using ArgumentStack = NWNXLib::Events::ArgumentStack;
+using ArgumentStack = NWNXLib::ArgumentStack;
 
 namespace SQL {
 

--- a/Plugins/SkillRanks/SkillRanks.cpp
+++ b/Plugins/SkillRanks/SkillRanks.cpp
@@ -46,7 +46,7 @@ SkillRanks::SkillRanks(Services::ProxyServiceList* services)
 {
 
 #define REGISTER(func) \
-    Events::RegisterEvent(PLUGIN_NAME, #func, \
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, #func, \
         [this](ArgumentStack&& args){ return func(std::move(args)); })
 
     REGISTER(GetSkillFeat);
@@ -724,19 +724,19 @@ char SkillRanks::GetSkillRankHook(CNWSCreatureStats* thisPtr, uint8_t nSkill, CN
 
 ArgumentStack SkillRanks::GetSkillFeatCountForSkill(ArgumentStack&& args)
 {
-    const auto skillId = Events::ExtractArgument<int32_t>(args);
+    const auto skillId = ScriptAPI::ExtractArgument<int32_t>(args);
     ASSERT_OR_THROW(skillId >= Constants::Skill::MIN);
     ASSERT_OR_THROW(skillId < Globals::Rules()->m_nNumSkills);
 
-    return Events::Arguments((int32_t)g_plugin->m_skillFeatMap[skillId].size());
+    return ScriptAPI::Arguments((int32_t)g_plugin->m_skillFeatMap[skillId].size());
 }
 
 ArgumentStack SkillRanks::GetSkillFeat(ArgumentStack&& args)
 {
-    const auto skillId = Events::ExtractArgument<int32_t>(args);
+    const auto skillId = ScriptAPI::ExtractArgument<int32_t>(args);
     ASSERT_OR_THROW(skillId >= Constants::Skill::MIN);
     ASSERT_OR_THROW(skillId < Globals::Rules()->m_nNumSkills);
-    const auto featId = Events::ExtractArgument<int32_t>(args);
+    const auto featId = ScriptAPI::ExtractArgument<int32_t>(args);
     ASSERT_OR_THROW(featId >= Constants::Feat::MIN);
     ASSERT_OR_THROW(featId < Globals::Rules()->m_nNumFeats);
 
@@ -747,7 +747,7 @@ ArgumentStack SkillRanks::GetSkillFeat(ArgumentStack&& args)
         std::string sBitClass = skillFeats[featId].bitsetClasses.to_string();
         sBitClass.erase(0, sBitClass.find_first_not_of('0'));
 
-        return Events::Arguments
+        return ScriptAPI::Arguments
         (
             skillFeats[featId].nKeyAbilityMask,
             skillFeats[featId].bBypassArmorCheckPenalty,
@@ -761,15 +761,15 @@ ArgumentStack SkillRanks::GetSkillFeat(ArgumentStack&& args)
         );
     }
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack SkillRanks::GetSkillFeatForSkillByIndex(ArgumentStack&& args)
 {
-    const auto skillId = Events::ExtractArgument<int32_t>(args);
+    const auto skillId = ScriptAPI::ExtractArgument<int32_t>(args);
     ASSERT_OR_THROW(skillId >= Constants::Skill::MIN);
     ASSERT_OR_THROW(skillId < Globals::Rules()->m_nNumSkills);
-    const auto index = Events::ExtractArgument<int32_t>(args);
+    const auto index = ScriptAPI::ExtractArgument<int32_t>(args);
     ASSERT_OR_THROW(index >= 0);
     ASSERT_OR_THROW(index < int32_t(g_plugin->m_skillFeatMap[skillId].size()));
 
@@ -784,7 +784,7 @@ ArgumentStack SkillRanks::GetSkillFeatForSkillByIndex(ArgumentStack&& args)
             std::string sBitClass = skillFeats[featId].bitsetClasses.to_string();
             sBitClass.erase(0, sBitClass.find_first_not_of('0'));
 
-            return Events::Arguments
+            return ScriptAPI::Arguments
             (
                 skillFeats[featId].nKeyAbilityMask,
                 skillFeats[featId].bBypassArmorCheckPenalty,
@@ -802,34 +802,34 @@ ArgumentStack SkillRanks::GetSkillFeatForSkillByIndex(ArgumentStack&& args)
         iterCount++;
     }
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack SkillRanks::SetSkillFeat(ArgumentStack&& args)
 {
-    const auto skillId = Events::ExtractArgument<int32_t>(args);
+    const auto skillId = ScriptAPI::ExtractArgument<int32_t>(args);
     ASSERT_OR_THROW(skillId >= Constants::Skill::MIN);
     ASSERT_OR_THROW(skillId < Globals::Rules()->m_nNumSkills);
-    const auto featId = Events::ExtractArgument<int32_t>(args);
+    const auto featId = ScriptAPI::ExtractArgument<int32_t>(args);
     ASSERT_OR_THROW(featId >= Constants::Feat::MIN);
     ASSERT_OR_THROW(featId < Globals::Rules()->m_nNumFeats);
 
     SkillFeats skillFeats {};
-    skillFeats.nModifier = Events::ExtractArgument<int32_t>(args);
-    skillFeats.nFocusFeat = Events::ExtractArgument<int32_t>(args);
-    std::bitset<255> cbs(Events::ExtractArgument<std::string>(args));
+    skillFeats.nModifier = ScriptAPI::ExtractArgument<int32_t>(args);
+    skillFeats.nFocusFeat = ScriptAPI::ExtractArgument<int32_t>(args);
+    std::bitset<255> cbs(ScriptAPI::ExtractArgument<std::string>(args));
     skillFeats.bitsetClasses = cbs;
 
     // If fClassLevelMod is not 0 and bitsetClasses is unset then we set it for all classes
-    skillFeats.fClassLevelMod = Events::ExtractArgument<float>(args);
+    skillFeats.fClassLevelMod = ScriptAPI::ExtractArgument<float>(args);
     if (skillFeats.fClassLevelMod != 0 && skillFeats.bitsetClasses.none())
         skillFeats.bitsetClasses.set();
 
-    skillFeats.nAreaFlagsRequired = Events::ExtractArgument<int32_t>(args);
-    skillFeats.nAreaFlagsForbidden = Events::ExtractArgument<int32_t>(args);
-    skillFeats.nDayOrNight = Events::ExtractArgument<int32_t>(args);
-    skillFeats.bBypassArmorCheckPenalty = Events::ExtractArgument<int32_t>(args);
-    skillFeats.nKeyAbilityMask = Events::ExtractArgument<int32_t>(args);
+    skillFeats.nAreaFlagsRequired = ScriptAPI::ExtractArgument<int32_t>(args);
+    skillFeats.nAreaFlagsForbidden = ScriptAPI::ExtractArgument<int32_t>(args);
+    skillFeats.nDayOrNight = ScriptAPI::ExtractArgument<int32_t>(args);
+    skillFeats.bBypassArmorCheckPenalty = ScriptAPI::ExtractArgument<int32_t>(args);
+    skillFeats.nKeyAbilityMask = ScriptAPI::ExtractArgument<int32_t>(args);
 
     // If they supplied an ability but didn't supply a calc mask bit, use MAX
     if (skillFeats.nKeyAbilityMask &&
@@ -842,7 +842,7 @@ ArgumentStack SkillRanks::SetSkillFeat(ArgumentStack&& args)
         skillFeats.nKeyAbilityMask |= maxMask;
     }
 
-    const auto createIfNonExistent = Events::ExtractArgument<int32_t>(args);
+    const auto createIfNonExistent = ScriptAPI::ExtractArgument<int32_t>(args);
     if (!createIfNonExistent && !g_plugin->m_skillFeatMap[skillId].count(featId))
     {
         LOG_ERROR("Attempt to set values on a Skill Feat that doesn't exist.");
@@ -852,13 +852,13 @@ ArgumentStack SkillRanks::SetSkillFeat(ArgumentStack&& args)
         g_plugin->m_skillFeatMap[skillId][featId] = skillFeats;
     }
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack SkillRanks::SetSkillFeatFocusModifier(ArgumentStack&& args)
 {
-    const auto mod = Events::ExtractArgument<int32_t>(args);
-    const auto epicFocus = Events::ExtractArgument<int32_t>(args);
+    const auto mod = ScriptAPI::ExtractArgument<int32_t>(args);
+    const auto epicFocus = ScriptAPI::ExtractArgument<int32_t>(args);
 
     for (int nSkill = 0; nSkill < Globals::Rules()->m_nNumSkills; nSkill++)
     {
@@ -874,61 +874,61 @@ ArgumentStack SkillRanks::SetSkillFeatFocusModifier(ArgumentStack&& args)
         }
     }
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack SkillRanks::GetAreaModifier(ArgumentStack&& args)
 {
-    const auto areaOid = Events::ExtractArgument<ObjectID>(args);
+    const auto areaOid = ScriptAPI::ExtractArgument<ObjectID>(args);
     auto *pArea = Globals::AppManager()->m_pServerExoApp->GetAreaByGameObjectID(areaOid);
     if (!pArea)
     {
         LOG_ERROR("GetAreaModifier function called on non-area object %x", areaOid);
-        return Events::Arguments();
+        return ScriptAPI::Arguments();
     }
-    const auto skillId = Events::ExtractArgument<int32_t>(args);
+    const auto skillId = ScriptAPI::ExtractArgument<int32_t>(args);
     ASSERT_OR_THROW(skillId >= Constants::Skill::MIN);
     ASSERT_OR_THROW(skillId < Globals::Rules()->m_nNumSkills);
 
     int32_t retVal = *pArea->nwnxGet<int>(areaModPOSKey + std::to_string(skillId));
 
-    return Events::Arguments(retVal);
+    return ScriptAPI::Arguments(retVal);
 }
 
 ArgumentStack SkillRanks::SetAreaModifier(ArgumentStack&& args)
 {
-    const auto areaOid = Events::ExtractArgument<ObjectID>(args);
+    const auto areaOid = ScriptAPI::ExtractArgument<ObjectID>(args);
     auto *pArea = Globals::AppManager()->m_pServerExoApp->GetAreaByGameObjectID(areaOid);
     if (!pArea)
     {
         LOG_ERROR("SetAreaModifier function called on non-area object %x", areaOid);
-        return Events::Arguments();
+        return ScriptAPI::Arguments();
     }
-    const auto skillId = Events::ExtractArgument<int32_t>(args);
+    const auto skillId = ScriptAPI::ExtractArgument<int32_t>(args);
     ASSERT_OR_THROW(skillId >= Constants::Skill::MIN);
     ASSERT_OR_THROW(skillId < Globals::Rules()->m_nNumSkills);
-    const auto modifier = Events::ExtractArgument<int32_t>(args);
+    const auto modifier = ScriptAPI::ExtractArgument<int32_t>(args);
     ASSERT_OR_THROW(modifier >= -127);
     ASSERT_OR_THROW(modifier < 127);
 
     pArea->nwnxSet(areaModPOSKey + std::to_string(skillId), modifier, true);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack SkillRanks::GetBlindnessPenalty(ArgumentStack &&)
 {
-    return Events::Arguments(g_plugin->m_blindnessMod);
+    return ScriptAPI::Arguments(g_plugin->m_blindnessMod);
 }
 
 ArgumentStack SkillRanks::SetBlindnessPenalty(ArgumentStack &&args)
 {
-    const auto mod = Events::ExtractArgument<int32_t>(args);
+    const auto mod = ScriptAPI::ExtractArgument<int32_t>(args);
     ASSERT_OR_THROW(mod >= -255);
     ASSERT_OR_THROW(mod < 255);
     g_plugin->m_blindnessMod = mod;
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 }

--- a/Plugins/SkillRanks/SkillRanks.hpp
+++ b/Plugins/SkillRanks/SkillRanks.hpp
@@ -4,7 +4,7 @@
 #include <bitset>
 #include <map>
 
-using ArgumentStack = NWNXLib::Events::ArgumentStack;
+using ArgumentStack = NWNXLib::ArgumentStack;
 
 namespace SkillRanks {
 

--- a/Plugins/SpellChecker/SpellChecker.cpp
+++ b/Plugins/SpellChecker/SpellChecker.cpp
@@ -28,7 +28,7 @@ SpellChecker::SpellChecker(Services::ProxyServiceList* services)
 {
 
 #define REGISTER(func) \
-    Events::RegisterEvent(PLUGIN_NAME, #func, \
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, #func, \
         [this](ArgumentStack&& args){ return func(std::move(args)); })
 
     REGISTER(FindMisspell);
@@ -81,7 +81,7 @@ void SpellChecker::Init()
 }
 ArgumentStack SpellChecker::FindMisspell(ArgumentStack&& args)
 {
-    std::string sentence = Events::ExtractArgument<std::string>(args);
+    std::string sentence = ScriptAPI::ExtractArgument<std::string>(args);
 
     std::string  word;
     std::vector <std::string> list;
@@ -105,12 +105,12 @@ ArgumentStack SpellChecker::FindMisspell(ArgumentStack&& args)
             output += list[i] + ",";
     }
 
-    return Events::Arguments(output);
+    return ScriptAPI::Arguments(output);
 }
 
 ArgumentStack SpellChecker::GetSuggestSpell(ArgumentStack&& args)
 {
-    std::string word = Events::ExtractArgument<std::string>(args);
+    std::string word = ScriptAPI::ExtractArgument<std::string>(args);
 
     const char* cword;
     int sc;
@@ -130,7 +130,7 @@ ArgumentStack SpellChecker::GetSuggestSpell(ArgumentStack&& args)
             SpellChecker::free_e(SpellChecker::created, &wlst, ns);
         }
     }
-    return Events::Arguments(output);
+    return ScriptAPI::Arguments(output);
 }
 
 

--- a/Plugins/SpellChecker/SpellChecker.hpp
+++ b/Plugins/SpellChecker/SpellChecker.hpp
@@ -4,7 +4,7 @@
 #include <iostream>
 
 
-using ArgumentStack = NWNXLib::Events::ArgumentStack;
+using ArgumentStack = NWNXLib::ArgumentStack;
 using HandleType = void*;
 
 namespace SpellChecker {

--- a/Plugins/Weapon/Weapon.cpp
+++ b/Plugins/Weapon/Weapon.cpp
@@ -27,7 +27,7 @@ Weapon::Weapon(Services::ProxyServiceList* services)
   : Plugin(services)
 {
 #define REGISTER(func) \
-    Events::RegisterEvent(PLUGIN_NAME, #func, \
+    ScriptAPI::RegisterEvent(PLUGIN_NAME, #func, \
         [this](ArgumentStack&& args){ return func(std::move(args)); })
 
     REGISTER(SetWeaponFocusFeat);
@@ -84,10 +84,10 @@ Weapon::~Weapon()
 
 ArgumentStack Weapon::SetWeaponFocusFeat(ArgumentStack&& args)
 {
-    const auto w_bitem  = Events::ExtractArgument<int32_t>(args);
+    const auto w_bitem  = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(w_bitem >= Constants::BaseItem::MIN);
       ASSERT_OR_THROW(w_bitem <= Constants::BaseItem::MAX);
-    const auto feat     = Events::ExtractArgument<int32_t>(args);
+    const auto feat     = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(feat >= Constants::Feat::MIN);
       ASSERT_OR_THROW(feat <= Constants::Feat::MAX);
 
@@ -109,15 +109,15 @@ ArgumentStack Weapon::SetWeaponFocusFeat(ArgumentStack&& args)
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Weapon Focus Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::SetGreaterWeaponFocusFeat(ArgumentStack&& args)
 {
-    const auto w_bitem  = Events::ExtractArgument<int32_t>(args);
+    const auto w_bitem  = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(w_bitem >= Constants::BaseItem::MIN);
       ASSERT_OR_THROW(w_bitem <= Constants::BaseItem::MAX);
-    const auto feat     = Events::ExtractArgument<int32_t>(args);
+    const auto feat     = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(feat >= Constants::Feat::MIN);
       ASSERT_OR_THROW(feat <= Constants::Feat::MAX);
 
@@ -139,15 +139,15 @@ ArgumentStack Weapon::SetGreaterWeaponFocusFeat(ArgumentStack&& args)
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Greater Weapon Focus Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::SetEpicWeaponFocusFeat(ArgumentStack&& args)
 {
-    const auto w_bitem  = Events::ExtractArgument<int32_t>(args);
+    const auto w_bitem  = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(w_bitem >= Constants::BaseItem::MIN);
       ASSERT_OR_THROW(w_bitem <= Constants::BaseItem::MAX);
-    const auto feat     = Events::ExtractArgument<int32_t>(args);
+    const auto feat     = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(feat >= Constants::Feat::MIN);
       ASSERT_OR_THROW(feat <= Constants::Feat::MAX);
 
@@ -169,15 +169,15 @@ ArgumentStack Weapon::SetEpicWeaponFocusFeat(ArgumentStack&& args)
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Epic Weapon Focus Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::SetWeaponFinesseSize(ArgumentStack&& args)
 {
-    const auto w_bitem  = Events::ExtractArgument<int32_t>(args);
+    const auto w_bitem  = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(w_bitem >= Constants::BaseItem::MIN);
       ASSERT_OR_THROW(w_bitem <= Constants::BaseItem::MAX);
-    const auto size     = Events::ExtractArgument<int32_t>(args);
+    const auto size     = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(size > 0);
       ASSERT_OR_THROW(size <= 255);
 
@@ -188,14 +188,14 @@ ArgumentStack Weapon::SetWeaponFinesseSize(ArgumentStack&& args)
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Weapon Finesse Size %d added for Base Item Type %d [%s]", size, w_bitem, baseItemName);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::GetWeaponFinesseSize(ArgumentStack&& args)
 {
     int32_t retVal = -1;
 
-    const auto baseItem  = Events::ExtractArgument<int32_t>(args);
+    const auto baseItem  = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(baseItem >= Constants::BaseItem::MIN);
       ASSERT_OR_THROW(baseItem <= Constants::BaseItem::MAX);
 
@@ -203,12 +203,12 @@ ArgumentStack Weapon::GetWeaponFinesseSize(ArgumentStack&& args)
     if (search != m_WeaponFinesseSizeMap.end())
         retVal = search->second;
 
-    return Events::Arguments(retVal);
+    return ScriptAPI::Arguments(retVal);
 }
 
 ArgumentStack Weapon::SetWeaponUnarmed(ArgumentStack&& args)
 {
-    const auto w_bitem  = Events::ExtractArgument<int32_t>(args);
+    const auto w_bitem  = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(w_bitem >= Constants::BaseItem::MIN);
       ASSERT_OR_THROW(w_bitem <= Constants::BaseItem::MAX);
 
@@ -219,12 +219,12 @@ ArgumentStack Weapon::SetWeaponUnarmed(ArgumentStack&& args)
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Base Item Type %d [%s] set as unarmed weapon", w_bitem, baseItemName);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::SetWeaponIsMonkWeapon(ArgumentStack&& args)
 {
-    const auto w_bitem  = Events::ExtractArgument<int32_t>(args);
+    const auto w_bitem  = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(w_bitem >= Constants::BaseItem::MIN);
       ASSERT_OR_THROW(w_bitem <= Constants::BaseItem::MAX);
 
@@ -237,15 +237,15 @@ ArgumentStack Weapon::SetWeaponIsMonkWeapon(ArgumentStack&& args)
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Base Item Type %d [%s] set as monk weapon", w_bitem, baseItemName);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::SetWeaponImprovedCriticalFeat(ArgumentStack&& args)
 {
-    const auto w_bitem  = Events::ExtractArgument<int32_t>(args);
+    const auto w_bitem  = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(w_bitem >= Constants::BaseItem::MIN);
       ASSERT_OR_THROW(w_bitem <= Constants::BaseItem::MAX);
-    const auto feat     = Events::ExtractArgument<int32_t>(args);
+    const auto feat     = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(feat >= Constants::Feat::MIN);
       ASSERT_OR_THROW(feat <= Constants::Feat::MAX);
 
@@ -267,15 +267,15 @@ ArgumentStack Weapon::SetWeaponImprovedCriticalFeat(ArgumentStack&& args)
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Improved Critical Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::SetWeaponSpecializationFeat(ArgumentStack&& args)
 {
-    const auto w_bitem  = Events::ExtractArgument<int32_t>(args);
+    const auto w_bitem  = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(w_bitem >= Constants::BaseItem::MIN);
       ASSERT_OR_THROW(w_bitem <= Constants::BaseItem::MAX);
-    const auto feat     = Events::ExtractArgument<int32_t>(args);
+    const auto feat     = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(feat >= Constants::Feat::MIN);
       ASSERT_OR_THROW(feat <= Constants::Feat::MAX);
 
@@ -297,15 +297,15 @@ ArgumentStack Weapon::SetWeaponSpecializationFeat(ArgumentStack&& args)
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Weapon Specialization Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::SetGreaterWeaponSpecializationFeat(ArgumentStack&& args)
 {
-    const auto w_bitem  = Events::ExtractArgument<int32_t>(args);
+    const auto w_bitem  = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(w_bitem >= Constants::BaseItem::MIN);
       ASSERT_OR_THROW(w_bitem <= Constants::BaseItem::MAX);
-    const auto feat     = Events::ExtractArgument<int32_t>(args);
+    const auto feat     = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(feat >= Constants::Feat::MIN);
       ASSERT_OR_THROW(feat <= Constants::Feat::MAX);
 
@@ -327,15 +327,15 @@ ArgumentStack Weapon::SetGreaterWeaponSpecializationFeat(ArgumentStack&& args)
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Greater Weapon Specialization Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::SetEpicWeaponSpecializationFeat(ArgumentStack&& args)
 {
-    const auto w_bitem  = Events::ExtractArgument<int32_t>(args);
+    const auto w_bitem  = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(w_bitem >= Constants::BaseItem::MIN);
       ASSERT_OR_THROW(w_bitem <= Constants::BaseItem::MAX);
-    const auto feat     = Events::ExtractArgument<int32_t>(args);
+    const auto feat     = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(feat >= Constants::Feat::MIN);
       ASSERT_OR_THROW(feat <= Constants::Feat::MAX);
 
@@ -357,15 +357,15 @@ ArgumentStack Weapon::SetEpicWeaponSpecializationFeat(ArgumentStack&& args)
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Epic Weapon Specialization Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::SetEpicWeaponOverwhelmingCriticalFeat(ArgumentStack&& args)
 {
-    const auto w_bitem  = Events::ExtractArgument<int32_t>(args);
+    const auto w_bitem  = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(w_bitem >= Constants::BaseItem::MIN);
       ASSERT_OR_THROW(w_bitem <= Constants::BaseItem::MAX);
-    const auto feat     = Events::ExtractArgument<int32_t>(args);
+    const auto feat     = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(feat >= Constants::Feat::MIN);
       ASSERT_OR_THROW(feat <= Constants::Feat::MAX);
 
@@ -387,15 +387,15 @@ ArgumentStack Weapon::SetEpicWeaponOverwhelmingCriticalFeat(ArgumentStack&& args
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Overwhelming Critical Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::SetEpicWeaponDevastatingCriticalFeat(ArgumentStack&& args)
 {
-    const auto w_bitem  = Events::ExtractArgument<int32_t>(args);
+    const auto w_bitem  = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(w_bitem >= Constants::BaseItem::MIN);
       ASSERT_OR_THROW(w_bitem <= Constants::BaseItem::MAX);
-    const auto feat     = Events::ExtractArgument<int32_t>(args);
+    const auto feat     = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(feat >= Constants::Feat::MIN);
       ASSERT_OR_THROW(feat <= Constants::Feat::MAX);
 
@@ -417,15 +417,15 @@ ArgumentStack Weapon::SetEpicWeaponDevastatingCriticalFeat(ArgumentStack&& args)
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Devastating Critical Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::SetWeaponOfChoiceFeat(ArgumentStack&& args)
 {
-    const auto w_bitem  = Events::ExtractArgument<int32_t>(args);
+    const auto w_bitem  = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(w_bitem >= Constants::BaseItem::MIN);
       ASSERT_OR_THROW(w_bitem <= Constants::BaseItem::MAX);
-    const auto feat     = Events::ExtractArgument<int32_t>(args);
+    const auto feat     = ScriptAPI::ExtractArgument<int32_t>(args);
       ASSERT_OR_THROW(feat >= Constants::Feat::MIN);
       ASSERT_OR_THROW(feat <= Constants::Feat::MAX);
 
@@ -447,13 +447,13 @@ ArgumentStack Weapon::SetWeaponOfChoiceFeat(ArgumentStack&& args)
     auto baseItemName = pBaseItem->GetNameText();
     LOG_INFO("Weapon of Choice Feat %d [%s] added for Base Item Type %d [%s]", feat, featName, w_bitem, baseItemName);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::SetOption(ArgumentStack&& args)
 {
-    const auto nOption  = Events::ExtractArgument<int32_t>(args);
-    const auto nVal     = Events::ExtractArgument<int32_t>(args);
+    const auto nOption  = ScriptAPI::ExtractArgument<int32_t>(args);
+    const auto nVal     = ScriptAPI::ExtractArgument<int32_t>(args);
 
     switch(nOption)
     {
@@ -466,34 +466,34 @@ ArgumentStack Weapon::SetOption(ArgumentStack&& args)
             LOG_INFO("Set NWNX_WEAPON_OPT_GRTSPEC_DAM_BONUS to %d", nVal);
             break;
     }
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::SetDevastatingCriticalEventScript(ArgumentStack&& args)
 {
-    m_DCScript = Events::ExtractArgument<std::string>(args);
+    m_DCScript = ScriptAPI::ExtractArgument<std::string>(args);
     LOG_INFO("Set Devastating Critical Event Script to %s", m_DCScript);
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::GetEventData(ArgumentStack&& args)
 {
-    const auto nOption  = Events::ExtractArgument<int32_t>(args);
+    const auto nOption  = ScriptAPI::ExtractArgument<int32_t>(args);
 
     switch(nOption)
     {
         case NWNX_WEAPON_GETDATA_DC:
-            return Events::Arguments(m_DCData.nDamage, m_DCData.oidTarget, m_DCData.oidWeapon);
+            return ScriptAPI::Arguments(m_DCData.nDamage, m_DCData.oidTarget, m_DCData.oidWeapon);
     }
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::SetEventData(ArgumentStack&& args)
 {
-    const auto nOption  = Events::ExtractArgument<int32_t>(args);
-    const auto nVal     = Events::ExtractArgument<int32_t>(args);
+    const auto nOption  = ScriptAPI::ExtractArgument<int32_t>(args);
+    const auto nVal     = ScriptAPI::ExtractArgument<int32_t>(args);
 
     switch(nOption)
     {
@@ -503,7 +503,7 @@ ArgumentStack Weapon::SetEventData(ArgumentStack&& args)
             break;
     }
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 int32_t Weapon::GetWeaponFocus(CNWSCreatureStats* pStats, CNWSItem* pWeapon)
@@ -1205,16 +1205,16 @@ int Weapon::GetLevelByClass(CNWSCreatureStats *pStats, uint32_t nClassType)
 
 ArgumentStack Weapon::SetOneHalfStrength(ArgumentStack&& args)
 {
-    auto objectId = Events::ExtractArgument<ObjectID>(args);
+    auto objectId = ScriptAPI::ExtractArgument<ObjectID>(args);
 
     if(objectId == Constants::OBJECT_INVALID)
     {
         LOG_INFO("Invalid Object Passed into SetOneHalfStrength");
-        return Events::Arguments();
+        return ScriptAPI::Arguments();
     }
 
-    auto bMulti = Events::ExtractArgument<int32_t>(args);
-    bool bPersist = !!Events::ExtractArgument<int32_t>(args);
+    auto bMulti = ScriptAPI::ExtractArgument<int32_t>(args);
+    bool bPersist = !!ScriptAPI::ExtractArgument<int32_t>(args);
 
     auto obj = Utils::GetGameObject(objectId);
     if(bMulti)
@@ -1222,12 +1222,12 @@ ArgumentStack Weapon::SetOneHalfStrength(ArgumentStack&& args)
     else
         obj->nwnxRemove("ONE_HALF_STRENGTH");
 
-    return Events::Arguments();
+    return ScriptAPI::Arguments();
 }
 
 ArgumentStack Weapon::GetOneHalfStrength(ArgumentStack&& args)
 {
-    auto objectId = Events::ExtractArgument<ObjectID>(args);
+    auto objectId = ScriptAPI::ExtractArgument<ObjectID>(args);
     int32_t retVal = 0;
     if(objectId != Constants::OBJECT_INVALID)
     {
@@ -1237,7 +1237,7 @@ ArgumentStack Weapon::GetOneHalfStrength(ArgumentStack&& args)
             retVal = exist.value();
     }
 
-    return Events::Arguments(retVal);
+    return ScriptAPI::Arguments(retVal);
 }
 
 ArgumentStack Weapon::SetMaxRangedAttackDistanceOverride(ArgumentStack&& args)

--- a/Plugins/Weapon/Weapon.hpp
+++ b/Plugins/Weapon/Weapon.hpp
@@ -28,7 +28,7 @@ struct MaxRangedAttackDistanceOverride
     float maxRangedPassiveAttackDistance;
 };
 
-using ArgumentStack = NWNXLib::Events::ArgumentStack;
+using ArgumentStack = NWNXLib::ArgumentStack;
 
 namespace Weapon {
 


### PR DESCRIPTION
`Events` was in the way. This renames all occurrences to `ScriptAPI`.

A followup change chould update NWNX_Events to pull the memory map and pubsub stuff into Core (leaving only the NWScript API and various hook in the plugin?)

Diff should also apply cleanly on .35, if you want to pull it in there right away.