### PR TITLE
SWIG: Replace comment contents only instead of whole line.

### DIFF
--- a/Plugins/SWIG/SWIG_DotNET/postprocess.sh
+++ b/Plugins/SWIG/SWIG_DotNET/postprocess.sh
@@ -3,5 +3,5 @@
 #Cleanup macro comments left by SWIG.
 for f in out/*.cs
 do
-  sed -i '/^[ \t]*\/\*@SWIG/d' "$f"
+  sed -i 's/\/\*@SWIG.*\*\///' "$f"
 done


### PR DESCRIPTION
Fixes replaced partial line comments from becoming uncompilable code:
```cs
/*@SWIG@*/}

}
```