### PR TITLE
Events: Fix skipping NWNX_ON_COMBAT_ATTACK_OF_OPPORTUNITY_BEFORE

### DIFF
--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1622,6 +1622,8 @@ _______________________________________
 	Event Data Tag        | Type   | Notes
 	----------------------|--------|-------
 	TARGET_OBJECT_ID      | object | The target of the attack of opportunity. Convert to object with StringToObject() |
+
+    @note If the BEFORE event is skipped the broadcasting creature will still make a tumble skill roll if moving.
 _______________________________________
 */
 


### PR DESCRIPTION
- Fixes attacks still being made against creatures if the event is skipped under some combat situations.
- Now also skips `SetBroadcastedAOOTo`
- Added a note to the event documentation that if the event is skipped, the broadcaster will still make a tumble roll.