### PR TITLE
Bugfix GetInventoryItemCount(): uint32_t to int32_t

### DIFF
--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -1010,7 +1010,7 @@ NWNX_EXPORT ArgumentStack ForceAssignUUID(ArgumentStack&& args)
     return {};
 }
 
-uint32_t GetItemRepositoryCount(CItemRepository *pRepo) 
+int32_t GetItemRepositoryCount(CItemRepository *pRepo) 
 {
     auto nItems = 0;
     for (auto *pNode = pRepo->m_oidItems.m_pcExoLinkedListInternal->pHead; pNode; pNode = pNode->pNext)


### PR DESCRIPTION
https://discord.com/channels/382306806866771978/382914210176172032/1162700205624401933

Per Daz: Returning a uint32_t confuses nwnx into thinking this is an objectID, which then returns as hex and throws warnings when trying to send int32_t back to game to read.