### PR TITLE
Optimize debug logging

### DIFF
--- a/NWNXLib/Log.cpp
+++ b/NWNXLib/Log.cpp
@@ -128,6 +128,7 @@ void WriteToLogFile(const char* message)
 // doesn't provide a hashing function for a const char* and I'm too lazy to write or copy/paste one.
 // Small perf hit when logging.
 static std::unordered_map<std::string, Channel::Enum> s_LogLevelMap;
+static Channel::Enum s_LogLevelMax;
 
 Channel::Enum GetLogLevel(const char* plugin)
 {
@@ -136,9 +137,15 @@ Channel::Enum GetLogLevel(const char* plugin)
     return entry == std::end(s_LogLevelMap) ? Channel::SEV_NOTICE : entry->second;
 }
 
+Channel::Enum GetMaxLogLevel()
+{
+    return s_LogLevelMax;
+}
+
 void SetLogLevel(const char* plugin, Channel::Enum logLevel)
 {
     s_LogLevelMap[plugin] = logLevel;
+    s_LogLevelMax = std::max(s_LogLevelMax, logLevel);
 }
 
 }

--- a/NWNXLib/Log.hpp
+++ b/NWNXLib/Log.hpp
@@ -52,6 +52,7 @@ template <typename ... Args>
 void Trace(Channel::Enum channel, const char* plugin, const char* file, int line, const char* format, Args&& ... args);
 
 Channel::Enum GetLogLevel(const char* plugin);
+Channel::Enum GetMaxLogLevel();
 void SetLogLevel(const char* plugin, Channel::Enum logLevel);
 void SetPrintTimestamp(bool value);
 bool GetPrintTimestamp();
@@ -73,6 +74,12 @@ void WriteToLogFile(const char* message);
 template <typename ... Args>
 void Trace(Channel::Enum channel, const char* plugin, const char* file, int line, const char* format, Args&& ... args)
 {
+    if (channel > GetMaxLogLevel())
+    {
+        // No need to do anything. No plugins have this log level.
+        return;
+    }
+
     Channel::Enum allowedChannel = GetLogLevel(plugin);
 
     if (channel > allowedChannel)


### PR DESCRIPTION
Adds an early return for max debug level, and a char* hashing function for the log level map.