### PR TITLE
Race: remove docs mention of requiring NWNX_Utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ https://github.com/nwnxee/unified/compare/build8193.36.12...HEAD
 - N/A
 
 ### Fixed
-- N/A
+- Race: Documentation updated as `NWNX_Utils` is no longer required with introduction of native `Get2DARowCount()`.
 
 ## 8193.36.10
 https://github.com/nwnxee/unified/compare/build8193.36.9...build8193.36.10

--- a/Plugins/Race/README.md
+++ b/Plugins/Race/README.md
@@ -10,7 +10,6 @@ This plugin allows for the builder to add new races or subraces and define many 
 ## Required NWNX Plugins
 
 * @ref skillranks "NWNX_SkillRanks" - Needed if you're modifying skill ranks.
-* @ref util "NWNX_Util" - Needed if you're using the 2da method which requires new `NWNX_Util_Get2DARowCount()`.
 
 ## Setup
 Adding new races is beyond the scope of this documentation. The builder should know how to add new races by adding a new entry in the `racialtypes.2da` as well as adding the appropriate TLK reference identifiers for that new race then adjusting the appropriate columns for their race, including the Ability Score modifications. 


### PR DESCRIPTION
Since `NWNX_Util_Get2DARowCount()` was added natively.