### PR TITLE
[8193.35] Fix SWIG plugin compile. Add optional undefined symbol check.

### DIFF
--- a/NWNXLib/API/API/CLastUpdateObject.hpp
+++ b/NWNXLib/API/API/CLastUpdateObject.hpp
@@ -126,7 +126,6 @@ struct CLastUpdateObject
 
     CLastUpdateObject();
     ~CLastUpdateObject();
-    const ObjectVisualTransformData & GetVisualTransformData();
     void SetVisualTransformData(const ObjectVisualTransformData & data);
     void InitializeQuickbar();
 

--- a/NWNXLib/API/API/CNWSCreatureAppearanceInfo.hpp
+++ b/NWNXLib/API/API/CNWSCreatureAppearanceInfo.hpp
@@ -38,10 +38,6 @@ struct CNWSCreatureAppearanceInfo
     ObjectVisualTransformData m_pRightHandItemVisualTransform;
     ObjectVisualTransformData m_pLeftHandItemVisualTransform;
 
-    CNWSCreatureAppearanceInfo();
-    void Clear();
-
-
 #ifdef NWN_CLASS_EXTENSION_CNWSCreatureAppearanceInfo
     NWN_CLASS_EXTENSION_CNWSCreatureAppearanceInfo
 #endif

--- a/NWNXLib/API/API/CNWSMessage.hpp
+++ b/NWNXLib/API/API/CNWSMessage.hpp
@@ -143,7 +143,6 @@ struct CNWSMessage : CNWMessage
     BOOL SendServerToPlayerArea_SetName(CNWSPlayer * player, OBJECT_ID oidArea);
     BOOL SendServerToPlayerArea_Destroyed(CNWSPlayer * player, OBJECT_ID oidArea);
     BOOL SendServerToPlayerUpdateSkyBox(int32_t nSkyBox, OBJECT_ID oidArea);
-    BOOL SendServerToPlayerUpdateFogColor(uint32_t nSunFogColor, uint32_t nMoonFogColor, OBJECT_ID oidArea);
     BOOL SendServerToPlayerUpdateFogAmount(uint8_t nSunFogAmount, uint8_t nMoonFogAmount, OBJECT_ID oidArea);
     BOOL SendServerToPlayerArea_UpdateWind(CNWSPlayer * pPlayer, Vector vDirection, float fMagnitude, float fYaw, float fPitch);
     BOOL SendServerToPlayerSetCustomToken(uint32_t nPlayerID, int32_t nCustomTokenNumber, const CExoString & sTokenValue);
@@ -336,7 +335,6 @@ struct CNWSMessage : CNWMessage
     BOOL SendServerToPlayerPolymorph(CNWSPlayer * pPlayer, OBJECT_ID oidMorpher, BOOL bMorphing, BOOL bAllowCancel);
     BOOL HandlePlayerToServerCutscene(CNWSPlayer * pPlayer, uint8_t nMinor);
     BOOL HandlePlayerToServerPlayerList(CNWSPlayer * pPlayer, uint8_t nMinor);
-    BOOL SendServerToPlayerGuiEvent_Disable(uint32_t nPlayerId, int32_t nGuiElement, BOOL bDisable);
     BOOL HandlePlayerToServerDevice(CNWSPlayer * pPlayer, uint8_t nMinor);
     //BOOL SendServerToPlayerNui_Create(CNWSPlayer * pPlayer, Nui::JSON::WindowToken cToken, Nui::JSON::WindowIdentifier sId, const json & jData);
     BOOL SendServerToPlayerNui_CreateClient(CNWSPlayer * pPlayer, Nui::JSON::WindowToken cToken, Nui::JSON::WindowIdentifier sId, const CResRef & cResRef);

--- a/NWNXLib/API/API/CNWSPlayerLUOAppearanceInfo.hpp
+++ b/NWNXLib/API/API/CNWSPlayerLUOAppearanceInfo.hpp
@@ -38,9 +38,6 @@ struct CNWSPlayerLUOAppearanceInfo
     ObjectVisualTransformData m_pRightHandItemVisualTransform;
     ObjectVisualTransformData m_pLeftHandItemVisualTransform;
 
-    CNWSPlayerLUOAppearanceInfo();
-    void Clear();
-
 #ifdef NWN_CLASS_EXTENSION_CNWSPlayerLUOAppearanceInfo
     NWN_CLASS_EXTENSION_CNWSPlayerLUOAppearanceInfo
 #endif

--- a/NWNXLib/API/API/CRes.hpp
+++ b/NWNXLib/API/API/CRes.hpp
@@ -44,7 +44,6 @@ struct CRes
     virtual BOOL OnResourceFreed();
     virtual BOOL OnResourceServiced();
     int32_t Release();
-    int32_t Request();
     void SetID(RESID nNewID);
 
 

--- a/NWNXLib/API/API/LerpFloat.hpp
+++ b/NWNXLib/API/API/LerpFloat.hpp
@@ -118,8 +118,6 @@ struct LerpFloat
     float Progress() const { return 1.0; }
     float Lerped() const { return m_value_to; }
 
-    void WriteGFF(CResGFF* pRes, CResStruct* pStruct, char* szLabel);
-
     void AssignStatic(float to)
     {
         m_value_to = to;

--- a/Plugins/SWIG/CMakeLists.txt
+++ b/Plugins/SWIG/CMakeLists.txt
@@ -16,6 +16,14 @@ function(add_swig_plugin target language interfaces)
     swig_add_library(${target} TYPE SHARED LANGUAGE ${language} SOURCES ${interfaces})
     configure_plugin(${target})
 
+    # By adding nwserver-linux to the SWIG directory, we can check for any undefined symbols from mismatching headers.
+    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/nwserver-linux)
+        add_library( nwserver SHARED IMPORTED )
+        set_target_properties( nwserver PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/nwserver-linux )
+        target_link_libraries(${target} nwserver)
+        target_link_options(${target} PRIVATE "LINKER:--no-undefined")
+    endif()
+
     set_target_properties(${target} PROPERTIES
       SWIG_INCLUDE_DIRECTORIES ../../../NWNXLib/API
       SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON

--- a/Plugins/SWIG/CMakeLists.txt
+++ b/Plugins/SWIG/CMakeLists.txt
@@ -1,6 +1,3 @@
-# temporarily disabled
-return()
-
 find_package(SWIG 4.0 COMPONENTS csharp)
 
 function(add_swig_plugin target language interfaces)

--- a/Plugins/SWIG/SWIG_DotNET/API_NWNXLib.i
+++ b/Plugins/SWIG/SWIG_DotNET/API_NWNXLib.i
@@ -132,6 +132,7 @@ MarshalPtr(Task::CExoTaskManager*, void*)
 %nodefaultctor CVirtualMachineDebugLoader;
 %nodefaultctor CResARE;
 %nodefaultctor CResIFO;
+%nodefaultctor JsonEngineStructureShared;
 
 // Ignore ambigious types.
 %ignore MIN;


### PR DESCRIPTION
Fixes compiling SWIG on 8193.35.

This PR also includes an optional build target that will validate all exported symbols against the headers in NWNXLib.
Put the linux binary in the root SWIG folder, and trigger a reload of the cmake project. Building SWIG will now report any missing symbols:

![image](https://user-images.githubusercontent.com/10942655/222936867-9f17da5c-0fc9-4a4c-9736-8b6ef8f617ee.png)

![image](https://user-images.githubusercontent.com/10942655/222937141-ad23fb1c-7b5b-4cba-b5ad-e167132bf967.png)