### PR TITLE
Tweaks: Fix server crash in `NWNX_TWEAKS_FIX_RESOLVE_SPECIAL_ATTACK_DAMAGE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ https://github.com/nwnxee/unified/compare/build8193.35.37...HEAD
 - N/A
 
 ### Fixed
-- N/A
+- Tweaks: Fixed a crash in `NWNX_TWEAKS_FIX_RESOLVE_SPECIAL_ATTACK_DAMAGE` when a ranged special attack was avoided with epic dodge.
 
 ## 8193.35.37
 https://github.com/nwnxee/unified/compare/build8193.35.36...build8193.35.37

--- a/Plugins/Tweaks/FixResolveSpecialAttackDamage.cpp
+++ b/Plugins/Tweaks/FixResolveSpecialAttackDamage.cpp
@@ -1,5 +1,6 @@
 #include "nwnx.hpp"
 #include "API/CNWSCreature.hpp"
+#include "API/CNWSCreatureStats.hpp"
 #include "API/CNWSCombatRound.hpp"
 #include "API/CNWSCombatAttackData.hpp"
 
@@ -81,8 +82,18 @@ void FixResolveSpecialAttackDamage()
             {
                 if (!GetAttackResultHit(pThis->m_pcCombatRound->GetAttack(pThis->m_pcCombatRound->m_nCurrentAttack)))
                 {
-                    pThis->ResolveRangedMiss(pTarget);
-                    return;
+                    bool bEpicDodgeUsed = true;
+                    if (auto *pTargetCreature = Utils::AsNWSCreature(pTarget))
+                    {
+                        if (pTargetCreature->m_pStats->HasFeat(Constants::Feat::EpicDodge))
+                            bEpicDodgeUsed = pTargetCreature->m_pcCombatRound->m_bEpicDodgeUsed;
+                    }
+
+                    if (bEpicDodgeUsed)
+                    {
+                        pThis->ResolveRangedMiss(pTarget);
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes a server crash in `NWNX_TWEAKS_FIX_RESOLVE_SPECIAL_ATTACK_DAMAGE` when a ranged special attack was avoided with epic dodge.

This fix is not perfect. Once epic dodge has been triggered, any further special attacks in the current round against the target will again consume damage reduction/etc effects on misses. I couldn't figure out a better way to fix this, and needed to throw something in quickly as we were getting a few frequent crashes from it.