### PR TITLE
Item: add {Get|Set}MinEquipLevel{Modifier|Override}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ https://github.com/nwnxee/unified/compare/build8193.35.40...HEAD
 - Util: GetModuleFile()
 - Creature: NWNX_Creature_GetMaxAttackRange()
 - Player: GetTURD()
+- Item: {Get|Set}MinEquipLevel{Modifier|Override}()
 
 ### Changed
 - Creature: Added an argument for passing a class package to `NWNX_Creature_LevelUp()`

--- a/Plugins/Item/Item.cpp
+++ b/Plugins/Item/Item.cpp
@@ -15,6 +15,8 @@
 using namespace NWNXLib;
 using namespace NWNXLib::API;
 
+static bool s_bMinEquipLevelHooksInitialized = false;
+
 NWNX_EXPORT ArgumentStack SetWeight(ArgumentStack&& args)
 {
     if (auto *pItem = Utils::PopItem(args))
@@ -280,9 +282,9 @@ CItemRepository* GetObjectItemRepository(OBJECT_ID oidPossessor)
 
     switch (pPossessor->m_nObjectType)
     {
-        case Constants::ObjectType::Creature: 
+        case Constants::ObjectType::Creature:
             return Utils::AsNWSCreature(pPossessor)->m_pcItemRepository;
-        case Constants::ObjectType::Placeable: 
+        case Constants::ObjectType::Placeable:
             return Utils::AsNWSPlaceable(pPossessor)->m_pcItemRepository;
         case Constants::ObjectType::Item:
             return Utils::AsNWSItem(pPossessor)->m_pItemRepository;
@@ -306,7 +308,7 @@ NWNX_EXPORT ArgumentStack MoveTo(ArgumentStack&& args)
                 oidRealItemPossessor = (pPossessor->m_nObjectType == Constants::ObjectType::Item) ? Utils::AsNWSItem(pPossessor)->m_oidPossessor : pPossessor->m_idSelf;
             }
             auto oidRealTargetPossessor = (pTarget->m_nObjectType == Constants::ObjectType::Item) ? Utils::AsNWSItem(pTarget)->m_oidPossessor : pTarget->m_idSelf;
-        
+
             // Is the item already on/in the target?
             if (oidRealItemPossessor == oidRealTargetPossessor)
             {
@@ -325,7 +327,7 @@ NWNX_EXPORT ArgumentStack MoveTo(ArgumentStack&& args)
                 case Constants::ObjectType::Creature:
                 {
                     auto pTargetCreature = Utils::AsNWSCreature(pTarget);
-                    
+
                     uint8_t x, y;
                     if (!pTargetCreature->m_pcItemRepository->FindPosition(pItem, x, y))
                     {
@@ -349,7 +351,7 @@ NWNX_EXPORT ArgumentStack MoveTo(ArgumentStack&& args)
                         LOG_DEBUG("NWNX_Item_MoveTo: Item does not fit in target placeable!");
                         return false;
                     }
-                    
+
                     pTargetPlaceable->AcquireItem(&pItem, pItem->m_oidPossessor, 0xFF, 0xFF, bSendFeedback);
                     break;
                 }
@@ -363,8 +365,8 @@ NWNX_EXPORT ArgumentStack MoveTo(ArgumentStack&& args)
                     pTargetStore->AcquireItem(pItem, false, 0xFF, 0xFF);
 
                     // CNWSStore::AcquireItem doesn't remove the source item
-                    if (pOriginalOwnerRepository) 
-                        pOriginalOwnerRepository->RemoveItem(pItem); 
+                    if (pOriginalOwnerRepository)
+                        pOriginalOwnerRepository->RemoveItem(pItem);
                     else if (pItem->m_oidArea != Constants::OBJECT_INVALID)
                         pItem->RemoveFromArea();
 
@@ -391,7 +393,7 @@ NWNX_EXPORT ArgumentStack MoveTo(ArgumentStack&& args)
                     if (!pTargetContainer->m_pItemRepository->FindPosition(pItem, x, y))
                     {
                         LOG_DEBUG("NWNX_Item_MoveTo: Item does not fit in target container!");
-                        
+
                         auto pOwnerCreature = Utils::AsNWSCreature(Utils::GetGameObject(oidRealTargetPossessor));
                         if (pOwnerCreature)
                         {
@@ -406,8 +408,8 @@ NWNX_EXPORT ArgumentStack MoveTo(ArgumentStack&& args)
                     pTargetContainer->AcquireItem(&pItem, pItem->m_oidPossessor, 0xFF, 0xFF, bSendFeedback);
                     break;
                 }
-                
-                default: 
+
+                default:
                     LOG_ERROR("NWNX_Item_MoveTo: Invalid target object type!");
                     return false;
             }
@@ -417,4 +419,79 @@ NWNX_EXPORT ArgumentStack MoveTo(ArgumentStack&& args)
     }
 
     return false;
+}
+
+static void InitItemEquipLevelHook()
+{
+    static Hooks::Hook pGetMinEquipLevel_hook =
+        Hooks::HookFunction(&CNWSItem::GetMinEquipLevel, +[](CNWSItem *pThis) -> uint8_t
+        {
+            int32_t retVal;
+
+            if (auto minEquipOvr = pThis->nwnxGet<int32_t>("MINIMUM_EQUIP_LEVEL_OVERRIDE"))
+                retVal = minEquipOvr.value();
+            else
+                retVal = pGetMinEquipLevel_hook->CallOriginal<uint8_t>(pThis);
+
+            if (auto minEquipMod = pThis->nwnxGet<int32_t>("MINIMUM_EQUIP_LEVEL_MODIFIER"))
+                retVal = retVal + minEquipMod.value();
+
+            return std::clamp<uint8_t>(retVal, 1, 255);
+        }, Hooks::Order::Late);
+
+    s_bMinEquipLevelHooksInitialized = true;
+}
+
+NWNX_EXPORT ArgumentStack SetMinEquipLevelModifier(ArgumentStack&& args)
+{
+    if (!s_bMinEquipLevelHooksInitialized)
+        InitItemEquipLevelHook();
+
+    if (auto* pItem = Utils::PopItem(args))
+    {
+        const auto modifier = args.extract<int32_t>();
+        const bool persist = !!args.extract<int32_t>();
+
+        if (modifier)
+            pItem->nwnxSet("MINIMUM_EQUIP_LEVEL_MODIFIER", modifier, persist);
+        else
+            pItem->nwnxRemove("MINIMUM_EQUIP_LEVEL_MODIFIER");
+    }
+    return {};
+}
+
+NWNX_EXPORT ArgumentStack GetMinEquipLevelModifier(ArgumentStack&& args)
+{
+    if (auto* pItem = Utils::PopItem(args))
+    {
+        return pItem->nwnxGet<int32_t>("MINIMUM_EQUIP_LEVEL_MODIFIER").value_or(0);
+    }
+    return 0;
+}
+
+NWNX_EXPORT ArgumentStack SetMinEquipLevelOverride(ArgumentStack&& args)
+{
+    if (!s_bMinEquipLevelHooksInitialized)
+        InitItemEquipLevelHook();
+
+    if (auto* pItem = Utils::PopItem(args))
+    {
+        const auto modifier = args.extract<int32_t>();
+        const bool persist = !!args.extract<int32_t>();
+
+        if (modifier)
+            pItem->nwnxSet("MINIMUM_EQUIP_LEVEL_OVERRIDE", modifier, persist);
+        else
+            pItem->nwnxRemove("MINIMUM_EQUIP_LEVEL_OVERRIDE");
+    }
+    return {};
+}
+
+NWNX_EXPORT ArgumentStack GetMinEquipLevelOverride(ArgumentStack&& args)
+{
+    if (auto* pItem = Utils::PopItem(args))
+    {
+        return pItem->nwnxGet<int32_t>("MINIMUM_EQUIP_LEVEL_OVERRIDE").value_or(0);
+    }
+    return 0;
 }

--- a/Plugins/Item/NWScript/nwnx_item.nss
+++ b/Plugins/Item/NWScript/nwnx_item.nss
@@ -100,6 +100,31 @@ int NWNX_Item_GetMinEquipLevel(object oItem);
 /// @return TRUE if the item was successfully moved to the target, otherwise FALSE
 int NWNX_Item_MoveTo(object oItem, object oTarget, int bHideAllFeedback = FALSE);
 
+/// @brief Set a modifier to the Minimum Level to Equip (Item Level Restriction).
+/// @param oItem The item object.
+/// @param nModifier the modifier to apply (After any Override)
+/// @param bPersist Whether the modifier should persist to gff field. Strongly Recommended to be TRUE (See warning)
+/// @note This function (or override partner) must be used each server reset to reenable persistence. Recommended use on OBJECT_INVALID OnModuleLoad.
+/// @warning if Persistence is FALSE, or not renabled, beware characters may trigger ELC logging in with now-invalid ItemLevelRestrictions equipped.
+void NWNX_Item_SetMinEquipLevelModifier(object oItem, int nModifier, int bPersist = TRUE);
+
+/// @brief Gets the applied modifier to the Minimum Level to Equip (Item Level Restriction).
+/// @param oItem The item object.
+int NWNX_Item_GetMinEquipLevelModifier(object oItem);
+
+/// @brief Set an override to the Minimum Level to Equip (Item Level Restriction).
+/// @param oItem The item object.
+/// @param nOverride the nOverride to apply (Before any Modifier)
+/// @param bPersist Whether the modifier should persist to gff field. Strongly Recommended to be TRUE (See warning)
+/// @note This function (or modifier partner) must be used each server reset to reenable persistence. Recommended use on OBJECT_INVALID OnModuleLoad.
+/// @warning if Persistence is FALSE, or not renabled, beware characters may trigger ELC logging in with now-invalid ItemLevelRestrictions equipped.
+void NWNX_Item_SetMinEquipLevelOverride(object oItem, int nOverride, int bPersist = TRUE);
+
+/// @brief Gets the applied override to the Minimum Level to Equip (Item Level Restriction).
+/// @param oItem The item object.
+int NWNX_Item_GetMinEquipLevelOverride(object oItem);
+
+
 /// @}
 
 void NWNX_Item_SetWeight(object oItem, int w)
@@ -225,5 +250,47 @@ int NWNX_Item_MoveTo(object oItem, object oTarget, int bHideAllFeedback = FALSE)
 
     NWNX_CallFunction(NWNX_Item, sFunc);
 
+    return NWNX_GetReturnValueInt();
+}
+
+void NWNX_Item_SetMinEquipLevelModifier(object oItem, int nModifier, int bPersist = TRUE)
+{
+    string sFunc = "SetMinEquipLevelModifier";
+
+    NWNX_PushArgumentInt(bPersist);
+    NWNX_PushArgumentInt(nModifier);
+    NWNX_PushArgumentObject(oItem);
+
+    NWNX_CallFunction(NWNX_Item, sFunc);
+}
+
+int NWNX_Item_GetMinEquipLevelModifier(object oItem)
+{
+    string sFunc = "GetMinEquipLevelModifier";
+
+    NWNX_PushArgumentObject(oItem);
+
+    NWNX_CallFunction(NWNX_Item, sFunc);
+    return NWNX_GetReturnValueInt();
+}
+
+void NWNX_Item_SetMinEquipLevelOverride(object oItem, int nOverride, int bPersist = TRUE)
+{
+    string sFunc = "SetMinEquipLevelOverride";
+
+    NWNX_PushArgumentInt(bPersist);
+    NWNX_PushArgumentInt(nOverride);
+    NWNX_PushArgumentObject(oItem);
+
+    NWNX_CallFunction(NWNX_Item, sFunc);
+}
+
+int NWNX_Item_GetMinEquipLevelOverride(object oItem)
+{
+    string sFunc = "GetMinEquipLevelOverride";
+
+    NWNX_PushArgumentObject(oItem);
+
+    NWNX_CallFunction(NWNX_Item, sFunc);
     return NWNX_GetReturnValueInt();
 }


### PR DESCRIPTION
Allows a direct modifier or override (or both) to an item's Minimum Equip Level for Item Level Restriction purposes. Uses POS for persistence.

Apologies for the auto-cleared non-significant whitespace. 