### PR TITLE
Fixed trap events being fired 3 times (issue 1462)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ https://github.com/nwnxee/unified/compare/build8193.35.36...HEAD
 
 ### Added
 - Events: added event data `TARGET_OBJECT_ID`, `TARGET_POSITION_X`, `TARGET_POSITION_Y` and `TARGET_POSITION_Z` to the `NWNX_ON_TRAP_SET_*` events
+- Events: added `NEEDS_TO_MOVE` event data to BEFORE trap events to differentiate between the BEFORE event that will be fired if the player is not in range of its target and the BEFORE event that will be fired right before interacting with the trap. Both BEFORE events are skippable
 
 ##### New Plugins
 - N/A
@@ -17,7 +18,7 @@ https://github.com/nwnxee/unified/compare/build8193.35.36...HEAD
 - N/A
 
 ### Changed
-- N/A
+- Events: Trap events don't fire 2-3 times for each action, but a single BEFORE and AFTER event plus an additional BEFORE event if the player needs to move to the target first
 
 ### Deprecated
 - N/A

--- a/Plugins/Events/Events/TrapEvents.cpp
+++ b/Plugins/Events/Events/TrapEvents.cpp
@@ -52,11 +52,16 @@ uint32_t HandleTrapHook(const std::string& event, Hooks::FunctionHook* originalT
         bInRange = pCreature->GetIsInUseRange((ObjectID)pNode->m_pParameter[0]);
     else
     {
-        Vector vTarget = Vector(*(float*)&pNode->m_pParameter[2], *(float*)&pNode->m_pParameter[3], *(float*)&pNode->m_pParameter[4]);
-        vTarget = VectorMath::Subtract(vTarget, VectorMath::Normalize(VectorMath::Subtract(pCreature->m_vPosition, vTarget)));
-        bInRange = (VectorMath::MagnitudeSquared(VectorMath::Subtract(pCreature->m_vPosition, vTarget)) < 2.25f);
+        if (auto *pGO = Utils::GetGameObject((uintptr_t)(pNode->m_pParameter[1])))
+            bInRange = pCreature->GetIsInUseRange(pGO->m_idSelf, 0.5f, false);
+        else
+        {
+            Vector vTarget = Vector(*(float*)&pNode->m_pParameter[2], *(float*)&pNode->m_pParameter[3], *(float*)&pNode->m_pParameter[4]);
+            vTarget = VectorMath::Subtract(vTarget, VectorMath::Normalize(VectorMath::Subtract(pCreature->m_vPosition, vTarget)));
+            bInRange = (VectorMath::MagnitudeSquared(VectorMath::Subtract(pCreature->m_vPosition, vTarget)) < 2.25f);
+        }
     }
-    
+
     if (!bInRange || !pCreature->m_bTrapAnimationPlayed) // BEFORE
     {
         PushEventData("NEEDS_TO_MOVE", std::to_string((uint32_t)!bInRange));
@@ -108,7 +113,7 @@ uint32_t HandleTrapHook(const std::string& event, Hooks::FunctionHook* originalT
 
         SignalEvent("NWNX_ON_TRAP_" + event + "_AFTER", pCreature->m_idSelf);
     }
- 
+
     return retVal;
 }
 

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -960,6 +960,7 @@ _______________________________________
     TARGET_POSITION_X     | float  | Only in SET events
     TARGET_POSITION_Y     | float  | Only in SET events
     TARGET_POSITION_Z     | float  | Only in SET events
+    NEEDS_TO_MOVE         | int    | TRUE/FALSE, only in _BEFORE events (not ENTER), if TRUE another _BEFORE event will be fired before the actual interaction with the trap
     TRAP_FORCE_SET        | int    | TRUE/FALSE, only in ENTER events
     ACTION_RESULT         | int    | TRUE/FALSE, only in _AFTER events (not ENTER)
 


### PR DESCRIPTION
A new event data named "NEEDS_TO_MOVE" will be passed to _BEFORE events to indicate that it's the first of 2 (!) _BEFORE events for this interaction. If TRUE the player first needs to move to the trap or target location. If FALSE the player is about to interact with the trap. Both BEFORE events can be skipped so now it's possible to cancel the interaction either before the player even made its way to the trap (old behaviour) or just before the player is about to interact with the trap at the location of the trap.

closes #1462 