### PR TITLE
Add Events: Attack of Opportunity events and Creature: BroadcastAttackOfOpportunity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 https://github.com/nwnxee/unified/compare/build8193.35.37...HEAD
 
 ### Added
-- N/A
+- Events: added skippable event `NWNX_ON_BROADCAST_ATTACK_OF_OPPORTUNITY_{BEFORE|AFTER}` which allows skipping a creature provoking attacks of opportunities from enemies.
+- Events: added skippable event `NWNX_ON_COMBAT_ATTACK_OF_OPPORTUNITY_{BEFORE|AFTER}` which allows stopping a creature from performing an attack of opportunity against a target.
 
 ##### New Plugins
 - N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ https://github.com/nwnxee/unified/compare/build8193.35.37...HEAD
 - N/A
 
 ##### New NWScript Functions
-- N/A
+- Creature: BroadcastAttackOfOpportunity()
 
 ### Changed
 - N/A

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -3301,3 +3301,20 @@ NWNX_EXPORT ArgumentStack SetMaximumBonusAttacks(ArgumentStack&& args)
 
     return {};
 }
+
+NWNX_EXPORT ArgumentStack BroadcastAttackOfOpportunity(ArgumentStack&& args)
+{
+    if (auto *pCreature = Utils::PopCreature(args))
+    {
+        auto oidSingleTarget = Constants::OBJECT_INVALID;
+        
+        if (auto *pTarget = Utils::PopCreature(args))
+            oidSingleTarget = pTarget->m_idSelf;
+
+        bool bMovement = !!args.extract<int32_t>();
+
+        pCreature->BroadcastAttackOfOpportunity(oidSingleTarget, bMovement);
+    }
+
+    return {};
+}

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -951,6 +951,11 @@ int NWNX_Creature_GetMaximumBonusAttacks(object oCreature);
 /// @note Persistence is enabled after a server reset by the first use of this function. Recommended to trigger on a dummy target OnModuleLoad to enable persistence.
 void NWNX_Creature_SetMaximumBonusAttacks(object oCreature, int nMaxBonusAttacks, int bPersist = FALSE);
 
+/// @brief Causes oCreature to broadcast an Attack of Opportunity against themself.
+/// @param oCreature The creature object.
+/// @param oSingleCreature A single creature to broadcast the Attack of Opporunity to. Use OBJECT_INVALID to broadcast to all nearby enemies.
+/// @param bMovement Whether the Attack of Opportunity was caused by movement.
+void NWNX_Creature_BroadcastAttackOfOpportunity(object oCreature, object oSingleCreature = OBJECT_INVALID, int bMovement = FALSE);
 /// @}
 
 void NWNX_Creature_AddFeat(object creature, int feat)
@@ -2459,6 +2464,16 @@ void NWNX_Creature_SetMaximumBonusAttacks(object oCreature, int nMaxBonusAttacks
 
     NWNX_PushArgumentInt(bPersist);
     NWNX_PushArgumentInt(nMaxBonusAttacks);
+    NWNX_PushArgumentObject(oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+}
+
+void NWNX_Creature_BroadcastAttackOfOpportunity(object oCreature, object oSingleCreature = OBJECT_INVALID, int bMovement = FALSE)
+{
+    string sFunc = "BroadcastAttackOfOpportunity";
+
+    NWNX_PushArgumentInt(bMovement);
+    NWNX_PushArgumentObject(oSingleCreature);
     NWNX_PushArgumentObject(oCreature);
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -2040,6 +2040,7 @@ string NWNX_Events_GetEventData(string tag);
 /// - Decrement Spell Count event
 /// - Play Visual Effect event
 /// - EventScript event
+/// - Attack of Opportunity events
 void NWNX_Events_SkipEvent();
 
 /// Set the return value of the event.

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1560,6 +1560,27 @@ _______________________________________
 	----------------------|--------|-------
 	OBJECT                | object | The Object being used |
 _______________________________________
+	## Broadcast Attack of Opportunity Events
+	- NWNX_ON_BROADCAST_ATTACK_OF_OPPORTUNITY_BEFORE
+	- NWNX_ON_BROADCAST_ATTACK_OF_OPPORTUNITY_AFTER
+
+	`OBJECT_SELF` = The creature broadcasting the Attack of Opportunity event
+
+	Event Data Tag        | Type   | Notes
+	----------------------|--------|-------
+	TARGET_OBJECT_ID      | object | A single object the attack of opportunity is being broadcast to. Convert to object with StringToObject() |
+    MOVEMENT              | int    | Whether this attack of opportunity is being triggered from movement |
+_______________________________________
+	## Combat Attack of Opportunity Events
+	- NWNX_ON_COMBAT_ATTACK_OF_OPPORTUNITY_BEFORE
+	- NWNX_ON_COMBAT_ATTACK_OF_OPPORTUNITY_AFTER
+
+	`OBJECT_SELF` = The creature performing the Attack of Opportunity against the broadcasting target.
+
+	Event Data Tag        | Type   | Notes
+	----------------------|--------|-------
+	TARGET_OBJECT_ID      | object | The target of the attack of opportunity. Convert to object with StringToObject() |
+_______________________________________
 */
 
 /// @name Events Event Constants
@@ -1886,6 +1907,10 @@ const string NWNX_ON_RUN_EVENT_SCRIPT_BEFORE = "NWNX_ON_RUN_EVENT_SCRIPT_BEFORE"
 const string NWNX_ON_RUN_EVENT_SCRIPT_AFTER = "NWNX_ON_RUN_EVENT_SCRIPT_AFTER";
 const string NWNX_ON_OBJECT_USE_BEFORE = "NWNX_ON_OBJECT_USE_BEFORE";
 const string NWNX_ON_OBJECT_USE_AFTER = "NWNX_ON_OBJECT_USE_AFTER";
+const string NWNX_ON_BROADCAST_ATTACK_OF_OPPORTUNITY_BEFORE = "NWNX_ON_BROADCAST_ATTACK_OF_OPPORTUNITY_BEFORE";
+const string NWNX_ON_BROADCAST_ATTACK_OF_OPPORTUNITY_AFTER = "NWNX_ON_BROADCAST_ATTACK_OF_OPPORTUNITY_AFTER";
+const string NWNX_ON_COMBAT_ATTACK_OF_OPPORTUNITY_BEFORE = "NWNX_ON_COMBAT_ATTACK_OF_OPPORTUNITY_BEFORE";
+const string NWNX_ON_COMBAT_ATTACK_OF_OPPORTUNITY_AFTER = "NWNX_ON_COMBAT_ATTACK_OF_OPPORTUNITY_AFTER";
 /// @}
 
 /// @name Events ObjectType Constants


### PR DESCRIPTION
Events:
- Adds skippable event `NWNX_ON_BROADCAST_ATTACK_OF_OPPORTUNITY_{BEFORE|AFTER}` which allows skipping a creature provoking attacks of opportunities from enemies.
- Adds skippable event `NWNX_ON_COMBAT_ATTACK_OF_OPPORTUNITY_{BEFORE|AFTER}` which allows stopping a creature from performing an attack of opportunity against a target.

Creature:
- Adds BroadcastAttackOfOpportunity()