### PR TITLE
Events: NWNX_ON_SET_EXPERIENCE update to allow SetEventResult

### DIFF
--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1664,7 +1664,9 @@ _______________________________________
 
     Event Data Tag        | Type   | Notes
     ----------------------|--------|-------
-    XP                    | int    | The xp value that is being set |
+    XP                    | int    | The xp value to be set. |
+
+    @note To set a different xp value in the BEFORE event: Skip the event and call NWNX_Events_SetEventResult() with the new value.
 _______________________________________
     ## Broadcast Attack of Opportunity Events
     - NWNX_ON_BROADCAST_ATTACK_OF_OPPORTUNITY_BEFORE


### PR DESCRIPTION
Added the option to set event result. Now the event can be (better) used to limit xp.