### PR TITLE
Correct spurious sqlite errors

### DIFF
--- a/Compatibility/inc_array.nss
+++ b/Compatibility/inc_array.nss
@@ -300,8 +300,15 @@ void Array_Erase(string tag, int index, object obj=OBJECT_INVALID)
 // if not found, return INVALID_INDEX
 int Array_Find_Str(string tag, string element, object obj=OBJECT_INVALID)
 {
-    string stmt = "SELECT IFNULL(MIN(ind),@invalid_index) FROM "+GetTableName(tag, obj)+" WHERE value = @element";
-    sqlquery sqlQuery = SqlPrepareQueryObject(GetModule(), stmt);
+    string stmt;
+    sqlquery sqlQuery;
+
+    // Just create it before trying to select in case it doesn't exist yet.
+    CreateArrayTable(tag, obj);
+
+    stmt = "SELECT IFNULL(MIN(ind),@invalid_index) FROM "+GetTableName(tag, obj)+" WHERE value = @element";
+    sqlQuery = SqlPrepareQueryObject(GetModule(), stmt);
+
     SqlBindInt(sqlQuery, "@invalid_index", INVALID_INDEX);
     SqlBindString(sqlQuery, "@element", element);
     if ( SqlStep(sqlQuery) ) {
@@ -367,6 +374,9 @@ void Array_Insert_Obj(string tag, int index, object element, object obj=OBJECT_I
 // Insert a new element at the end of the array.
 void Array_PushBack_Str(string tag, string element, object obj=OBJECT_INVALID)
 {
+    // Create it before trhing to INSERT into it.  If it already exists, this is a no-op.
+    CreateArrayTable(tag, obj);
+    
     // If rowCount = 10, indexes are from 0 to 9, so this becomes the 11th entry at index 10.
     int rowCount = GetRowCount(tag, obj);
 


### PR DESCRIPTION
Trying to get data from an array that doesn't have a supporting table created yet produces sqlite errors.

In several cases, just create the table before trying to insert/select from it.   

No harm to the data.  If it already exists, nothing happens and if it didn't exist, it will now exist and be empty.