### PR TITLE
Add Object: {Get|Set}NameByLanguage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ https://github.com/nwnxee/unified/compare/build8193.36.12...HEAD
 
 ##### New NWScript Functions
 - Util: GetModuleTlkFile()
+- Object: {Set|Get}LocalizedName()
 
 ### Changed
 - N/A

--- a/Plugins/Object/NWScript/nwnx_object.nss
+++ b/Plugins/Object/NWScript/nwnx_object.nss
@@ -418,6 +418,21 @@ int NWNX_Object_GetLastSpellInstant();
 /// @param oCreator The new creator of the trap. Any non-creature creator will assign OBJECT_INVALID (similar to toolset-laid traps)
 void NWNX_Object_SetTrapCreator(object oObject, object oCreator);
 
+/// @brief Return the name of the object for nLanguage.
+/// @param oObject an object
+/// @param nLanguage A PLAYER_LANGUAGE constant.
+/// @param nGender   Gender to use, 0 or 1.
+/// @return The localized string.
+string NWNX_Object_GetLocalizedName(object oObject, int nLanguage, int nGender = 0);
+
+/// @brief Set the name of the object as set in the toolset for nLanguage.
+/// @note You may have to SetName(oObject, "") for the translated string to show.
+/// @param oObject an object
+/// @param sName New value to set
+/// @param nLanguage A PLAYER_LANGUAGE constant.
+/// @param nGender   Gender to use, 0 or 1.
+void NWNX_Object_SetLocalizedName(object oObject, string sName, int nLanguage, int nGender = 0);
+
 /// @}
 
 int NWNX_Object_GetLocalVariableCount(object obj)
@@ -1034,5 +1049,29 @@ void NWNX_Object_SetTrapCreator(object oObject, object oCreator)
     string sFunc = "SetTrapCreator";
     NWNX_PushArgumentObject(oCreator);
     NWNX_PushArgumentObject(oObject);
+    NWNX_CallFunction(NWNX_Object, sFunc);
+}
+
+string NWNX_Object_GetLocalizedName(object oObject, int nLanguage, int nGender = 0)
+{
+    string sFunc = "GetLocalizedName";
+
+    NWNX_PushArgumentInt(nGender);
+    NWNX_PushArgumentInt(nLanguage);
+    NWNX_PushArgumentObject(oObject);
+
+    NWNX_CallFunction(NWNX_Object, sFunc);
+    return NWNX_GetReturnValueString();
+}
+
+void NWNX_Object_SetLocalizedName(object oObject, string sName, int nLanguage, int nGender = 0)
+{
+    string sFunc = "SetLocalizedName";
+
+    NWNX_PushArgumentInt(nGender);
+    NWNX_PushArgumentInt(nLanguage);
+    NWNX_PushArgumentString(sName);
+    NWNX_PushArgumentObject(oObject);
+
     NWNX_CallFunction(NWNX_Object, sFunc);
 }

--- a/Plugins/Object/Object.cpp
+++ b/Plugins/Object/Object.cpp
@@ -1285,3 +1285,46 @@ NWNX_EXPORT ArgumentStack SetTrapCreator(ArgumentStack&& args)
     }
     return {};
 }
+
+NWNX_EXPORT ArgumentStack GetLocalizedName(ArgumentStack&& args)
+{
+    if (auto *pGameObject = Utils::PopGameObject(args))
+    {
+        const auto nLanguage = args.extract<int32_t>();
+        const auto nGender   = args.extract<int32_t>();
+
+        CExoString myString;
+
+        if (auto *pArea = Utils::AsNWSArea(pGameObject))
+            pArea->m_lsName.GetString(nLanguage, &myString, nGender);
+        else if (auto *pObject = Utils::AsNWSObject(pGameObject))
+            pObject->GetFirstName().GetString(nLanguage, &myString, nGender);
+
+        return myString;
+    }
+    return {};
+}
+
+NWNX_EXPORT ArgumentStack SetLocalizedName(ArgumentStack&& args)
+{
+    if (auto *pGameObject = Utils::PopGameObject(args))
+    {
+        const auto sName     = args.extract<std::string>();
+        const auto nLanguage = args.extract<int32_t>();
+        const auto nGender   = args.extract<int32_t>();
+
+        CExoString myString(sName);
+        if (auto *pArea = Utils::AsNWSArea(pGameObject))
+        {
+            pArea->m_lsName.RemoveString(nLanguage, nGender);
+            pArea->m_lsName.AddString(nLanguage, myString, nGender);
+        }
+        else if (auto *pObject = Utils::AsNWSObject(pGameObject))
+        {
+            pObject->GetFirstName().RemoveString(nLanguage, nGender);
+            pObject->GetFirstName().AddString(nLanguage, myString, nGender);
+        }
+    }
+
+    return {};
+}


### PR DESCRIPTION
In my effort to have dual-language module, using `SetName` will overwrite translations. For this reason, if we set the name for specific languages, and then usually `SetName(oObject, "")`, the translations will be correct for all players.

Their might be 3 gender values, neutral, male, and female, but experimenting with French made out to have male=0, female=1. Unsure, but I believe German might be a language with three language genders.