### PR TITLE
[Assert/DotNET] Add assertion failure message/handler.

### DIFF
--- a/NWNXLib/Assert.cpp
+++ b/NWNXLib/Assert.cpp
@@ -29,7 +29,9 @@ void FailInternal(const char* condition, const char* file, int line, const char*
         std::strncat(buffer, message, sizeof(buffer)-1);
     }
 
-    std::strncat(buffer, Platform::GetStackTrace(20).c_str(), sizeof(buffer)-1);
+    std::string stackTrace = Platform::GetStackTrace(20);
+    MessageBus::Broadcast("NWNX_ASSERT_FAIL", { buffer, stackTrace });
+    std::strncat(buffer, stackTrace.c_str(), sizeof(buffer)-1);
     std::fputs(buffer, stdout);
     std::fflush(stdout);
     NWNXLib::Log::WriteToLogFile(buffer);

--- a/Plugins/DotNET/NWN/Internal/Bootstrap.cs
+++ b/Plugins/DotNET/NWN/Internal/Bootstrap.cs
@@ -11,6 +11,7 @@ namespace NWN
         public delegate int RunScriptHandlerDelegate(string script, uint oid);
         public delegate void ClosureHandlerDelegate(ulong eid, uint oid);
         public delegate void SignalHandlerDelegate(string signal);
+        public delegate void AssertHandlerDelegate(string message, string stackTrace);
 
         [StructLayout(LayoutKind.Sequential)]
         public struct AllHandlers
@@ -19,6 +20,7 @@ namespace NWN
             public RunScriptHandlerDelegate RunScript;
             public ClosureHandlerDelegate   Closure;
             public SignalHandlerDelegate    Signal;
+            public AssertHandlerDelegate    AssertFail;
         }
 
         [SuppressUnmanagedCodeSecurity]


### PR DESCRIPTION
This PR adds support for receiving assertion fail messages in C#.

This allows someone to implement a managed exception that shows the call stack that caused the assertion failure:

![image](https://user-images.githubusercontent.com/10942655/223128651-c924864f-567f-4119-b925-94e4b72e57f0.png)
