### PR TITLE
Add basic file writing capacities

### DIFF
--- a/Plugins/File/CMakeLists.txt
+++ b/Plugins/File/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_plugin(File "File.cpp")

--- a/Plugins/File/File.cpp
+++ b/Plugins/File/File.cpp
@@ -1,0 +1,70 @@
+#include "nwnx.hpp"
+
+#include <filesystem>
+#include <fstream>
+
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+namespace fs = std::filesystem;
+
+
+std::string ValidateFilePath(const std::string& filename)
+{
+    if (filename.length() >= 255)
+    {
+      LOG_ERROR("Passed filename is too long.");
+      return "";
+    }
+
+    std::string filepath = fs::current_path();
+
+    while (true)
+    {
+        if (fs::is_directory(filepath + "/logs.0"))
+            return filepath + "/logs.0/" + filename;
+
+        std::size_t nloc = filepath.rfind("/");
+        if (nloc == std::string::npos)
+            return "";
+
+        filepath = filepath.substr(0, nloc);
+        if (filepath.length() <= 1)
+            return "";
+    }
+}
+
+NWNX_EXPORT ArgumentStack FileTruncate(ArgumentStack&& args)
+{
+    const auto filename = args.extract<std::string>();
+
+    std::string filepath = ValidateFilePath(filename);
+    if (!filepath.length())
+      return {};
+
+    std::ofstream outfile(filepath, std::ios_base::out);
+
+    return {};
+}
+
+NWNX_EXPORT ArgumentStack FileAppend(ArgumentStack&& args)
+{
+    const auto filename = args.extract<std::string>();
+    const auto line = args.extract<std::string>();
+
+    if (line.length() >= 4096)
+    {
+      LOG_ERROR("Passed line is too long.");
+      return "";
+    }
+
+    std::string filepath = ValidateFilePath(filename);
+    if (!filepath.length())
+      return {};
+
+    std::ofstream outfile(filepath, std::ios_base::app);
+    outfile << line << "\n";
+
+    return {};
+}

--- a/Plugins/File/NWScript/nwnx_file.nss
+++ b/Plugins/File/NWScript/nwnx_file.nss
@@ -1,0 +1,31 @@
+/// @addtogroup file File
+/// @brief Various file writing functions
+/// @{
+/// @file nwnx_file.nss
+#include "nwnx"
+
+const string NWNX_File = "NWNX_File"; ///< @private
+
+/// @brief Truncate the file
+void NWNX_File_Truncate(string filename);
+
+/// @brief Append line to file
+void NWNX_File_Append(string filename, string line);
+
+void NWNX_File_Truncate(string filename)
+{
+    string sFunc = "FileTruncate";
+
+    NWNX_PushArgumentString(filename);
+    NWNX_CallFunction(NWNX_File, sFunc);
+}
+
+void NWNX_File_Append(string filename, string line)
+{
+    string sFunc = "FileAppend";
+
+    NWNX_PushArgumentString(line);
+    NWNX_PushArgumentString(filename);
+    NWNX_CallFunction(NWNX_File, sFunc);
+}
+


### PR DESCRIPTION
I currently export textual data when starting the server. My current method consists of using the log functions, and using the script name as a prefix to then grep the server logs and build a rst (sphinx documentation file).

During discussions, it was proposed I use sqlite instead. But that requires creating the schema, exporting to sqlite, and then extracting and formatting to rst. Much more complicated.

Being able to write arbitrary files also will allow me to keep a distinct `warnings.log` and `errors.log`, something like:

```
void LogWarning(string sLogEntry, string sConsoleColor = CONSOLE_COLOR_YELLOW);
void LogWarning(string sLogEntry, string sConsoleColor = CONSOLE_COLOR_YELLOW)
{
  WriteTimestampedLogEntryEx("warning:", sLogEntry, CONSOLE_COLOR_YELLOW);
  NWNX_File_Append("/../../logs/warnings.log", sLogEntry);
}
```

There's many other possibilities that open up when allowing file operations via NWNX.

I've added the strict minimum for now, but will augment the available functions depending on demand.