### PR TITLE
Race: Suppress and Reactive for temp disabling nwnx_race effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ https://github.com/nwnxee/unified/compare/build8193.36.12...HEAD
 - Store: {Get|Set}MarkUp()
 - Player: ReloadTlk()
 - Player: ReloadColorPalettes()
+- Race: SuppressCreatureRaceEffects()
+- Race: ReactivateCreatureRaceEffects()
 
 ### Changed
 - Player: added bChatWindow parameter to FloatingTextStringOnCreature()

--- a/Plugins/Race/NWScript/nwnx_race.nss
+++ b/Plugins/Race/NWScript/nwnx_race.nss
@@ -54,6 +54,16 @@ int NWNX_Race_GetParentRace(int iRace);
 /// or Favored Enemy: Wild Elf
 void NWNX_Race_SetFavoredEnemyFeat(int iRace, int iFeat);
 
+/// @brief Removes any nwnx_race 'Effects' on the targeted creature. Suppression lasts until levelup, next login, or Reactivated by function.
+/// @param oCreature The creature to suppress
+/// @note Not all nwnx_race modifiers are achieved via effect. Those that are not directly consider the creatures current race.
+void NWNX_Race_SuppressCreatureRaceEffects(object oCreature);
+
+/// @brief Reactivates the nwnx_race 'Effects' on the targeted creature after they were Suppressed.
+/// @param oCreature The creature to reactive
+/// @note Safe to use on non-suppressed creatures - Triggers a refresh of effects but won't stack.
+void NWNX_Race_ReactivateCreatureRaceEffects(object oCreature);
+
 /// @}
 
 void NWNX_Race_SetRacialModifier(int iRace, int iMod, int iParam1, int iParam2 = 0xDEADBEEF, int iParam3 = 0xDEADBEEF)
@@ -86,5 +96,21 @@ void NWNX_Race_SetFavoredEnemyFeat(int iRace, int iFeat)
     NWNX_PushArgumentInt(iFeat);
     NWNX_PushArgumentInt(iRace);
 
+    NWNX_CallFunction(NWNX_Race, sFunc);
+}
+
+void NWNX_Race_SuppressCreatureRaceEffects(object creature)
+{
+    string sFunc = "SuppressCreatureRaceEffects";
+
+    NWNX_PushArgumentObject(creature);
+    NWNX_CallFunction(NWNX_Race, sFunc);
+}
+
+void NWNX_Race_ReactivateCreatureRaceEffects(object oCreature)
+{
+    string sFunc = "ReactivateCreatureRaceEffects";
+
+    NWNX_PushArgumentObject(oCreature);
     NWNX_CallFunction(NWNX_Race, sFunc);
 }

--- a/Plugins/Race/Race.cpp
+++ b/Plugins/Race/Race.cpp
@@ -184,14 +184,17 @@ void Race::RemoveRaceEffects(CNWSCreature *pCreature)
     if (pCreature->m_pStats == nullptr || effectsLevelAdded == 0)
         return;
 
+    std::vector<uint64_t> remove(128);
     for (int i = pCreature->m_appliedEffects.num; i >= 0; --i)
     {
         auto eff = (CGameEffect*)pCreature->m_appliedEffects.element[i];
         if (eff->m_sCustomTag == "NWNX_Race_RacialMod")
         {
-            pCreature->RemoveEffectById(eff->m_nID);
+            remove.push_back(eff->m_nID);
         }
     }
+    for (auto id: remove)
+        pCreature->RemoveEffectById(id);
 
     pCreature->nwnxRemove("RACEMODS_ADDED_LEVEL");
 }

--- a/Plugins/Race/Race.hpp
+++ b/Plugins/Race/Race.hpp
@@ -25,6 +25,8 @@ private:
     ArgumentStack SetRacialModifier(ArgumentStack&& args);
     ArgumentStack GetParentRace(ArgumentStack&& args);
     ArgumentStack SetFavoredEnemyFeat(ArgumentStack&& args);
+    ArgumentStack SuppressCreatureRaceEffects(ArgumentStack&& args);
+    ArgumentStack ReactivateCreatureRaceEffects(ArgumentStack&& args);
 
     enum RaceModifier
     {
@@ -80,6 +82,7 @@ private:
 
 
     static void DoEffect(CNWSCreature*, uint16_t, int32_t, int32_t = 0, int32_t = 0, int32_t = 0, int32_t = 0, int32_t = 0);
+    static void RemoveRaceEffects(CNWSCreature*);
     static void ApplyRaceEffects(CNWSCreature*);
     static void SetOrRestoreRace(bool, CNWSCreatureStats*, CNWSCreatureStats* = nullptr);
     static void SetRaceModifier(int32_t, RaceModifier, int32_t, int32_t, int32_t);


### PR DESCRIPTION
By request of Noler on discord.
Splits out the removal of the effects into its own function, and then adds nwscript calls to the Apply/Removal of them.

Compiled locally but untested. Only substantive c++ change was effect countdown remove rather than count-up creating a list to then count-through and remove from.