### PR TITLE
Edit SEV_ERROR log channel styling

### DIFF
--- a/NWNXLib/Log.cpp
+++ b/NWNXLib/Log.cpp
@@ -86,7 +86,7 @@ void InternalTrace(Channel::Enum channel, Channel::Enum allowedChannel, const ch
         case Channel::SEV_INFO:    std::cout << rang::fg::gray;                      break;
         case Channel::SEV_NOTICE:  /*default*/                                       break;
         case Channel::SEV_WARNING: std::cout << rang::fg::yellow;                    break;
-        case Channel::SEV_ERROR:   std::cout << rang::fg::red << rang::style::dim;   break;
+        case Channel::SEV_ERROR:   std::cout << rang::fg::red;                       break;
         case Channel::SEV_FATAL:   std::cout << rang::fg::red << rang::style::bold;  break;
     }
     std::cout << message << rang::style::reset << rang::fg::reset  << std::endl;


### PR DESCRIPTION
The current dim red color is hard to read on windows terminal output, when using a dark color theme. This change removes the "dim" tag in order to give it a more contrasted red color.