### PR TITLE
Optionally override docker FROM image with build-args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 # This image is for users who wish to build their images themselves. It uses the builder factory that is created
 # via the builder.Dockerfile and the base that is created via the base.Dockerfile
 
-FROM nwnxee/builder as builder
+ARG BUILDER_IMAGE
+ARG BASE_IMAGE
+
+FROM ${BUILDER_IMAGE:-nwnxee/builder} as builder
 WORKDIR /nwnx/home
 COPY ./ .
 # Compile nwnx
@@ -11,7 +14,7 @@ ARG CXX=g++
 ENV CXX=$CXX
 RUN Scripts/buildnwnx.sh -j $(nproc)
 
-FROM nwnxee/nwnxee-base
+FROM ${BASE_IMAGE:-nwnxee/nwnxee-base}
 COPY --from=builder /nwnx/home/Binaries/* /nwn/nwnx/
 
 # Configure nwserver to run with nwnx

--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ To build on Windows:
 3.  The Container will execute the ./scripts/buildnwnx.sh script
 4.  To perform a clean build pass -FORCECLEAN eg './scripts/rundockerbuild.ps1 -FORCECLEAN'
 
+## Docker images
+
+Prebuilt images exist for the master branch and can be found under [nwnxee/package](https://github.com/orgs/nwnxee/packages?repo_name=unified). The Dockerfiles in this repository serve the following purposes:
+
+1. `builder.Dockerfile` defines the environment to compile nwnx ([ghcr.io/nwnxee/builder](https://github.com/nwnxee/unified/pkgs/container/builder))
+1. `base.Dockerfile` defines the environment to run nwserver and nwnx, but has no nwnx binaries ([ghcr.io/nwnxee/nwnxee-base](https://github.com/nwnxee/unified/pkgs/container/nwnxee-base))
+1. `gha.Dockerfile` defines the environment to run nwserver and nwnx, using binaries built by CI [ghcr.io/nwnxee/unified](https://github.com/nwnxee/unified/pkgs/container/unified)
+1. `Dockerfile` defines the environment to run nwserver and nwnx, using binaries built locally with the builder image, and based on the local base image
+
+Note that the nwserver binary in the base image is included by starting "FROM [ghcr.io/urothis/nwserver](https://github.com/urothis/nwserver/pkgs/container/nwserver)".
+
+It is recommended to use the prebuilt images for production environments. If you cannot use a prebuilt image (e.g. if you are testing a preview branch), you can build the image locally using `Dockerfile`. You may use `Scripts/buildimages.sh` to do this, or run the docker build commands yourself.
+
 ## Contributing code
 
 All contribution are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for requirements and style guidelines.

--- a/Scripts/buildimages.sh
+++ b/Scripts/buildimages.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# This script will:
+# 1. Read the target nwserver version of the branch
+# 2. Download the appropriate prebuilt nwserver image
+# 3. Download the latest prebuilt builder image
+# 4. Build the base image using (2)
+# 5. Build nwnxee/unified image using (3) and (4)
+#
+GRAY='\e[90m'
+NC='\033[0m'
+
+set -e
+
+pushd "$(git rev-parse --show-toplevel)" > /dev/null
+
+nwn_build="$(grep 'set(TARGET_NWN_BUILD ' CMakeLists.txt | cut -d' ' -f2 | sed 's/)//')"
+nwn_build_revision="$(grep 'set(TARGET_NWN_BUILD_REVISION ' CMakeLists.txt | cut -d' ' -f2 | sed 's/)//')"
+nwn_build_postfix="$(grep 'set(TARGET_NWN_BUILD_POSTFIX ' CMakeLists.txt | cut -d' ' -f2 | sed 's/)//')"
+nwn_version="$nwn_build.$nwn_build_revision.$nwn_build_postfix"
+
+NWSERVER_IMAGE=ghcr.io/urothis/nwserver:"$nwn_version"
+BUILDER_IMAGE=ghcr.io/nwnxee/builder
+BASE_IMAGE=nwnxee/nwnxee-base:"$nwn_version"
+NWNXEE_IMAGE=nwnxee/unified:"build$nwn_version-nwnx-$(git rev-parse --short HEAD)"
+
+echo "Building images on branch '$(git rev-parse --abbrev-ref HEAD)'"
+echo -e "  NWSERVER_IMAGE: $NWSERVER_IMAGE ${GRAY}(pull)${NC}"
+echo -e "  BUILDER_IMAGE: $BUILDER_IMAGE ${GRAY}(pull)${NC}"
+echo -e "  BASE_IMAGE: $BASE_IMAGE"
+echo -e "  NWNXEE_IMAGE: $NWNXEE_IMAGE"
+echo
+
+# Pull recent images from the registry to avoid hitting local image cache
+docker pull "$NWSERVER_IMAGE"
+docker pull "$BUILDER_IMAGE"
+
+docker build . \
+  -f base.Dockerfile \
+  -t "$BASE_IMAGE" \
+  --build-arg NWSERVER_IMAGE="$NWSERVER_IMAGE"
+docker build . \
+  -t "$NWNXEE_IMAGE" \
+  --build-arg BUILDER_IMAGE="$BUILDER_IMAGE" \
+  --build-arg BASE_IMAGE="$BASE_IMAGE" \
+
+popd > /dev/null
+
+exit 0


### PR DESCRIPTION
To make building docker images from other branches, like preview, a little easier.

Example usage:
```shell
./Scripts/buildimages.sh

## or, if you prefer writing out the build command by hand
docker build . -t nwnxee/unified:build8193.37.2 \
  --build-arg BUILDER_IMAGE="ghcr.io/nwnxee/builder:2186dc2" \
  --build-arg BASE_IMAGE="ghcr.io/urothis/nwserver:8193.37.2"
```

Defaults are left untouched so this change should not break anything.

### _Edit 29.03.24:_

`Scripts/buildimages.sh` has been added to make building images easier. Example output (before it runs the docker build commands):

![image](https://github.com/nwnxee/unified/assets/3417835/cb1995bd-5ba1-46df-bdf9-8bff078850a3)

Example of the resulting images running the script on branches `master` and `build8193.37`
```shell
$ docker images

REPOSITORY                                  TAG                                      IMAGE ID       CREATED         SIZE
nwnxee/unified                              build8193.37.2-nwnx-6e5b994f0d4          68908bb022ff   3 hours ago     788MB
nwnxee-base                                 8193.37.2                                5f8f5b26f96e   3 hours ago     519MB
nwnxee/unified                              build8193.36.12-nwnx-a060ee24eea         3b9d4090ec25   3 hours ago     820MB
nwnxee-base                                 8193.36.12                               f782d8b0108b   3 hours ago     517MB
ghcr.io/urothis/nwserver                    8193.36.12                               c7b9c8967ead   10 hours ago    328MB
ghcr.io/urothis/nwserver                    8193.37.2                                0522da296114   10 hours ago    330MB
````