### PR TITLE
Object: GetInventoryItemCount() will also work on stores.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ https://github.com/nwnxee/unified/compare/build8193.35.40...HEAD
 - Player: Added arguments for passing transform data (scale, translation, rotation) to `NWNX_Player_ShowVisualEffect()` and `NWNX_Player_ApplyInstantVisualEffectToObject()`
 - Damage: The damage event now also fires for doors
 - Feat: Added the 'Damage'(Increase/Decrease) as an option
+- Object: GetInventoryItemCount() will also work on stores.
 
 ### Deprecated
 - N/A

--- a/Plugins/Object/NWScript/nwnx_object.nss
+++ b/Plugins/Object/NWScript/nwnx_object.nss
@@ -393,7 +393,7 @@ int NWNX_Object_GetLastSpellCastDomainLevel(object oObject);
 void NWNX_Object_ForceAssignUUID(object oObject, string sUUID);
 
 /// @brief Returns how many items are in oObject's inventory.
-/// @param oObject A creature, placeable, or item.
+/// @param oObject A creature, placeable, item or store.
 /// @return Returns a count of how many items are in oObject's inventory.
 int NWNX_Object_GetInventoryItemCount(object oObject);
 

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -27,6 +27,7 @@
 #include "API/CLoopingVisualEffect.hpp"
 #include "API/CNWSpellArray.hpp"
 #include "API/CNWSSpellScriptData.hpp"
+#include "API/CNWSStore.hpp"
 #include "API/CNWSFaction.hpp"
 #include "API/CVirtualMachine.hpp"
 #include <cstring>
@@ -1009,6 +1010,22 @@ NWNX_EXPORT ArgumentStack ForceAssignUUID(ArgumentStack&& args)
     return {};
 }
 
+uint32_t GetItemRepositoryCount(CItemRepository *pRepo) {
+
+    auto nItems = 0;
+    for (auto *pNode = pRepo->m_oidItems.m_pcExoLinkedListInternal->pHead; pNode; pNode = pNode->pNext)
+    {
+        if (auto *pItem = pRepo->ItemListGetItem(pNode))
+        {
+            nItems++;
+            if (auto *pItemRepo = pItem->m_pItemRepository)
+                nItems += pItemRepo->m_oidItems.Count();
+            }
+        }
+
+    return nItems;
+}
+
 NWNX_EXPORT ArgumentStack GetInventoryItemCount(ArgumentStack&& args)
 {
     if (auto *pObject = Utils::PopObject(args))
@@ -1021,20 +1038,20 @@ NWNX_EXPORT ArgumentStack GetInventoryItemCount(ArgumentStack&& args)
             pRepo = pPlaceable->m_pcItemRepository;
         else if (auto *pItem = Utils::AsNWSItem(pObject))
             pRepo = pItem->m_pItemRepository;
+        else if (auto *pStore = Utils::AsNWSStore(pObject))
+	{
+		auto nItems = 0;
+		for (int n=0; n<5; n++)
+		{
+		    pRepo = pStore->m_aInventory[n];
+		    nItems += GetItemRepositoryCount (pRepo);
+		}
+		return nItems;
+	}
         else
             return 0;
 
-        auto nItems = 0;
-        for (auto *pNode = pRepo->m_oidItems.m_pcExoLinkedListInternal->pHead; pNode; pNode = pNode->pNext)
-        {
-            if (auto *pItem = pRepo->ItemListGetItem(pNode))
-            {
-                nItems++;
-                if (auto *pItemRepo = pItem->m_pItemRepository)
-                    nItems += pItemRepo->m_oidItems.Count();
-            }
-        }
-
+	auto nItems = GetItemRepositoryCount (pRepo);
         return nItems;
     }
 

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -1039,19 +1039,19 @@ NWNX_EXPORT ArgumentStack GetInventoryItemCount(ArgumentStack&& args)
         else if (auto *pItem = Utils::AsNWSItem(pObject))
             pRepo = pItem->m_pItemRepository;
         else if (auto *pStore = Utils::AsNWSStore(pObject))
-	{
-		auto nItems = 0;
-		for (int n=0; n<5; n++)
-		{
-		    pRepo = pStore->m_aInventory[n];
-		    nItems += GetItemRepositoryCount (pRepo);
-		}
-		return nItems;
-	}
+        {
+            auto nItems = 0;
+                for (int n=0; n<5; n++)
+                {
+                    pRepo = pStore->m_aInventory[n];
+                    nItems += GetItemRepositoryCount (pRepo);
+                }
+            return nItems;
+        }
         else
             return 0;
 
-	auto nItems = GetItemRepositoryCount (pRepo);
+    auto nItems = GetItemRepositoryCount (pRepo);
         return nItems;
     }
 

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -1010,8 +1010,8 @@ NWNX_EXPORT ArgumentStack ForceAssignUUID(ArgumentStack&& args)
     return {};
 }
 
-uint32_t GetItemRepositoryCount(CItemRepository *pRepo) {
-
+uint32_t GetItemRepositoryCount(CItemRepository *pRepo) 
+{
     auto nItems = 0;
     for (auto *pNode = pRepo->m_oidItems.m_pcExoLinkedListInternal->pHead; pNode; pNode = pNode->pNext)
     {
@@ -1041,17 +1041,17 @@ NWNX_EXPORT ArgumentStack GetInventoryItemCount(ArgumentStack&& args)
         else if (auto *pStore = Utils::AsNWSStore(pObject))
         {
             auto nItems = 0;
-                for (int n=0; n<5; n++)
-                {
-                    pRepo = pStore->m_aInventory[n];
-                    nItems += GetItemRepositoryCount (pRepo);
-                }
+            for (int n = 0; n < 5; n++)
+            {
+                pRepo = pStore->m_aInventory[n];
+                nItems += GetItemRepositoryCount (pRepo);
+            }
             return nItems;
         }
         else
             return 0;
 
-    auto nItems = GetItemRepositoryCount (pRepo);
+        auto nItems = GetItemRepositoryCount (pRepo);
         return nItems;
     }
 

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -1051,7 +1051,7 @@ NWNX_EXPORT ArgumentStack GetInventoryItemCount(ArgumentStack&& args)
         else
             return 0;
 
-        auto nItems = GetItemRepositoryCount (pRepo);
+        auto nItems = GetItemRepositoryCount(pRepo);
         return nItems;
     }
 


### PR DESCRIPTION
Stores have 5 CItemRepository's (one for each tab).

This adds a a function to count items in CItemRepository and loops over the store's to get full count.

Otherwise, existing Creature/Placeables/Items will call it and just return since they only have 1 CItemRepository.