### PR TITLE
Item: RestoreItemAppearance updates item BaseAC Immediately.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ https://github.com/nwnxee/unified/compare/build8193.36.9...HEAD
 - N/A
 
 ### Changed
-- N/A
+- NWNX_Item_RestoreItemAppearance() will now force an immediate update to the items AC, depending on new appearance.
 
 ### Deprecated
 - N/A

--- a/Plugins/Item/Item.cpp
+++ b/Plugins/Item/Item.cpp
@@ -251,6 +251,7 @@ NWNX_EXPORT ArgumentStack RestoreItemAppearance(ArgumentStack&& args)
                 break;
             }
         }
+        pItem->m_nArmorValue = pItem->ComputeArmorClass();
     }
     else
     {


### PR DESCRIPTION
Previously, an appearance change from RestoreItemAppearance which resulted in a different Base AC (I.E. Torso's changing appearance to a different armour type) would not recalculate straight away. In our experience applying this to player gear, we found they would logout with their newly changed armour only to be hit with ELC due to the item level mismatch on re-entry. 

Some investigation lead to this simple fix. ComputeAC is such a small function I'm just calling it on any item - If desired (or this causes unforeseen problems) could gate it behind an `if(BaseType == Armor)`.