### PR TITLE
Renamed Tile Events to Movement Events, and added events for AIActionJumpToPoint/Object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ https://github.com/nwnxee/unified/compare/build8193.35.40...HEAD
 - Events: added `NWNX_ON_PLACEABLE_CLOSE_{BEFORE|AFTER}` which fires when player closes a placeable.
 - Events: added event `NWNX_ON_CREATURE_TILE_CHANGE_{BEFORE|AFTER}` which fires when a creature changes the tile it's on.
 - Tweaks: added `NWNX_TWEAKS_SETAREA_CALLS_SETPOSITION` which will enable firing of the `NWNX_ON_MATERIALCHANGE_*` and `NWNX_ON_CREATURE_TILE_CHANGE_*` events when a creature is first added to an area.
+- Events: added `NWNX_ON_CREATURE_JUMP_TO_POSITION_{BEFORE|AFTER}` which fires when a creature is being jumped to a new location (area + x/y/z coordinates).
+- Events: added `NWNX_ON_CREATURE_JUMP_TO_OBJECT_{BEFORE|AFTER}` which fires when a creature is being jumped to a new location (to an object).
 
 ##### New Plugins
 - Resources: Adds `RESOURCES_*` variables for adding NWSync as a resource source, and specifying a replacement hak list.

--- a/Plugins/Events/CMakeLists.txt
+++ b/Plugins/Events/CMakeLists.txt
@@ -19,7 +19,7 @@ add_plugin(Events
     "Events/JournalEvents.cpp"
     "Events/LevelEvents.cpp"
     "Events/MapEvents.cpp"
-    "Events/TileEvents.cpp"
+    "Events/MovementEvents.cpp"
     "Events/ObjectEvents.cpp"
     "Events/PartyEvents.cpp"
     "Events/PolymorphEvents.cpp"

--- a/Plugins/Events/Events/MovementEvents.cpp
+++ b/Plugins/Events/Events/MovementEvents.cpp
@@ -167,7 +167,7 @@ int32_t ActionJumpToObjectHook(CNWSCreature* thisPtr, CNWSObjectActionNode* pAct
 
     if (PushAndSignal("NWNX_ON_CREATURE_JUMP_TO_OBJECT_BEFORE"))
     {
-        retVal = s_JumpToPointHook->CallOriginal<int32_t>(thisPtr, pActionNode);
+        retVal = s_JumpToObjectHook->CallOriginal<int32_t>(thisPtr, pActionNode);
     }
     else
     {

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1714,7 +1714,7 @@ _______________________________________
 _______________________________________
     ## Creature Jump To Point Events
     - NWNX_ON_CREATURE_JUMP_TO_POINT_BEFORE
-    - NWNX_ON_CREATURE_JUMP_TO_POINT_BEFORE
+    - NWNX_ON_CREATURE_JUMP_TO_POINT_AFTER
 
     `OBJECT_SELF` = The creature jumping.
 
@@ -1727,7 +1727,7 @@ _______________________________________
 _______________________________________
     ## Creature Jump To Object Events
     - NWNX_ON_CREATURE_JUMP_TO_OBJECT_BEFORE
-    - NWNX_ON_CREATURE_JUMP_TO_OBJECT_BEFORE
+    - NWNX_ON_CREATURE_JUMP_TO_OBJECT_AFTER
 
     `OBJECT_SELF` = The creature jumping.
 

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1712,6 +1712,29 @@ _______________________________________
     NEW_TILE_X            | int    | The tile grid x position of the new tile. |
     NEW_TILE_Y            | int    | The tile grid y position of the new tile. |
 _______________________________________
+    ## Creature Jump To Point Events
+    - NWNX_ON_CREATURE_JUMP_TO_POINT_BEFORE
+    - NWNX_ON_CREATURE_JUMP_TO_POINT_BEFORE
+
+    `OBJECT_SELF` = The creature jumping.
+
+    Event Data Tag        | Type   | Notes
+    ----------------------|--------|-------
+    TARGET_AREA           | object | The target area. Convert to object with StringToObject() |
+    POS_X                 | int    | The tile grid x position of the old tile. |
+    POS_Y                 | int    | The tile grid y position of the old tile. |
+    POS_Z                 | int    | The index of the new tile. |
+_______________________________________
+    ## Creature Jump To Object Events
+    - NWNX_ON_CREATURE_JUMP_TO_OBJECT_BEFORE
+    - NWNX_ON_CREATURE_JUMP_TO_OBJECT_BEFORE
+
+    `OBJECT_SELF` = The creature jumping.
+
+    Event Data Tag        | Type   | Notes
+    ----------------------|--------|-------
+    TARGET                | object | The object the creature is jumping to. Convert to object with StringToObject() |
+_______________________________________
 */
 
 /// @name Events Event Constants
@@ -2056,6 +2079,10 @@ const string NWNX_ON_ATTACK_TARGET_CHANGE_BEFORE = "NWNX_ON_ATTACK_TARGET_CHANGE
 const string NWNX_ON_ATTACK_TARGET_CHANGE_AFTER = "NWNX_ON_ATTACK_TARGET_CHANGE_AFTER";
 const string NWNX_ON_CREATURE_TILE_CHANGE_BEFORE = "NWNX_ON_CREATURE_TILE_CHANGE_BEFORE";
 const string NWNX_ON_CREATURE_TILE_CHANGE_AFTER = "NWNX_ON_CREATURE_TILE_CHANGE_AFTER";
+const string NWNX_ON_CREATURE_JUMP_TO_POINT_BEFORE = "NWNX_ON_CREATURE_JUMP_TO_POINT_BEFORE";
+const string NWNX_ON_CREATURE_JUMP_TO_POINT_AFTER = "NWNX_ON_CREATURE_JUMP_TO_POINT_AFTER";
+const string NWNX_ON_CREATURE_JUMP_TO_OBJECT_BEFORE = "NWNX_ON_CREATURE_JUMP_TO_OBJECT_BEFORE";
+const string NWNX_ON_CREATURE_JUMP_TO_OBJECT_AFTER = "NWNX_ON_CREATURE_JUMP_TO_OBJECT_AFTER";
 /// @}
 
 /// @name Events ObjectType Constants
@@ -2216,6 +2243,7 @@ string NWNX_Events_GetEventData(string tag);
 /// - EventScript event
 /// - Broadcast Safe Projectile event
 /// - Attack of Opportunity events
+/// - Creature Jump events
 void NWNX_Events_SkipEvent();
 
 /// Set the return value of the event.

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1721,9 +1721,9 @@ _______________________________________
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
     TARGET_AREA           | object | The target area. Convert to object with StringToObject() |
-    POS_X                 | int    | The tile grid x position of the old tile. |
-    POS_Y                 | int    | The tile grid y position of the old tile. |
-    POS_Z                 | int    | The index of the new tile. |
+    POS_X                 | float  | The x position the target is being moved to |
+    POS_Y                 | float  | The y position the target is being moved to |
+    POS_Z                 | float  | The z position the target is being moved to |
 _______________________________________
     ## Creature Jump To Object Events
     - NWNX_ON_CREATURE_JUMP_TO_OBJECT_BEFORE


### PR DESCRIPTION
As discussed in discord, this PR adds two new events to capture creature jumps to point or object. Link to the discussion:

https://discord.com/channels/382306806866771978/382914210176172032/1154714844977692783