### PR TITLE
Added bChatWindow argument to NWNX_Player_FloatingTextStringOnCreature

### DIFF
--- a/NWNXLib/API/Constants/MiscRules.hpp
+++ b/NWNXLib/API/Constants/MiscRules.hpp
@@ -145,9 +145,10 @@ namespace SavingThrowType
         Evil         = 17,
         Law          = 18,
         Chaos        = 19,
+        Paralysis    = 20,
     };
     constexpr int32_t MIN   = 0;
-    constexpr int32_t MAX   = 19;
+    constexpr int32_t MAX   = 20;
 
     constexpr const char* ToString(const unsigned value)
     {
@@ -173,6 +174,7 @@ namespace SavingThrowType
             "Evil",
             "Law",
             "Chaos",
+            "Paralysis",
         };
 
         return (value > MAX) ? "(invalid)" : TYPE_STRINGS[value];

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -329,7 +329,8 @@ void NWNX_Player_SetCreatureNameOverride(object oPlayer, object oCreature, strin
 /// @param oPlayer The player to display the text to.
 /// @param oCreature The creature to display the text above.
 /// @param sText The text to display.
-void NWNX_Player_FloatingTextStringOnCreature(object oPlayer, object oCreature, string sText);
+/// @param bChatWindow If TRUE, sText will be displayed in oPlayer's chat window.
+void NWNX_Player_FloatingTextStringOnCreature(object oPlayer, object oCreature, string sText, int bChatWindow = TRUE);
 
 /// @brief Toggle oPlayer's PlayerDM status.
 /// @note This function does nothing for actual DMClient DMs or players with a client version < 8193.14
@@ -910,10 +911,11 @@ void NWNX_Player_SetCreatureNameOverride(object oPlayer, object oCreature, strin
     NWNX_CallFunction(NWNX_Player, sFunc);
 }
 
-void NWNX_Player_FloatingTextStringOnCreature(object oPlayer, object oCreature, string sText)
+void NWNX_Player_FloatingTextStringOnCreature(object oPlayer, object oCreature, string sText, int bChatWindow = TRUE)
 {
     string sFunc = "FloatingTextStringOnCreature";
 
+    NWNX_PushArgumentInt(bChatWindow);
     NWNX_PushArgumentString(sText);
     NWNX_PushArgumentObject(oCreature);
     NWNX_PushArgumentObject(oPlayer);

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -1263,6 +1263,15 @@ NWNX_EXPORT ArgumentStack FloatingTextStringOnCreature(ArgumentStack&& args)
           ASSERT_OR_THROW(oidCreature != Constants::OBJECT_INVALID);
         auto text = args.extract<std::string>();
           ASSERT_OR_THROW(!text.empty());
+        int32_t showInChat = 1;
+        try
+        {
+            showInChat = args.extract<int32_t>();
+        }
+        catch(const std::runtime_error& e)
+        {
+            LOG_WARNING("NWNX_Player_FloatingTextStringOnCreature: Missing bChatWindow arguments. Continuing with default values. Please update nwnx_player.nss and recompile your module!");
+        }
 
         if (auto *pCreature = Utils::AsNWSCreature(Utils::GetGameObject(oidCreature)))
         {
@@ -1270,6 +1279,7 @@ NWNX_EXPORT ArgumentStack FloatingTextStringOnCreature(ArgumentStack&& args)
             {
                 CNWCCMessageData messageData;
                 messageData.SetObjectID(0, pCreature->m_idSelf);
+                messageData.SetInteger(0, showInChat);
                 messageData.SetInteger(9, 94);
                 messageData.SetString(0, text);
 


### PR DESCRIPTION
No changelog, because not done for .36 yet
Also added the missing "Paralysis" constant for SavingThrowType

issue 1697 can now be closed (couldn't close it with #close - didn't show me that issue in the list)