### PR TITLE
Profiler: fixed order of parameters in nss script for PushPerfScope()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ https://github.com/nwnxee/unified/compare/build8193.36.12...HEAD
 - Docker: Add dotnet-runtime-8.0, dotnet-apphost-pack-8.0 packages.
 - Item: Added parameter `bUpdateCreatureAppearance` to SetItemAppearance() to update the appearance of the item's possessor.
 - Events: Added PLAYER_NAME, CDKEY as event data to the client disconnect events `NWNX_ON_CLIENT_DISCONNECT_{BEFORE|AFTER}`.
+- Profiler: fixed order of parameters in nss script for PushPerfScope()
 
 ### Deprecated
 - DotNET: GetFunctionPointer()

--- a/Plugins/Profiler/NWScript/nwnx_profiler.nss
+++ b/Plugins/Profiler/NWScript/nwnx_profiler.nss
@@ -41,13 +41,13 @@ void NWNX_Profiler_PushPerfScope(string name, string tag0_tag = "", string tag0_
 {
     string sFunc = "PushPerfScope";
 
-    NWNX_PushArgumentString(name);
-
     if (tag0_value != "" && tag0_tag != "")
     {
         NWNX_PushArgumentString(tag0_value);
         NWNX_PushArgumentString(tag0_tag);
     }
+
+    NWNX_PushArgumentString(name);
 
     NWNX_CallFunction(NWNX_Profiler, sFunc);
 }


### PR DESCRIPTION
Without this patch, the result of `NWNX_Profiler_PushPerfScope("PerfScopeName", "tag0_tag", "tag0_value");` is `NWNX_Profiler.TimingEvent,EventName=tag0_tag,tag0_value=PerfScopeName`

The patch fixes the order of the pushed arguments:

```
NWNX_Profiler_PushPerfScope("Test2", "tag0_tag", "tag0_value");
NWNX_Profiler_PushPerfScope("Test3", "tag0_tag", "tag0_value");

# Gives:
NWNX_Profiler.TimingEvent,EventName=Test2,tag0_tag=tag0_value
NWNX_Profiler.TimingEvent,EventName=Test3
```