### PR TITLE
Util: GetModuleTlkFile()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ https://github.com/nwnxee/unified/compare/build8193.36.12...HEAD
 - N/A
 
 ##### New NWScript Functions
-- N/A
+- Util: GetModuleTlkFile()
 
 ### Changed
 - N/A

--- a/Plugins/Util/NWScript/nwnx_util.nss
+++ b/Plugins/Util/NWScript/nwnx_util.nss
@@ -259,6 +259,10 @@ void NWNX_Util_UpdateClientObject(object oObjectToUpdate, object oPlayer = OBJEC
 /// @return TRUE if successful, FALSE on error.
 int NWNX_Util_CleanResourceDirectory(string sAlias, int nResType = 0xFFFF);
 
+/// @brief Return the filename of the tlk file.
+/// @return The name
+string NWNX_Util_GetModuleTlkFile();
+
 /// @}
 
 string NWNX_Util_GetCurrentScriptName(int depth = 0)
@@ -645,4 +649,11 @@ int NWNX_Util_CleanResourceDirectory(string sAlias, int nResType = 0xFFFF)
     NWNX_PushArgumentString(sAlias);
     NWNX_CallFunction(NWNX_Util, sFunc);
     return NWNX_GetReturnValueInt();
+}
+
+string NWNX_Util_GetModuleTlkFile()
+{
+    string sFunc = "GetModuleTlkFile";
+    NWNX_CallFunction(NWNX_Util, sFunc);
+    return NWNX_GetReturnValueString();
 }

--- a/Plugins/Util/Util.cpp
+++ b/Plugins/Util/Util.cpp
@@ -792,3 +792,9 @@ NWNX_EXPORT ArgumentStack CleanResourceDirectory(ArgumentStack&& args)
     Globals::ExoResMan()->UpdateResourceDirectory(alias + ":");
     return bOk;
 }
+
+NWNX_EXPORT ArgumentStack GetModuleTlkFile(ArgumentStack&& args)
+{
+    CNWSModule *pMod = Utils::GetModule();
+    return pMod->m_sModuleAltTLKFile;
+}


### PR DESCRIPTION
Get the name of the TLK file.

Usage:
Get the TLK file, faerun_en, and from it determine the others. Usage in a framework so no module variable is required.