### PR TITLE
Add SWIG comment stripping for macros.

### DIFF
--- a/Plugins/SWIG/CMakeLists.txt
+++ b/Plugins/SWIG/CMakeLists.txt
@@ -5,7 +5,7 @@ function(add_swig_plugin target language interfaces)
         OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${target}/NWNXLib.i
         DEPENDS Core
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/generate.sh
-        COMMAND chmod a+x ../generate.sh && mkdir -p ./out && ../generate.sh
+        COMMAND chmod a+x ../generate.sh && ../generate.sh
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${target}
     )
 
@@ -13,7 +13,7 @@ function(add_swig_plugin target language interfaces)
     set_property(SOURCE ${interfaces} PROPERTY DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${target}/NWNXLib.i)
     set_property(SOURCE ${interfaces} PROPERTY COMPILE_OPTIONS ${ARGN})
 
-    swig_add_library(${target} TYPE SHARED LANGUAGE ${language} SOURCES ${interfaces})
+    swig_add_library(${target} TYPE SHARED LANGUAGE ${language} SOURCES ${interfaces} OUTPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${target}/out )
     configure_plugin(${target})
 
     set_target_properties(${target} PROPERTIES
@@ -22,6 +22,11 @@ function(add_swig_plugin target language interfaces)
       POSITION_INDEPENDENT_CODE ON)
 
     target_link_options(${target} PRIVATE "LINKER:--no-undefined,--no-demangle")
+
+    add_custom_command(TARGET ${target}_swig_compilation POST_BUILD
+            COMMAND chmod a+x postprocess.sh && ./postprocess.sh
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${target}
+    )
 endfunction()
 
 if(SWIG_FOUND)

--- a/Plugins/SWIG/SWIG_DotNET/postprocess.sh
+++ b/Plugins/SWIG/SWIG_DotNET/postprocess.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+#Cleanup macro comments left by SWIG.
+for f in out/*.cs
+do
+  sed -i '/^[ \t]*\/\*@SWIG/d' "$f"
+done


### PR DESCRIPTION
This PR strips the macro comments added by SWIG causing different outputs based on where it is built:

E.g:
```cs
/*@SWIG:/__w/NWN.Native/NWN.Native/nwnx/Plugins/SWIG/SWIG_DotNET/DotNETExtensions.i,1,SWIG_DOTNET_EXTENSIONS@*/
  public global::System.IntPtr Pointer {
    get {
      return swigCPtr.Handle;
    }
  }
```