### PR TITLE
DotNET: Add FunctionHook Overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ https://github.com/nwnxee/unified/compare/build8193.36.12...HEAD
 ### Added
 - DotNET: Added `NWNX_DOTNET_METHOD` option to change entrypoint method (default: `Bootstrap`)
 - DotNET: Added `NWNX_DOTNET_NEW_BOOTSTRAP` option to enable a new bootstrap method with less boilerplate code.
+- DotNET: Added `RequestFunctionHook`, `ReturnFunctionHook`.
 
 ##### New Plugins
 - Store: Enables getting and setting store data.

--- a/Plugins/DotNET/DotNETExports.cpp
+++ b/Plugins/DotNET/DotNETExports.cpp
@@ -737,6 +737,24 @@ NWNX_EXPORT void ReturnHook(void* trampoline)
     }
 }
 
+NWNX_EXPORT Hooks::FunctionHook* RequestFunctionHook(void* address, void* managedFuncPtr, const int32_t order)
+{
+    const auto funcHook = s_managedHooks.emplace_back(Hooks::HookFunction(address, managedFuncPtr, order)).get();
+    return funcHook;
+}
+
+NWNX_EXPORT void ReturnFunctionHook(const Hooks::FunctionHook* funcHook)
+{
+    for (auto it = s_managedHooks.begin(); it != s_managedHooks.end(); ++it)
+    {
+        if (it->get() == funcHook)
+        {
+            s_managedHooks.erase(it);
+            return;
+        }
+    }
+}
+
 std::vector<void*> GetExports()
 {
     //


### PR DESCRIPTION
Context: https://discord.com/channels/382306806866771978/662711711605719051/1235673196355784794

Since the hook trampoline value can change from other hooks that might subscribe before it, it is currently not possible to reliably return a hook.

This PR adds new hook methods to use pointers to the full Hooks::FunctionHook structure, which should be much more reliable for hook returns.