### PR TITLE
Creature: Add SetMulticlassLimit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ https://github.com/nwnxee/unified/compare/build8193.36.12...HEAD
 - Events: Added events `NWNX_ON_SET_EXPERIENCE_{BEFORE|AFTER}` which fire when the XP of a player changes.
 - NoStack: Added `NWNX_NOSTACK_IGNORE_SUPERNATURAL_INNATE` to ignore effects created by the Feat, Race and SkillRanks plugins when stacking.
 - Tweaks: added `NWNX_TWEAKS_CUTSCENE_MODE_NO_TURD` to not drop a TURD when SetCutsceneMode() is called.
+- Creature: Added `NWNX_Creature_{Get|Set}MulticlassLimit()`.
 
 ##### New Plugins
 - Store: Enables getting and setting store data.

--- a/Plugins/Creature/NWScript/nwnx_creature.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature.nss
@@ -1007,6 +1007,23 @@ void NWNX_Creature_SetAbilityIncreaseByLevel(object oCreature, int nLevel, int n
 /// @return The maximum attack range for oCreature to oTarget
 float NWNX_Creature_GetMaxAttackRange(object oCreature, object oTarget);
 
+/// @brief Returns the creature's multiclass limit.
+/// @note Only works on player characters.
+/// @param oCreature The creature object. Has to be a player character.
+/// @return The PCs multiclass limit. Returns 0 if no limit is set.
+int NWNX_Creature_GetMulticlassLimit(object oCreature);
+
+/// @brief Sets the creature's multiclass limit.
+/// @note Only works on player characters and only for future level ups.
+/// Classes already taken will continue to be available on level up.
+/// The limit must be lower than the server limit set in ruleset.2da MULTICLASS_LIMIT.
+/// Setting a value of 0 will remove the limit.
+/// @param oCreature The creature object. Has to be a player character.
+/// @param nLimit The multiclass limit.
+/// @param bPersist Whether the limit should persist to the .bic file.
+/// @note Persistence is enabled after a server reset by the first use of this function.
+void NWNX_Creature_SetMulticlassLimit(object oCreature, int nLimit, int bPersist = FALSE);
+
 /// @}
 
 void NWNX_Creature_AddFeat(object creature, int feat)
@@ -2610,4 +2627,25 @@ float NWNX_Creature_GetMaxAttackRange(object oCreature, object oTarget)
     NWNX_CallFunction(NWNX_Creature, sFunc);
 
     return NWNX_GetReturnValueFloat();
+}
+
+int NWNX_Creature_GetMulticlassLimit(object oCreature)
+{
+    string sFunc = "GetMulticlassLimit";
+
+    NWNX_PushArgumentObject(oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
+
+    return NWNX_GetReturnValueInt();
+}
+
+
+void NWNX_Creature_SetMulticlassLimit(object oCreature, int nLimit, int bPersist = FALSE)
+{
+    string sFunc = "SetMulticlassLimit";
+
+    NWNX_PushArgumentInt(bPersist);
+    NWNX_PushArgumentInt(nLimit);
+    NWNX_PushArgumentObject(oCreature);
+    NWNX_CallFunction(NWNX_Creature, sFunc);
 }

--- a/Plugins/Creature/NWScript/nwnx_creature_t.nss
+++ b/Plugins/Creature/NWScript/nwnx_creature_t.nss
@@ -257,7 +257,7 @@ void main()
     NWNX_Creature_SetDomain(oCreature2, CLASS_TYPE_CLERIC, 2, (nDomain2+1)%5);
     NWNX_Tests_Report("NWNX_Creature", "{S,G}etDomain", GetDomain(oCreature2, 1, CLASS_TYPE_CLERIC) == (nDomain2+1)%5);
 
-	//Test Armor class versus function, elf mage vs bandit
+    //Test Armor class versus function, elf mage vs bandit
     NWNX_Tests_Report("NWNX_Creature", "Without a Versus GetArmorClassVersus", NWNX_Creature_GetArmorClassVersus(oCreature, OBJECT_INVALID) > 0);
     int nOldAC = NWNX_Creature_GetArmorClassVersus(oCreature, oCreature2);
     int nOldTouchAC = NWNX_Creature_GetArmorClassVersus(oCreature, oCreature2, TRUE);
@@ -274,6 +274,10 @@ void main()
     int nInitiativeMod = NWNX_Creature_GetInitiativeModifier(oCreature);
     NWNX_Creature_SetInitiativeModifier(oCreature, nInitiativeMod + 10);
     NWNX_Tests_Report("NWNX_Creature", "{S,G}etInitiativeModifer", NWNX_Creature_GetInitiativeModifier(oCreature) == nInitiativeMod+10);
+
+    NWNX_Creature_SetMulticlassLimit(oCreature, 2);
+    NWNX_Tests_Report("NWNX_Creature", "{Set/Get}MulticlassLimit", NWNX_Creature_GetMulticlassLimit(oCreature) == 2);
+    NWNX_Creature_SetMulticlassLimit(oCreature, 0);
 
     WriteTimestampedLogEntry("NWNX_Creature unit test end.");
 }


### PR DESCRIPTION
Adds `NWNX_Creature_SetMulticlassLimit(object oCreature, int nLimit)` to limit the number of classes a PC can take dynamically.