### PR TITLE
Fixing GetStringLevenshteinDistance in nwnx_util.nss

### DIFF
--- a/Plugins/Util/NWScript/nwnx_util.nss
+++ b/Plugins/Util/NWScript/nwnx_util.nss
@@ -531,7 +531,7 @@ int NWNX_Util_GetStringLevenshteinDistance(string sString, string sCompareTo)
 {
     NWNXPushString(sCompareTo);
     NWNXPushString(sString);
-    NWNXCall(NWNX_Util, "LevenshteinDistance");
+    NWNXCall(NWNX_Util, "GetStringLevenshteinDistance");
     return NWNXPopInt();
 }
 


### PR DESCRIPTION
The string being called was missing `GetString`, causing errors when trying to use the function. This is just a simple edit to fix it.