### PR TITLE
SWIG: Fix cmake error when using ninja instead of make.

### DIFF
--- a/Plugins/SWIG/CMakeLists.txt
+++ b/Plugins/SWIG/CMakeLists.txt
@@ -17,7 +17,7 @@ function(add_swig_plugin target language interfaces)
     configure_plugin(${target})
 
     # By adding nwserver-linux to the SWIG directory, we can check for any undefined symbols from mismatching headers.
-    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/nwserver-linux)
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/nwserver-linux)
         add_library( nwserver SHARED IMPORTED )
         set_target_properties( nwserver PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/nwserver-linux )
         target_link_libraries(${target} nwserver)
@@ -29,7 +29,14 @@ function(add_swig_plugin target language interfaces)
       SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON
       POSITION_INDEPENDENT_CODE ON)
 
-    add_custom_command(TARGET ${target}_swig_compilation POST_BUILD
+    if(CMAKE_GENERATOR MATCHES "Make")
+        set(post_process_target ${target}_swig_compilation)
+    else()
+        message(STATUS "Generator '${CMAKE_GENERATOR}' does not create intermediate SWIG projects. Post processing will occur after plugin generation.")
+        set(post_process_target ${target})
+    endif()
+
+    add_custom_command(TARGET ${post_process_target} POST_BUILD
             COMMAND chmod a+x postprocess.sh && ./postprocess.sh
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${target}
     )


### PR DESCRIPTION
Fixes the following error when using ninja instead of make as the build tool/generator:

```
CMake Error at Plugins/SWIG/CMakeLists.txt:32 (add_custom_command):
  No TARGET 'SWIG_DotNET_swig_compilation' has been created in this
  directory.
```