### PR TITLE
Creature: DoItemCastSpell () allow setting casting item and impact script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ https://github.com/nwnxee/unified/compare/build8193.35.37...HEAD
 - N/A
 
 ### Changed
-- N/A
+- Creature: DoItemCastSpell() can now override the spell impact script, and set the spell cast item retrieved by GetSpellCastItem().
 
 ### Deprecated
 - N/A

--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -2850,9 +2850,12 @@ NWNX_EXPORT ArgumentStack DoItemCastSpell(ArgumentStack&& args)
           ASSERT_OR_THROW(delay >= 0.0f);
         auto projectilePathType = args.extract<int32_t>();
         auto projectileSpellID = args.extract<int32_t>();
+        auto oidItem = args.extract<ObjectID>();
+        auto impactScript = args.extract<std::string>();
 
         auto *pSpell = Globals::Rules()->m_pSpellArray->GetSpell(spellID);
         auto *pTarget = Utils::AsNWSObject(Utils::GetGameObject(oidTarget));
+        auto *pItem = Utils::AsNWSObject(Utils::GetGameObject(oidItem));
         auto *pArea = Utils::AsNWSArea(Utils::GetGameObject(oidArea));
 
         if (!pSpell || (!pTarget && !pArea))
@@ -2887,9 +2890,9 @@ NWNX_EXPORT ArgumentStack DoItemCastSpell(ArgumentStack&& args)
         pSpellScriptData->m_nFeatId = 0xFFFF;
         pSpellScriptData->m_oidCaster = pCaster->m_idSelf;
         pSpellScriptData->m_oidTarget = pTarget ? pTarget->m_idSelf : Constants::OBJECT_INVALID;
-        pSpellScriptData->m_oidItem = Constants::OBJECT_INVALID;
+        pSpellScriptData->m_oidItem = pItem ? pItem->m_idSelf : Constants::OBJECT_INVALID;
         pSpellScriptData->m_vTargetPosition = vTargetPosition;
-        pSpellScriptData->m_sScript = pSpell->m_sImpactScript;
+        pSpellScriptData->m_sScript = !impactScript.empty() ? CExoString(impactScript) : pSpell->m_sImpactScript;
         pSpellScriptData->m_oidArea = oidTargetArea;
         pSpellScriptData->m_nItemCastLevel = casterLevel;
 

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -865,7 +865,9 @@ void NWNX_Creature_SetLastKiller(object oCreature, object oKiller);
 /// @param fProjectileTime The time in seconds for the projectile to reach the target. 0.0f for no projectile.
 /// @param nProjectilePathType A PROJECTILE_PATH_TYPE_* constant.
 /// @param nProjectileSpellID An optional spell ID which to use the projectile vfx of. -1 to use nSpellID's projectile vfx.
-void NWNX_Creature_DoItemCastSpell(object oCreature, object oTarget, location locTarget, int nSpellID, int nCasterLevel, float fProjectileTime, int nProjectilePathType = PROJECTILE_PATH_TYPE_DEFAULT, int nProjectileSpellID = -1);
+/// @param oItem The spell cast item retrieved by GetSpellCastItem().
+/// @param sImpactScript The spell impact script. Set to "****"" to not run any impact script. If left blank, will execute nSpellID's impact script.
+void NWNX_Creature_DoItemCastSpell(object oCreature, object oTarget, location locTarget, int nSpellID, int nCasterLevel, float fProjectileTime, int nProjectilePathType = PROJECTILE_PATH_TYPE_DEFAULT, int nProjectileSpellID = -1, object oItem = OBJECT_INVALID, string sImpactScript = "");
 
 /// @brief Have oCreature instantly equip oItem to nInventorySlot.
 /// @param oCreature The creature.
@@ -2307,13 +2309,15 @@ void NWNX_Creature_SetLastKiller(object oCreature, object oKiller)
     NWNX_CallFunction(NWNX_Creature, sFunc);
 }
 
-void NWNX_Creature_DoItemCastSpell(object oCreature, object oTarget, location locTarget, int nSpellID, int nCasterLevel, float fProjectileTime, int nProjectilePathType = PROJECTILE_PATH_TYPE_DEFAULT, int nProjectileSpellID = -1)
+void NWNX_Creature_DoItemCastSpell(object oCreature, object oTarget, location locTarget, int nSpellID, int nCasterLevel, float fProjectileTime, int nProjectilePathType = PROJECTILE_PATH_TYPE_DEFAULT, int nProjectileSpellID = -1, object oItem = OBJECT_INVALID, string sImpactScript = "")
 {
     string sFunc = "DoItemCastSpell";
 
     object oArea = GetAreaFromLocation(locTarget);
     vector vPosition = GetPositionFromLocation(locTarget);
 
+    NWNX_PushArgumentString(sImpactScript);
+    NWNX_PushArgumentObject(oItem);
     NWNX_PushArgumentInt(nProjectileSpellID);
     NWNX_PushArgumentInt(nProjectilePathType);
     NWNX_PushArgumentFloat(fProjectileTime);


### PR DESCRIPTION
Allows oItem retrieved by GetSpellCastItem() to be set in DoItemCastSpell(), as well as overriding the impact script (or even removing the impact script if set to "****").

When combined with NWNX_ON_BROADCAST_SAFE_PROJECTILE_BEFORE it allows us to effectively create a ActionCastCustomFakeSpell() function that casts a ActionCastFakeSpell* or ActionCastSpell*, which we then replace with DoItemCastSpell() during the broadcast event to use a custom projectile or impact script instead.