### PR TITLE
Add GetDawnHour/GetDuskHour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ https://github.com/nwnxee/unified/compare/build8193.36.12...HEAD
 - Race: ReactivateCreatureRaceEffects()
 - Creature: {Get|Set}MulticlassLimit()
 - Util: UpdateResourceDirectory()
+- Util: GetDawnHour()
+- Util: GetDuskHour()
 
 ### Changed
 - Player: added bChatWindow parameter to FloatingTextStringOnCreature()

--- a/Plugins/Util/NWScript/nwnx_util.nss
+++ b/Plugins/Util/NWScript/nwnx_util.nss
@@ -228,9 +228,17 @@ int NWNX_Util_GetScriptParamIsSet(string sParamName);
 /// @param nDawnHour The new dawn hour
 void NWNX_Util_SetDawnHour(int nDawnHour);
 
+/// @brief Get the module dawn hour.
+/// @return The dawn hour
+int NWNX_Util_GetDawnHour();
+
 /// @brief Set the module dusk hour.
 /// @param nDuskHour The new dusk hour
 void NWNX_Util_SetDuskHour(int nDuskHour);
+
+/// @brief Get the module dusk hour.
+/// @return The dusk hour
+int NWNX_Util_GetDuskHour();
 
 /// @return Returns the number of microseconds since midnight on January 1, 1970.
 struct NWNX_Util_HighResTimestamp NWNX_Util_GetHighResTimeStamp();
@@ -593,12 +601,28 @@ void NWNX_Util_SetDawnHour(int nDawnHour)
     NWNX_CallFunction(NWNX_Util, sFunc);
 }
 
+int NWNX_Util_GetDawnHour()
+{
+    string sFunc = "GetDawnHour";
+
+    NWNX_CallFunction(NWNX_Util, sFunc);
+    return NWNX_GetReturnValueInt();
+}
+
 void NWNX_Util_SetDuskHour(int nDuskHour)
 {
     string sFunc = "SetDuskHour";
 
     NWNX_PushArgumentInt(nDuskHour);
     NWNX_CallFunction(NWNX_Util, sFunc);
+}
+
+int NWNX_Util_GetDuskHour()
+{
+    string sFunc = "GetDuskHour";
+
+    NWNX_CallFunction(NWNX_Util, sFunc);
+    return NWNX_GetReturnValueInt();
 }
 
 struct NWNX_Util_HighResTimestamp NWNX_Util_GetHighResTimeStamp()

--- a/Plugins/Util/Util.cpp
+++ b/Plugins/Util/Util.cpp
@@ -690,6 +690,11 @@ NWNX_EXPORT ArgumentStack SetDawnHour(ArgumentStack &&args)
     return {};
 }
 
+NWNX_EXPORT ArgumentStack GetDawnHour(ArgumentStack &&args)
+{
+    return Utils::GetModule()->m_nDawnHour;
+}
+
 NWNX_EXPORT ArgumentStack SetDuskHour(ArgumentStack &&args)
 {
     const auto duskHour = args.extract<int32_t>();
@@ -699,6 +704,11 @@ NWNX_EXPORT ArgumentStack SetDuskHour(ArgumentStack &&args)
     Utils::GetModule()->m_nDuskHour = duskHour;
 
     return {};
+}
+
+NWNX_EXPORT ArgumentStack GetDuskHour(ArgumentStack &&args)
+{
+    return Utils::GetModule()->m_nDuskHour;
 }
 
 NWNX_EXPORT ArgumentStack GetHighResTimeStamp(ArgumentStack&&)


### PR DESCRIPTION
Unless I missed something, there's no way to get current dawn and dusk hours.

The two new functions add the get functions in addition to the previously available set functions.