### PR TITLE
DotNET: Add crash handler override support.

### DIFF
--- a/Plugins/DotNET/NWN/Internal/Bootstrap.cs
+++ b/Plugins/DotNET/NWN/Internal/Bootstrap.cs
@@ -12,6 +12,7 @@ namespace NWN
         public delegate void ClosureHandlerDelegate(ulong eid, uint oid);
         public delegate void SignalHandlerDelegate(string signal);
         public delegate void AssertHandlerDelegate(string message, string stackTrace);
+        public delegate void CrashHandlerDelegate(int signal, string stackTrace);
 
         [StructLayout(LayoutKind.Sequential)]
         public struct AllHandlers
@@ -21,6 +22,7 @@ namespace NWN
             public ClosureHandlerDelegate   Closure;
             public SignalHandlerDelegate    Signal;
             public AssertHandlerDelegate    AssertFail;
+            public CrashHandlerDelegate     CrashHandler;
         }
 
         [SuppressUnmanagedCodeSecurity]


### PR DESCRIPTION
Adds support for overriding the NWNX crash handler.

This allows a custom C# handler to attempt to resolve a managed backtrace before crashing the server, giving better visibility when debugging. And hopefully less Anvil bugs ending up in the NWNX chat ;)

Example from a double-free issue:

![image](https://github.com/nwnxee/unified/assets/10942655/851bc2ed-466a-49c7-857a-21fdce0023bb)

I tried to implement this through the existing `MessageBus::Broadcast("NWNX_CORE_SIGNAL")` system, but wasn't able to reach managed code again before encountering more dragons.