### PR TITLE
Create a new store plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ https://github.com/nwnxee/unified/compare/build8193.36.12...HEAD
 - N/A
 
 ##### New Plugins
-- N/A
+- Store: Enables getting and setting store data.
 
 ##### New NWScript Functions
 - Util: GetModuleTlkFile()
+- Store: New `GetIsRestrictedBuyItem`
+- Store: New `{Get|Set}BlackMarketMarkDown`
+- Store: New `{Get|Set}MarkDown`
+- Store: New `{Get|Set}MarkUp`
 
 ### Changed
 - N/A

--- a/NWNXLib/Utils.cpp
+++ b/NWNXLib/Utils.cpp
@@ -509,6 +509,10 @@ CNWSDoor* PopDoor(ArgumentStack& args, bool throwOnFail)
 {
     return AsNWSDoor(PopGameObject(args, throwOnFail));
 }
+CNWSStore* PopStore(ArgumentStack& args, bool throwOnFail)
+{
+    return AsNWSStore(PopGameObject(args, throwOnFail));
+}
 CNWSPlayer* PopPlayer(ArgumentStack& args, bool throwOnFail)
 {
     const auto playerId = args.extract<ObjectID>();

--- a/NWNXLib/nwnx.hpp
+++ b/NWNXLib/nwnx.hpp
@@ -251,6 +251,7 @@ namespace Utils
     CNWSWaypoint*  PopWaypoint(ArgumentStack& args, bool throwOnFail=false);
     CNWSTrigger*   PopTrigger(ArgumentStack& args, bool throwOnFail=false);
     CNWSDoor*      PopDoor(ArgumentStack& args, bool throwOnFail=false);
+    CNWSStore*     PopStore(ArgumentStack& args, bool throwOnFail=false);
 
     int32_t NWScriptObjectTypeToEngineObjectType(int32_t nwscriptObjectType);
     void UpdateClientObject(ObjectID oidObject);

--- a/Plugins/Store/CMakeLists.txt
+++ b/Plugins/Store/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_plugin(Store
+    "Store.cpp")

--- a/Plugins/Store/NWScript/nwnx_store.nss
+++ b/Plugins/Store/NWScript/nwnx_store.nss
@@ -1,0 +1,131 @@
+/// @addtogroup store
+/// @brief Functions exposing additional store properties.
+/// @{
+/// @file nwnx_store.nss
+#include "nwnx"
+
+const string NWNX_Store = "NWNX_Store"; ///< @private
+
+/// @brief Return status of a base item purchase status.
+/// @param oStore The store object.
+/// @param nBaseItem A BASE_ITEM_* value
+/// @return TRUE if the quest has been completed. -1 if the player does not have the journal entry.
+int NWNX_Store_GetIsRestrictedBuyItem(object oStore, int nBaseItem);
+
+/// @brief Return the blackmarket mark down of a store
+/// @param oStore The store object.
+/// @return mark down of a store, -1 on error
+int NWNX_Store_GetBlackMarketMarkDown(object oStore);
+
+/// @brief Set the blackmarket mark down of a store
+/// @param oStore The store object.
+/// @param nValue The amount.
+void NWNX_Store_SetBlackMarketMarkDown(object oStore, int nValue);
+
+/// @brief Return the mark down of a store
+/// @param oStore The store object.
+/// @return mark down of a store, -1 on error
+int NWNX_Store_GetMarkDown(object oStore);
+
+/// @brief Set the mark down of a store
+/// @param oStore The store object.
+/// @param nValue The amount.
+void NWNX_Store_SetMarkDown(object oStore, int nValue);
+
+/// @brief Return the mark up of a store
+/// @param oStore The store object.
+/// @return mark up of a store, -1 on error
+int NWNX_Store_GetMarkUp(object oStore);
+
+/// @brief Set the mark up of a store
+/// @param oStore The store object.
+/// @param nValue The amount.
+void NWNX_Store_SetMarkUp(object oStore, int nValue);
+
+/// @brief Return current customer count
+/// @param oStore The store object.
+/// @return count, or -1 on error
+int NWNX_Store_GetCurrentCustomersCount(object oStore);
+
+/// @}
+
+int NWNX_Store_GetIsRestrictedBuyItem(object oStore, int nBaseItem)
+{
+    string sFunc = "GetIsRestrictedBuyItem";
+
+    NWNX_PushArgumentInt(nBaseItem);
+    NWNX_PushArgumentObject(oStore);
+
+    NWNX_CallFunction(NWNX_Store, sFunc);
+    return NWNX_GetReturnValueInt();
+}
+
+int NWNX_Store_GetBlackMarketMarkDown(object oStore)
+{
+    string sFunc = "GetBlackMarketMarkDown";
+
+    NWNX_PushArgumentObject(oStore);
+
+    NWNX_CallFunction(NWNX_Store, sFunc);
+    return NWNX_GetReturnValueInt();
+}
+
+void NWNX_Store_SetBlackMarketMarkDown(object oStore, int nValue)
+{
+    string sFunc = "SetBlackMarketMarkDown";
+
+    NWNX_PushArgumentInt(nValue);
+    NWNX_PushArgumentObject(oStore);
+
+    NWNX_CallFunction(NWNX_Store, sFunc);
+}
+
+int NWNX_Store_GetMarkDown(object oStore)
+{
+    string sFunc = "GetMarkDown";
+
+    NWNX_PushArgumentObject(oStore);
+
+    NWNX_CallFunction(NWNX_Store, sFunc);
+    return NWNX_GetReturnValueInt();
+}
+
+void NWNX_Store_SetMarkDown(object oStore, int nValue)
+{
+    string sFunc = "SetMarkDown";
+
+    NWNX_PushArgumentInt(nValue);
+    NWNX_PushArgumentObject(oStore);
+
+    NWNX_CallFunction(NWNX_Store, sFunc);
+}
+
+int NWNX_Store_GetMarkUp(object oStore)
+{
+    string sFunc = "GetMarkUp";
+
+    NWNX_PushArgumentObject(oStore);
+
+    NWNX_CallFunction(NWNX_Store, sFunc);
+    return NWNX_GetReturnValueInt();
+}
+
+void NWNX_Store_SetMarkUp(object oStore, int nValue)
+{
+    string sFunc = "SetMarkUp";
+
+    NWNX_PushArgumentInt(nValue);
+    NWNX_PushArgumentObject(oStore);
+
+    NWNX_CallFunction(NWNX_Store, sFunc);
+}
+
+int NWNX_Store_GetCurrentCustomerCount(object oStore)
+{
+    string sFunc = "GetCurrentCustomerCount";
+
+    NWNX_PushArgumentObject(oStore);
+
+    NWNX_CallFunction(NWNX_Store, sFunc);
+    return NWNX_GetReturnValueInt();
+}

--- a/Plugins/Store/Store.cpp
+++ b/Plugins/Store/Store.cpp
@@ -1,0 +1,90 @@
+#include "nwnx.hpp"
+
+#include "API/CNWSStore.hpp"
+
+using namespace NWNXLib;
+using namespace NWNXLib::API;
+
+NWNX_EXPORT ArgumentStack GetIsRestrictedBuyItem(ArgumentStack&& args)
+{
+    if (auto *pStore = Utils::PopStore(args))
+    {
+        const auto nBaseItemID = args.extract<int32_t>();
+        return pStore->GetIsRestrictedBuyItem(nBaseItemID);
+    }
+    return -1;
+}
+
+NWNX_EXPORT ArgumentStack GetBlackMarketMarkDown(ArgumentStack&& args)
+{
+    if (auto *pStore = Utils::PopStore(args))
+    {
+        return pStore->m_nBlackMarketMarkDown;
+    }
+    return -1;
+}
+
+NWNX_EXPORT ArgumentStack SetBlackMarketMarkDown(ArgumentStack&& args)
+{
+    if (auto *pStore = Utils::PopStore(args))
+    {
+        const auto nValue = args.extract<int32_t>();
+          ASSERT_OR_THROW(nValue >= 0);
+          ASSERT_OR_THROW(nValue <= 100);
+        pStore->m_nBlackMarketMarkDown = nValue;
+    }
+    return {};
+}
+
+NWNX_EXPORT ArgumentStack GetMarkDown(ArgumentStack&& args)
+{
+
+    if (auto *pStore = Utils::PopStore(args))
+    {
+        return pStore->m_nMarkDown;
+    }
+    return -1;
+}
+
+NWNX_EXPORT ArgumentStack SetMarkDown(ArgumentStack&& args)
+{
+    if (auto *pStore = Utils::PopStore(args))
+    {
+        const auto nValue = args.extract<int32_t>();
+          ASSERT_OR_THROW(nValue >= 0);
+          ASSERT_OR_THROW(nValue <= 100);
+        pStore->m_nMarkDown = nValue;
+    }
+    return {};
+}
+
+NWNX_EXPORT ArgumentStack GetMarkUp(ArgumentStack&& args)
+{
+
+    if (auto *pStore = Utils::PopStore(args))
+    {
+        return pStore->m_nMarkUp;
+    }
+    return -1;
+}
+
+NWNX_EXPORT ArgumentStack SetMarkUp(ArgumentStack&& args)
+{
+    if (auto *pStore = Utils::PopStore(args))
+    {
+        const auto nValue = args.extract<int32_t>();
+          ASSERT_OR_THROW(nValue >= 1);
+          ASSERT_OR_THROW(nValue <= 1000);
+        pStore->m_nMarkUp = nValue;
+    }
+    return {};
+}
+
+NWNX_EXPORT ArgumentStack GetCustomerCount(ArgumentStack&& args)
+{
+    if (auto *pStore = Utils::PopStore(args))
+    {
+        return pStore->m_aCurrentCustomers.num;
+    }
+    return -1;
+}


### PR DESCRIPTION
##### New NWScript Functions
- Store: New `GetIsRestrictedBuyItem`
- Store: New `{Get|Set}BlackMarketMarkDown`
- Store: New `{Get|Set}MarkDown`
- Store: New `{Get|Set}MarkUp`

Since there's the possibilty of having a whitelist or blacklist for selling back to the store, I'm unsure if exposing just ``GetIsRestrictedBuyItem`` is sufficient.