### PR TITLE
Add NWNX_Player_ReloadTlk()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ https://github.com/nwnxee/unified/compare/build8193.36.12...HEAD
 - Store: {Get|Set}BlackMarketMarkDown()
 - Store: {Get|Set}MarkDown()
 - Store: {Get|Set}MarkUp()
+- Player: ReloadTlk()
 
 ### Changed
 - N/A

--- a/Plugins/Player/NWScript/nwnx_player.nss
+++ b/Plugins/Player/NWScript/nwnx_player.nss
@@ -396,6 +396,10 @@ void NWNX_Player_CloseStore(object oPlayer);
 /// @note Overrides will not persist through relogging.
 void NWNX_Player_SetTlkOverride(object oPlayer, int nStrRef, string sOverride, int bRestoreGlobal = TRUE);
 
+/// @brief Make the player reload it's TlkTable.
+/// @param oPlayer The player.
+void NWNX_Player_ReloadTlk(object oPlayer);
+
 /// @brief Update wind for oPlayer only.
 /// @param oPlayer The player.
 /// @param vDirection The Wind's direction.
@@ -1046,6 +1050,14 @@ void NWNX_Player_SetTlkOverride(object oPlayer, int nStrRef, string sOverride, i
     NWNX_PushArgumentInt(bRestoreGlobal);
     NWNX_PushArgumentString(sOverride);
     NWNX_PushArgumentInt(nStrRef);
+    NWNX_PushArgumentObject(oPlayer);
+    NWNX_CallFunction(NWNX_Player, sFunc);
+}
+
+void NWNX_Player_ReloadTlk(object oPlayer)
+{
+    string sFunc = "ReloadTlk";
+
     NWNX_PushArgumentObject(oPlayer);
     NWNX_CallFunction(NWNX_Player, sFunc);
 }

--- a/Plugins/Player/Player.cpp
+++ b/Plugins/Player/Player.cpp
@@ -1711,6 +1711,30 @@ NWNX_EXPORT ArgumentStack SetTlkOverride(ArgumentStack&& args)
     return {};
 }
 
+NWNX_EXPORT ArgumentStack ReloadTlk(ArgumentStack&& args)
+{
+    if (auto *pPlayer = Utils::PopPlayer(args))
+    {
+        if (auto *pMessage = Globals::AppManager()->m_pServerExoApp->GetNWSMessage())
+        {
+            pMessage->CreateWriteMessage(4, pPlayer->m_nPlayerID, 1);
+            pMessage->WriteDWORD(0x10);
+            uint8_t *buffer;
+            uint32_t size;
+            if (pMessage->GetWriteMessage(&buffer, &size))
+            {
+                pMessage->SendServerToPlayerMessage(pPlayer->m_nPlayerID,
+                                                    Constants::MessageMajor::Resman,
+                                                    0x4,
+                                                    buffer, size);
+            }
+        }
+    }
+
+    return {};
+}
+
+
 NWNX_EXPORT ArgumentStack UpdateWind(ArgumentStack&& args)
 {
     if (auto *pPlayer = Utils::PopPlayer(args))


### PR DESCRIPTION
In case you want the less capable, but also less dangerous thing ;-)

Tested with 2 tlks: faerun_en.tlk and faerun_fr.tlk. Both served with nwsync.

Changed from "en" to "fr" via these two lines:

```
NWNX_Player_SetResManOverride(oSpeaker, RESTYPE_TLK, "faerun_en", "faerun_fr");
NWNX_Player_ReloadTlk(oSpeaker);
```