### PR TITLE
Add Object: GetNameByLanguage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 https://github.com/nwnxee/unified/compare/build8193.36.12...HEAD
 
 ### Added
-- N/A
+- Object: GetNameByLanguage()
 
 ##### New Plugins
 - N/A

--- a/Plugins/Object/NWScript/nwnx_object.nss
+++ b/Plugins/Object/NWScript/nwnx_object.nss
@@ -418,6 +418,12 @@ int NWNX_Object_GetLastSpellInstant();
 /// @param oCreator The new creator of the trap. Any non-creature creator will assign OBJECT_INVALID (similar to toolset-laid traps)
 void NWNX_Object_SetTrapCreator(object oObject, object oCreator);
 
+/// @brief Return the name of the object as set in the toolset for nLanguage.
+/// @param oObject an object
+/// @param nLanguage A PLAYER_LANGUAGE constant.
+/// @return The localized string.
+string NWNX_Object_GetNameByLanguage(object oObject, int nLanguage);
+
 /// @}
 
 int NWNX_Object_GetLocalVariableCount(object obj)
@@ -1035,4 +1041,15 @@ void NWNX_Object_SetTrapCreator(object oObject, object oCreator)
     NWNX_PushArgumentObject(oCreator);
     NWNX_PushArgumentObject(oObject);
     NWNX_CallFunction(NWNX_Object, sFunc);
+}
+
+string NWNX_Object_GetNameByLanguage(object oObject, int nLanguage)
+{
+    string sFunc = "GetNameByLanguage";
+
+    NWNX_PushArgumentInt(nLanguage);
+    NWNX_PushArgumentObject(oObject);
+
+    NWNX_CallFunction(NWNX_Object, sFunc);
+    return NWNX_GetReturnValueString();
 }

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -1285,3 +1285,16 @@ NWNX_EXPORT ArgumentStack SetTrapCreator(ArgumentStack&& args)
     }
     return {};
 }
+
+NWNX_EXPORT ArgumentStack GetNameByLanguage(ArgumentStack&& args)
+{
+    if (auto *pObject = Utils::PopObject(args))
+    {
+        const auto nLanguage = args.extract<int32_t>();
+
+        CExoString myString;
+        pObject->GetFirstName().GetString(nLanguage, &myString);
+        return myString;
+    }
+    return {};
+}


### PR DESCRIPTION
When filing in the French and English section of a placeable in the toolset, and using the French interface, the name stays in English during game. Only interface, and items seem correctly translated.

Currently, with the reload-tlk PR, I can correctly show FloatingText by ResRef.

With this patch, I can also override creature and placeable names for the player which is one step forward to my dual-language module.