### PR TITLE
Fixing GetPlayOption and SetPlayOption in Administration.cpp

### DIFF
--- a/Plugins/Administration/Administration.cpp
+++ b/Plugins/Administration/Administration.cpp
@@ -267,8 +267,6 @@ NWNX_EXPORT ArgumentStack GetPlayOption(ArgumentStack&& args)
 
     const auto option = args.extract<int32_t>();
 
-    ASSERT_OR_THROW(option >= 0); ASSERT_OR_THROW(option <= 26);
-
     switch (option)
     {
         case 0: // NWNX_ADMINISTRATION_OPTION_ALL_KILLABLE
@@ -400,7 +398,6 @@ NWNX_EXPORT ArgumentStack SetPlayOption(ArgumentStack&& args)
     const auto option = args.extract<int32_t>();
     const auto value = args.extract<int32_t>();
 
-    ASSERT_OR_THROW(option >= 0); ASSERT_OR_THROW(option <= 26);
     ASSERT_OR_THROW(value >= 0);
 
     switch (option)


### PR DESCRIPTION
Removed the asserts on the "option" variable, as unknown cases are caught by the default case of the switch statement that follows.