### PR TITLE
build: bump download and upload-artifact due to deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,21 +118,21 @@ jobs:
       run: zip -j ./NWScript.zip `find . -name "*.nss" | grep -Pv '_t+[0-9]{0,1}.nss'`
 
     - name: Upload Binaries
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: github.event_name == 'push'
       with:
        path: ./NWNX-EE.zip
        name: NWNX-EE.zip
 
     - name: Upload Scripts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: github.event_name == 'push'
       with:
         path: ./NWScript.zip
         name: NWScript.zip
 
     - name: Upload Tar Binaries for Docker
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: github.event_name == 'push'
       with:
         name: NWNX-EE.tar
@@ -197,7 +197,7 @@ jobs:
           echo "nwn_build_postfix=$(grep 'set(TARGET_NWN_BUILD_POSTFIX ' CMakeLists.txt | cut -d' ' -f2 | sed 's/)//')" >> $GITHUB_OUTPUT
 
       - name: Download Binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: NWNX-EE.tar
 
@@ -268,7 +268,7 @@ jobs:
         run: |
           echo "${{ steps.create_release.outputs.upload_url }}" > ./upload_url
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./upload_url
           name: upload_url
@@ -280,19 +280,19 @@ jobs:
 
     steps:
     - name: Download Binaries
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: NWNX-EE.zip
         path: ./
 
     - name: Download Scripts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: NWScript.zip
         path: ./
 
     - name: Download URL
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: upload_url
         path: ./


### PR DESCRIPTION
Closes #1769 

Since dependabot in the above PR only bumps the `download-artifact` version, we also need to bump the `upload-artifact` to version 4 as well.