### PR TITLE
Area: Fix RotateArea's NewOrientation for NWN bearings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ https://github.com/nwnxee/unified/compare/build8193.35.40...HEAD
 ### Fixed
 - Experimental: PlayerHitpointsAsPercentage: added the new argument nMessageLimit to SendServerToPlayerGameObjUpdate hook
 - Reveal: Fixed Reveal plugin always revealing all PCs regardless of plugin usage.
+- Area: RotateArea's 'NewOrientation' corrected for NWN bearings, correcting direction of objects within the area after 90 or 270 degree rotation.
 
 ## 8193.35.40
 https://github.com/nwnxee/unified/compare/build8193.35.37...build8193.35.40

--- a/Plugins/Area/Area.cpp
+++ b/Plugins/Area/Area.cpp
@@ -1044,7 +1044,7 @@ NWNX_EXPORT ArgumentStack RotateArea(ArgumentStack&& args)
                 case 1:
                 {
                     vOrientation.x = (std::cos(std::acos(vOrientation.x) - (M_PI/2)));//less half-radian
-                    vOrientation.y = (std::sin(std::asin(vOrientation.y) - (M_PI/2)));
+                    vOrientation.y = (std::sin(std::asin(vOrientation.y) + (M_PI/2)));
                     break;
                 }
                 case 2:
@@ -1056,7 +1056,7 @@ NWNX_EXPORT ArgumentStack RotateArea(ArgumentStack&& args)
                 case 3:
                 {
                     vOrientation.x = (std::cos(std::acos(vOrientation.x) + (M_PI/2)));//Add half-radian
-                    vOrientation.y = (std::sin(std::asin(vOrientation.y) + (M_PI/2)));
+                    vOrientation.y = (std::sin(std::asin(vOrientation.y) - (M_PI/2)));
                     break;
                 }
             }


### PR DESCRIPTION
Original math based on +90degrees being clockwise. NWN uses +90 degrees to be Anti-clockwise. PR fixes the math for this.
Thanks @Daztek for troubleshooting the math.