### PR TITLE
Fix incorrect detection of runtimeconfig.json

### DIFF
--- a/Plugins/DotNET/DotNET.cpp
+++ b/Plugins/DotNET/DotNET.cpp
@@ -158,7 +158,7 @@ void LoadNetCore(const std::string& assembly)
 {
     hostfxr_handle cxt = nullptr;
 
-    auto runtimeConfig = assembly + ".runtimeConfig.json";
+    auto runtimeConfig = assembly + ".runtimeconfig.json";
     int returnCode = hostfxr_initialize_for_runtime_config(runtimeConfig.c_str(), nullptr, &cxt);
     if (returnCode != 0 || cxt == nullptr)
         LOG_FATAL("Unable to load runtime config '%s'; returnCode=0x%x", runtimeConfig, returnCode);


### PR DESCRIPTION
Fixes a issue that prevented loading the dotnet assembly on case-sensitive platforms.