### PR TITLE
Reveal: Fix Reveal plugin always revealing PCs when the plugin is enabled, regardless of usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ https://github.com/nwnxee/unified/compare/build8193.35.40...HEAD
 
 ### Fixed
 - Experimental: PlayerHitpointsAsPercentage: added the new argument nMessageLimit to SendServerToPlayerGameObjUpdate hook
+- Reveal: Fixed Reveal plugin always revealing all PCs regardless of plugin usage.
 
 ## 8193.35.40
 https://github.com/nwnxee/unified/compare/build8193.35.37...build8193.35.40

--- a/Plugins/Reveal/Reveal.cpp
+++ b/Plugins/Reveal/Reveal.cpp
@@ -57,10 +57,9 @@ BOOL Reveal::HookStealthDetection(CNWSCreature* pObserverCreature, CNWSCreature*
             {
                 if (pObserverCreature->GetFaction()->GetLeader() == pHidingCreature->GetFaction()->GetLeader())
                 {
-                    if(pHidingCreature->nwnxGet<int>(detectionKey + "PARTY"))
-                    {
-                        *bSeen = true;
-                    }
+                    auto detectionVector = pHidingCreature->nwnxGet<int>(detectionKey + "PARTY");
+                    if (detectionVector && *detectionVector)
+                        *bSeen = *detectionVector;
                     *bHeard = true;
                     return true;
                 }
@@ -70,10 +69,11 @@ BOOL Reveal::HookStealthDetection(CNWSCreature* pObserverCreature, CNWSCreature*
             if (reveal && *reveal)
             {
                 pHidingCreature->nwnxRemove(revealKey + Utils::ObjectIDToString(pObserverCreature->m_idSelf)); //remove mapping after first check
-                if (pHidingCreature->nwnxGet<int>(detectionKey + Utils::ObjectIDToString(pObserverCreature->m_idSelf)))
-                {
-                    *bSeen = true;
-                }
+                
+                auto detectionVector = pHidingCreature->nwnxGet<int>(detectionKey + Utils::ObjectIDToString(pObserverCreature->m_idSelf));
+                if (detectionVector && *detectionVector)
+                    *bSeen = *detectionVector;
+
                 *bHeard = true;
                 return true;
             }

--- a/Plugins/Reveal/Reveal.cpp
+++ b/Plugins/Reveal/Reveal.cpp
@@ -46,17 +46,18 @@ Reveal::Reveal(Services::ProxyServiceList* services)
 Reveal::~Reveal()
 {
 }
-int32_t Reveal::HookStealthDetection(CNWSCreature* pObserverCreature, CNWSCreature* pHidingCreature, int32_t bClearLOS, int32_t* bSeen, int32_t* bHeard, int32_t bTargetInvisible)
+BOOL Reveal::HookStealthDetection(CNWSCreature* pObserverCreature, CNWSCreature* pHidingCreature, BOOL bClearLOS, BOOL* bSeen, BOOL* bHeard, BOOL bTargetHiding)
 {
     if (pObserverCreature->m_bPlayerCharacter && pHidingCreature->m_bPlayerCharacter && pHidingCreature->m_nStealthMode)
     {
         if (pObserverCreature->GetArea() == pHidingCreature->GetArea())
         {
-            if (*pHidingCreature->nwnxGet<int>(revealKey + "PARTY"))
+            auto partyReveal = pHidingCreature->nwnxGet<int>(revealKey + "PARTY");
+            if (partyReveal && *partyReveal)
             {
                 if (pObserverCreature->GetFaction()->GetLeader() == pHidingCreature->GetFaction()->GetLeader())
                 {
-                    if(*pHidingCreature->nwnxGet<int>(detectionKey + "PARTY"))
+                    if(pHidingCreature->nwnxGet<int>(detectionKey + "PARTY"))
                     {
                         *bSeen = true;
                     }
@@ -64,10 +65,12 @@ int32_t Reveal::HookStealthDetection(CNWSCreature* pObserverCreature, CNWSCreatu
                     return true;
                 }
             }
-            if (*pHidingCreature->nwnxGet<int>(revealKey + Utils::ObjectIDToString(pObserverCreature->m_idSelf)))
+
+            auto reveal = pHidingCreature->nwnxGet<int>(revealKey + Utils::ObjectIDToString(pObserverCreature->m_idSelf));
+            if (reveal && *reveal)
             {
                 pHidingCreature->nwnxRemove(revealKey + Utils::ObjectIDToString(pObserverCreature->m_idSelf)); //remove mapping after first check
-                if (*pHidingCreature->nwnxGet<int>(detectionKey + Utils::ObjectIDToString(pObserverCreature->m_idSelf)))
+                if (pHidingCreature->nwnxGet<int>(detectionKey + Utils::ObjectIDToString(pObserverCreature->m_idSelf)))
                 {
                     *bSeen = true;
                 }
@@ -76,7 +79,7 @@ int32_t Reveal::HookStealthDetection(CNWSCreature* pObserverCreature, CNWSCreatu
             }
         }
     }
-    return g_plugin->m_DoStealthDetection->CallOriginal<int32_t>(pObserverCreature, pHidingCreature, bClearLOS, bSeen, bHeard, bTargetInvisible);
+    return g_plugin->m_DoStealthDetection->CallOriginal<BOOL>(pObserverCreature, pHidingCreature, bClearLOS, bSeen, bHeard, bTargetHiding);
 }
 
 

--- a/Plugins/Reveal/Reveal.cpp
+++ b/Plugins/Reveal/Reveal.cpp
@@ -60,6 +60,9 @@ BOOL Reveal::HookStealthDetection(CNWSCreature* pObserverCreature, CNWSCreature*
                     auto detectionVector = pHidingCreature->nwnxGet<int>(detectionKey + "PARTY");
                     if (detectionVector && *detectionVector)
                         *bSeen = *detectionVector;
+                    else
+                        *bSeen = false;
+
                     *bHeard = true;
                     return true;
                 }
@@ -73,6 +76,8 @@ BOOL Reveal::HookStealthDetection(CNWSCreature* pObserverCreature, CNWSCreature*
                 auto detectionVector = pHidingCreature->nwnxGet<int>(detectionKey + Utils::ObjectIDToString(pObserverCreature->m_idSelf));
                 if (detectionVector && *detectionVector)
                     *bSeen = *detectionVector;
+                else
+                    *bSeen = false;
 
                 *bHeard = true;
                 return true;

--- a/Plugins/Reveal/Reveal.hpp
+++ b/Plugins/Reveal/Reveal.hpp
@@ -14,7 +14,7 @@ public:
 private:
     NWNXLib::Hooks::Hook m_DoStealthDetection;
 
-    static int32_t HookStealthDetection(CNWSCreature* thisCreature, CNWSCreature* pHidingCreature, int32_t bClearLOS, int32_t* bSeen, int32_t* bHeard, int32_t bTargetInvisible);
+    static BOOL HookStealthDetection(CNWSCreature* thisCreature, CNWSCreature* pHidingCreature, BOOL bClearLOS, BOOL* bSeen, BOOL* bHeard, BOOL bTargetHiding);
 
     ArgumentStack RevealTo(ArgumentStack&& args);
     ArgumentStack SetRevealToParty(ArgumentStack&& args);


### PR DESCRIPTION
As the label on the tin says, this fixes PCs always being revealed to other PCs when the plugin is enabled regardless of plugin usage, as mentioned by someone on discord a while ago which I ran into today when enabling and attempting to use the plugin: https://discord.com/channels/382306806866771978/387223972808359936/1121979712818917436