### PR TITLE
Revert ssl Docker change

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -25,9 +25,6 @@ RUN runDeps="hunspell \
     && wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
     && dpkg -i packages-microsoft-prod.deb \
     && rm packages-microsoft-prod.deb \
-    && wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1-1ubuntu2.1~18.04.22_amd64.deb \
-    && dpkg -i libssl1.1_1.1.1-1ubuntu2.1~18.04.22_amd64.deb \
-    && rm libssl1.1_1.1.1-1ubuntu2.1~18.04.22_amd64.deb \
     && apt-get update \
     && apt-get -y install --no-install-recommends $runDeps \
     && ln -s /usr/lib/x86_64-linux-gnu/libhunspell-?.*.so /usr/lib/x86_64-linux-gnu/libhunspell.so \

--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -11,9 +11,9 @@ RUN runDeps="hunspell \
     libmariadb3 \
     libpq5 \
     libsqlite3-0 \
-    libruby3.1 \
-    luajit libluajit-5.1-2 \
-    libssl3 \
+    libruby2.5 \
+    luajit libluajit-5.1 \
+    libssl1.1 \
     inotify-tools \
     patch \
     unzip \


### PR DESCRIPTION
Because the Dotnet project ran into issues with bullseye releases and OpenSSL, the default image now defaults to a buster release.

https://hub.docker.com/repository/docker/urothis/nwserver/tags?page=1&ordering=last_updated The default image and -buster resolve to the same image currently.

Dotnet 8 should resolve this dependency issue.
https://github.com/dotnet/dotnet-docker/issues/4322 
Looks to have already been merged, so we should see all resolve upon 8 reaching stable later this year.