### PR TITLE
Added NWNX_EXPERIMENTAL_END_COMBATROUND_AFTER_SPELLCAST 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ https://github.com/nwnxee/unified/compare/build8193.35.37...HEAD
 - Events: added skippable event `NWNX_ON_BROADCAST_ATTACK_OF_OPPORTUNITY_{BEFORE|AFTER}` which allows skipping a creature provoking attacks of opportunities from enemies.
 - Events: added skippable event `NWNX_ON_COMBAT_ATTACK_OF_OPPORTUNITY_{BEFORE|AFTER}` which allows stopping a creature from performing an attack of opportunity against a target.
 - Events: added skippable event `NWNX_ON_AREA_PLAY_BATTLE_MUSIC_{BEFORE|AFTER}` which allows skipping the starting/stopping of an area's battle music.
+- Experimental: Added `NWNX_EXPERIMENTAL_END_COMBATROUND_AFTER_SPELLCAST` to end combat rounds right after casting or canceling a spell so that a new spell can be cast immediately after
 
 ##### New Plugins
 - N/A

--- a/Plugins/Experimental/CMakeLists.txt
+++ b/Plugins/Experimental/CMakeLists.txt
@@ -4,4 +4,5 @@ add_plugin(Experimental
     "SuppressPlayerLoginInfo.cpp"
     "UnhardcodeRangerDualWield.cpp"
     "PlayerHitpointsAsPercentage.cpp"
-    "IgnoreModuleVersion.cpp")
+    "IgnoreModuleVersion.cpp"
+    "EndCombatRoundAfterSpellcast.cpp")

--- a/Plugins/Experimental/EndCombatRoundAfterSpellcast.cpp
+++ b/Plugins/Experimental/EndCombatRoundAfterSpellcast.cpp
@@ -1,0 +1,26 @@
+#include "nwnx.hpp"
+
+#include "API/CNWSCombatRound.hpp"
+
+namespace Experimental {
+
+    using namespace NWNXLib;
+    using namespace NWNXLib::API;
+
+    uint32_t nCurrentSpellId;
+
+    void EndCombatRoundAfterSpellcast() __attribute__((constructor));
+    void EndCombatRoundAfterSpellcast()
+    {
+        if (!Config::Get<bool>("END_COMBATROUND_AFTER_SPELLCAST", false))
+            return;
+
+        static Hooks::Hook s_RemoveSpellAction_hook = Hooks::HookFunction(&CNWSCombatRound::RemoveSpellAction,
+            +[](CNWSCombatRound* pThis) -> void
+            {
+                s_RemoveSpellAction_hook->CallOriginal<void>(pThis);
+                if (pThis->m_bSpellCastRound)
+                    pThis->EndCombatRound();
+            }, Hooks::Order::Early);
+    }
+}

--- a/Plugins/Experimental/EndCombatRoundAfterSpellcast.cpp
+++ b/Plugins/Experimental/EndCombatRoundAfterSpellcast.cpp
@@ -7,8 +7,6 @@ namespace Experimental {
     using namespace NWNXLib;
     using namespace NWNXLib::API;
 
-    uint32_t nCurrentSpellId;
-
     void EndCombatRoundAfterSpellcast() __attribute__((constructor));
     void EndCombatRoundAfterSpellcast()
     {

--- a/Plugins/Experimental/README.md
+++ b/Plugins/Experimental/README.md
@@ -19,3 +19,4 @@ The following environmental variable is required to load the plugin:
 | `NWNX_EXPERIMENTAL_DISABLE_LEVELUP_VALIDATION` | true/false | Disable LevelUp Validation |
 | `NWNX_EXPERIMENTAL_UNHARDCODE_RANGER_DUALWIELD` | true/false | Removes the hardcoded effects of the Ranger's Dual-wield feat. |
 | `NWNX_EXPERIMENTAL_IGNORE_MODULE_VERSION` | true/false | Ignore the module's version when loading. |
+| `NWNX_EXPERIMENTAL_END_COMBATROUND_AFTER_SPELLCAST` | true/false | Combat rounds end right after a spell cast making it possible to cast another spell right after |

--- a/Plugins/Experimental/README.md
+++ b/Plugins/Experimental/README.md
@@ -19,4 +19,4 @@ The following environmental variable is required to load the plugin:
 | `NWNX_EXPERIMENTAL_DISABLE_LEVELUP_VALIDATION` | true/false | Disable LevelUp Validation |
 | `NWNX_EXPERIMENTAL_UNHARDCODE_RANGER_DUALWIELD` | true/false | Removes the hardcoded effects of the Ranger's Dual-wield feat. |
 | `NWNX_EXPERIMENTAL_IGNORE_MODULE_VERSION` | true/false | Ignore the module's version when loading. |
-| `NWNX_EXPERIMENTAL_END_COMBATROUND_AFTER_SPELLCAST` | true/false | Combat rounds end right after a spell cast making it possible to cast another spell right after |
+| `NWNX_EXPERIMENTAL_END_COMBATROUND_AFTER_SPELLCAST` | true/false | Combat rounds end immediately a spell cast making it possible to cast another spell right after |


### PR DESCRIPTION
Makes it so that combat rounds end immediately after casting or aborting a spell so another spell can be cast right after. 