### PR TITLE
Tile Change Event Stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ https://github.com/nwnxee/unified/compare/build8193.35.40...HEAD
 - Tweaks: added `NWNX_TWEAKS_FIX_AUTOMAP_CRASH` which fixes a server crash that happens when automap data is outdated for a player.
 - Events: added event `NWNX_ON_ATTACK_TARGET_CHANGE_{BEFORE|AFTER}` which fires when a creature changes its attack target.
 - Events: added event `NWNX_ON_CREATURE_TILE_CHANGE_{BEFORE|AFTER}` which fires when a creature changes the tile it's on.
+- Tweaks: added `NWNX_TWEAKS_SETAREA_CALLS_SETPOSITION` which will enable firing of the `NWNX_ON_MATERIALCHANGE_*` and `NWNX_ON_CREATURE_TILE_CHANGE_*` events when a creature is first added to an area.
 
 ##### New Plugins
 - Resources: Adds `RESOURCES_*` variables for adding NWSync as a resource source, and specifying a replacement hak list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ https://github.com/nwnxee/unified/compare/build8193.35.40...HEAD
 - Events: added event `NWNX_ON_SPELL_FAILED_{BEFORE|AFTER}` which fires when the casting of a spell did not finish for any reason.
 - Tweaks: added `NWNX_TWEAKS_FIX_AUTOMAP_CRASH` which fixes a server crash that happens when automap data is outdated for a player.
 - Events: added event `NWNX_ON_ATTACK_TARGET_CHANGE_{BEFORE|AFTER}` which fires when a creature changes its attack target.
+- Events: added event `NWNX_ON_CREATURE_TILE_CHANGE_{BEFORE|AFTER}` which fires when a creature changes the tile it's on.
 
 ##### New Plugins
 - Resources: Adds `RESOURCES_*` variables for adding NWSync as a resource source, and specifying a replacement hak list.

--- a/Plugins/Events/CMakeLists.txt
+++ b/Plugins/Events/CMakeLists.txt
@@ -19,7 +19,7 @@ add_plugin(Events
     "Events/JournalEvents.cpp"
     "Events/LevelEvents.cpp"
     "Events/MapEvents.cpp"
-    "Events/MaterialChangeEvents.cpp"
+    "Events/TileEvents.cpp"
     "Events/ObjectEvents.cpp"
     "Events/PartyEvents.cpp"
     "Events/PolymorphEvents.cpp"

--- a/Plugins/Events/Events/TileEvents.cpp
+++ b/Plugins/Events/Events/TileEvents.cpp
@@ -13,8 +13,8 @@ static Hooks::Hook s_SetPositionHook;
 
 static void SetPositionHook(CNWSObject*, Vector, int32_t);
 
-void MaterialChangeEvents() __attribute__((constructor));
-void MaterialChangeEvents()
+void TileEvents() __attribute__((constructor));
+void TileEvents()
 {
     InitOnFirstSubscribe("NWNX_ON_MATERIALCHANGE_.*", []() {
         s_SetPositionHook = Hooks::HookFunction(&CNWSObject::SetPosition,

--- a/Plugins/Events/Events/TileEvents.cpp
+++ b/Plugins/Events/Events/TileEvents.cpp
@@ -4,14 +4,17 @@
 #include "API/CNWSArea.hpp"
 #include "API/CNWSObject.hpp"
 #include "API/CNWSCreature.hpp"
+#include "API/CNWSTile.hpp"
 
 namespace Events {
 
 using namespace NWNXLib;
 
 static Hooks::Hook s_SetPositionMaterialChangeHook;
+static Hooks::Hook s_SetPositionTileChangeHook;
 
 static void SetPositionMaterialChangeHook(CNWSObject*, Vector, int32_t);
+static void SetPositionTileChangeHook(CNWSObject*, Vector, int32_t);
 
 void TileEvents() __attribute__((constructor));
 void TileEvents()
@@ -19,6 +22,11 @@ void TileEvents()
     InitOnFirstSubscribe("NWNX_ON_MATERIALCHANGE_.*", []() {
         s_SetPositionMaterialChangeHook = Hooks::HookFunction(&CNWSObject::SetPosition,
             &SetPositionMaterialChangeHook, Hooks::Order::Earliest);
+    });
+
+    InitOnFirstSubscribe("NWNX_ON_CREATURE_TILE_CHANGE_.*", []() {
+        s_SetPositionTileChangeHook = Hooks::HookFunction(&CNWSObject::SetPosition,
+            &SetPositionTileChangeHook, Hooks::Order::Earliest);
     });
 }
 
@@ -57,6 +65,53 @@ void SetPositionMaterialChangeHook(CNWSObject* thisPtr, Vector vPosition, BOOL b
     }
 
     s_SetPositionMaterialChangeHook->CallOriginal<void>(thisPtr, vPosition, bDoingCharacterCopy);
+}
+
+void SetPositionTileChangeHook(CNWSObject* thisPtr, Vector vPosition, BOOL bDoingCharacterCopy)
+{
+    if (thisPtr->m_nObjectType != API::Constants::ObjectType::Creature)
+    {
+        s_SetPositionTileChangeHook->CallOriginal<void>(thisPtr, vPosition, bDoingCharacterCopy);
+        return;
+    }
+
+    if (auto *pCreature = Utils::AsNWSCreature(thisPtr))
+    {
+        CNWSArea *pArea = API::Globals::AppManager()->m_pServerExoApp->GetAreaByGameObjectID(pCreature->m_oidArea);
+        if (!pArea)
+            pArea = API::Globals::AppManager()->m_pServerExoApp->GetAreaByGameObjectID(pCreature->m_oidDesiredArea);
+
+        if (pArea)
+        {
+            CNWSTile *pOldTile = pArea->GetTile(pCreature->m_vPosition);
+            CNWSTile *pNewTile = pArea->GetTile(vPosition);
+
+            if (pOldTile && pNewTile && (pOldTile != pNewTile || pCreature->m_vPosition == vPosition))
+            {
+                PushEventData("OLD_TILE_INDEX", std::to_string(pOldTile->m_nGridX + (pArea->m_nWidth * pOldTile->m_nGridY)));
+                PushEventData("OLD_TILE_X", std::to_string(pOldTile->m_nGridX));
+                PushEventData("OLD_TILE_Y", std::to_string(pOldTile->m_nGridY));
+                PushEventData("NEW_TILE_INDEX", std::to_string(pNewTile->m_nGridX + (pArea->m_nWidth * pNewTile->m_nGridY)));
+                PushEventData("NEW_TILE_X", std::to_string(pNewTile->m_nGridX));
+                PushEventData("NEW_TILE_Y", std::to_string(pNewTile->m_nGridY));
+                SignalEvent("NWNX_ON_CREATURE_TILE_CHANGE_BEFORE", pCreature->m_idSelf);
+
+                s_SetPositionTileChangeHook->CallOriginal<void>(thisPtr, vPosition, bDoingCharacterCopy);
+
+                PushEventData("OLD_TILE_INDEX", std::to_string(pOldTile->m_nGridX + (pArea->m_nWidth * pOldTile->m_nGridY)));
+                PushEventData("OLD_TILE_X", std::to_string(pOldTile->m_nGridX));
+                PushEventData("OLD_TILE_Y", std::to_string(pOldTile->m_nGridY));
+                PushEventData("NEW_TILE_INDEX", std::to_string(pNewTile->m_nGridX + (pArea->m_nWidth * pNewTile->m_nGridY)));
+                PushEventData("NEW_TILE_X", std::to_string(pNewTile->m_nGridX));
+                PushEventData("NEW_TILE_Y", std::to_string(pNewTile->m_nGridY));
+                SignalEvent("NWNX_ON_CREATURE_TILE_CHANGE_AFTER", pCreature->m_idSelf);
+
+                return;
+            }
+        }
+    }
+
+    s_SetPositionTileChangeHook->CallOriginal<void>(thisPtr, vPosition, bDoingCharacterCopy);
 }
 
 }

--- a/Plugins/Events/Events/TileEvents.cpp
+++ b/Plugins/Events/Events/TileEvents.cpp
@@ -3,52 +3,60 @@
 #include "API/CServerExoApp.hpp"
 #include "API/CNWSArea.hpp"
 #include "API/CNWSObject.hpp"
+#include "API/CNWSCreature.hpp"
 
 namespace Events {
 
 using namespace NWNXLib;
 
-static std::unordered_map<ObjectID, int32_t> m_objectCurrentMaterial;
-static Hooks::Hook s_SetPositionHook;
+static Hooks::Hook s_SetPositionMaterialChangeHook;
 
-static void SetPositionHook(CNWSObject*, Vector, int32_t);
+static void SetPositionMaterialChangeHook(CNWSObject*, Vector, int32_t);
 
 void TileEvents() __attribute__((constructor));
 void TileEvents()
 {
     InitOnFirstSubscribe("NWNX_ON_MATERIALCHANGE_.*", []() {
-        s_SetPositionHook = Hooks::HookFunction(&CNWSObject::SetPosition,
-                                         &SetPositionHook, Hooks::Order::Earliest);
+        s_SetPositionMaterialChangeHook = Hooks::HookFunction(&CNWSObject::SetPosition,
+            &SetPositionMaterialChangeHook, Hooks::Order::Earliest);
     });
 }
 
-void SetPositionHook(CNWSObject* thisPtr, Vector vPosition, BOOL bDoingCharacterCopy)
+void SetPositionMaterialChangeHook(CNWSObject* thisPtr, Vector vPosition, BOOL bDoingCharacterCopy)
 {
     if (thisPtr->m_nObjectType != API::Constants::ObjectType::Creature)
     {
-        s_SetPositionHook->CallOriginal<void>(thisPtr, vPosition, bDoingCharacterCopy);
+        s_SetPositionMaterialChangeHook->CallOriginal<void>(thisPtr, vPosition, bDoingCharacterCopy);
         return;
     }
 
-    if (auto *pArea = API::Globals::AppManager()->m_pServerExoApp->GetAreaByGameObjectID(thisPtr->m_oidArea))
+    if (auto *pCreature = Utils::AsNWSCreature(thisPtr))
     {
-        auto iMat = pArea->GetSurfaceMaterial(vPosition);
-        if (!m_objectCurrentMaterial.count(thisPtr->m_idSelf) || iMat != m_objectCurrentMaterial[thisPtr->m_idSelf])
+        CNWSArea *pArea = API::Globals::AppManager()->m_pServerExoApp->GetAreaByGameObjectID(pCreature->m_oidArea);
+        if (!pArea)
+            pArea = API::Globals::AppManager()->m_pServerExoApp->GetAreaByGameObjectID(pCreature->m_oidDesiredArea);
+
+        if (pArea)
         {
-            PushEventData("MATERIAL_TYPE", std::to_string(iMat));
-            SignalEvent("NWNX_ON_MATERIALCHANGE_BEFORE", thisPtr->m_idSelf);
+            int32_t oldMaterial = pArea->GetSurfaceMaterial(pCreature->m_vPosition);
+            int32_t newMaterial = pArea->GetSurfaceMaterial(vPosition);
 
-            s_SetPositionHook->CallOriginal<void>(thisPtr, vPosition, bDoingCharacterCopy);
+            if (oldMaterial != newMaterial || pCreature->m_vPosition == vPosition)
+            {
+                PushEventData("MATERIAL_TYPE", std::to_string(newMaterial));
+                SignalEvent("NWNX_ON_MATERIALCHANGE_BEFORE", thisPtr->m_idSelf);
 
-            PushEventData("MATERIAL_TYPE", std::to_string(iMat));
-            SignalEvent("NWNX_ON_MATERIALCHANGE_AFTER", thisPtr->m_idSelf);
+                s_SetPositionMaterialChangeHook->CallOriginal<void>(thisPtr, vPosition, bDoingCharacterCopy);
 
-            m_objectCurrentMaterial[thisPtr->m_idSelf] = iMat;
-            return;
+                PushEventData("MATERIAL_TYPE", std::to_string(newMaterial));
+                SignalEvent("NWNX_ON_MATERIALCHANGE_AFTER", thisPtr->m_idSelf);
+
+                return;
+            }
         }
     }
 
-    s_SetPositionHook->CallOriginal<void>(thisPtr, vPosition, bDoingCharacterCopy);
+    s_SetPositionMaterialChangeHook->CallOriginal<void>(thisPtr, vPosition, bDoingCharacterCopy);
 }
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1674,6 +1674,21 @@ _______________________________________
     AUTOMATIC_CHANGE      | int    | TRUE if the game automatically decided on the new target, FALSE if explicitly chosen |
     RETARGETABLE          | int    | TRUE if the new target can be changed using NWNX_Events_SetEventResult() (Only in BEFORE) |
 _______________________________________
+    ## Creature Tile Change Events
+    - NWNX_ON_CREATURE_TILE_CHANGE_BEFORE
+    - NWNX_ON_CREATURE_TILE_CHANGE_AFTER
+
+    `OBJECT_SELF` = The creature changing tile positions.
+
+    Event Data Tag        | Type   | Notes
+    ----------------------|--------|-------
+    OLD_TILE_INDEX        | int    | The index of the old tile. |
+    OLD_TILE_X            | int    | The tile grid x position of the old tile. |
+    OLD_TILE_Y            | int    | The tile grid y position of the old tile. |
+    NEW_TILE_INDEX        | int    | The index of the new tile. |
+    NEW_TILE_X            | int    | The tile grid x position of the new tile. |
+    NEW_TILE_Y            | int    | The tile grid y position of the new tile. |
+_______________________________________
 */
 
 /// @name Events Event Constants
@@ -2012,6 +2027,8 @@ const string NWNX_ON_AREA_PLAY_BATTLE_MUSIC_BEFORE = "NWNX_ON_AREA_PLAY_BATTLE_M
 const string NWNX_ON_AREA_PLAY_BATTLE_MUSIC_AFTER = "NWNX_ON_AREA_PLAY_BATTLE_MUSIC_AFTER";
 const string NWNX_ON_ATTACK_TARGET_CHANGE_BEFORE = "NWNX_ON_ATTACK_TARGET_CHANGE_BEFORE";
 const string NWNX_ON_ATTACK_TARGET_CHANGE_AFTER = "NWNX_ON_ATTACK_TARGET_CHANGE_AFTER";
+const string NWNX_ON_CREATURE_TILE_CHANGE_BEFORE = "NWNX_ON_CREATURE_TILE_CHANGE_BEFORE";
+const string NWNX_ON_CREATURE_TILE_CHANGE_AFTER = "NWNX_ON_CREATURE_TILE_CHANGE_AFTER";
 /// @}
 
 /// @name Events ObjectType Constants

--- a/Plugins/Tweaks/CMakeLists.txt
+++ b/Plugins/Tweaks/CMakeLists.txt
@@ -38,4 +38,5 @@ add_plugin(Tweaks
     "RangedWeaponsUseOnHitEffectItemProperties.cpp"
     "RangedWeaponsUseOnHitCastSpellItemProperties.cpp"
     "CastAllOnHitCastSpellItemProperties.cpp"
-    "FixAutoMapCrash.cpp")
+    "FixAutoMapCrash.cpp"
+    "SetAreaCallsSetPosition.cpp")

--- a/Plugins/Tweaks/README.md
+++ b/Plugins/Tweaks/README.md
@@ -49,6 +49,7 @@ Tweaks stuff. See below.
 | `NWNX_TWEAKS_RANGED_WEAPONS_USE_ON_HIT_CAST_SPELL_ITEM_PROPERTIES` | true or false | Makes all bows, crossbows, and slings use On Hit: Cast Spell item properties (in addition to their ammunition). |
 | `NWNX_TWEAKS_CAST_ALL_ON_HIT_CAST_SPELL_ITEM_PROPERTIES` | true or false | Casts all On Hit: Cast Spell item properties on hit, instead of only the first property. |
 | `NWNX_TWEAKS_FIX_AUTOMAP_CRASH` | true or false | Fixes a server crash that happens when automap data is outdated for a player. |
+| `NWNX_TWEAKS_SETAREA_CALLS_SETPOSITION` | true or false | If enabled, a creature getting added to an area will fire the `NWNX_ON_MATERIALCHANGE_*` and `NWNX_ON_CREATURE_TILE_CHANGE_*` events. |
 
 ## Environment variable values
 

--- a/Plugins/Tweaks/SetAreaCallsSetPosition.cpp
+++ b/Plugins/Tweaks/SetAreaCallsSetPosition.cpp
@@ -1,0 +1,32 @@
+#include "nwnx.hpp"
+#include "API/CNWSArea.hpp"
+#include "API/CNWSObject.hpp"
+#include "API/CNWSCreature.hpp"
+
+
+namespace Tweaks {
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+void SetAreaCallsSetPosition() __attribute__((constructor));
+void SetAreaCallsSetPosition()
+{
+    if (!Config::Get<bool>("SETAREA_CALLS_SETPOSITION", false))
+        return;
+
+    LOG_INFO("Calling SetPosition() after SetArea().");
+
+    static Hooks::Hook s_SetAreaHook = Hooks::HookFunction(&CNWSObject::SetArea,+[](CNWSObject *pThis, CNWSArea *pArea) -> void
+    {
+        s_SetAreaHook->CallOriginal<void>(pThis, pArea);
+
+        if (pThis->GetArea())
+        {
+            if (auto *pCreature = Utils::AsNWSCreature(pThis))
+                pCreature->SetPosition(pCreature->m_vPosition);
+        }
+    }, Hooks::Order::Early);
+}
+
+}


### PR DESCRIPTION
* Refactors and simplifies `NWNX_ON_MATERIALCHANGE_*`
* Adds event `NWNX_ON_CREATURE_TILE_CHANGE_{BEFORE|AFTER}` which fires when a creature changes the tile it's on.
* Adds tweak `NWNX_TWEAKS_SETAREA_CALLS_SETPOSITION` which will enable firing of the `NWNX_ON_MATERIALCHANGE_*` and `NWNX_ON_CREATURE_TILE_CHANGE_*` events when a creature is first added to an area.