### PR TITLE
Update dotnet-runtime to 7.0

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -17,8 +17,8 @@ RUN runDeps="hunspell \
     inotify-tools \
     patch \
     unzip \
-    dotnet-runtime-6.0 \
-    dotnet-apphost-pack-6.0" \
+    dotnet-runtime-7.0 \
+    dotnet-apphost-pack-7.0" \
     installDeps="ca-certificates wget" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $installDeps \


### PR DESCRIPTION
Why:

With the removal of the `FunctionsLinux` in 8193.35, function hooking is a bit tricker in C#. You have to use dlsym/GetProcAddress with the symbol to get the actual function pointer to hook.

In .NET 7, Microsoft added a new API for resolving the entrypoint/main program handle, making this much nicer to do: https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.nativelibrary.getmainprogramhandle?view=net-7.0