### PR TITLE
SSL_CTX_set0_tmp_dh_pkey() segfaulted in WSL2 environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.10)
 project(NWNX-Unified)
 
 if(NOT CMAKE_BUILD_TYPE)

--- a/NWNXLib/External/funchook/CMakeLists.txt
+++ b/NWNXLib/External/funchook/CMakeLists.txt
@@ -1,5 +1,5 @@
 # GIT_SHALLOW requires cmake 3.6.
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.10)
 
 project(funchook VERSION 2.0.0 LANGUAGES C ASM)
 

--- a/Plugins/Redis/cpp_redis/CMakeLists.txt
+++ b/Plugins/Redis/cpp_redis/CMakeLists.txt
@@ -23,7 +23,7 @@
 ###
 # config
 ###
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.10)
 set(CMAKE_MACOSX_RPATH 1)
 include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
 

--- a/Plugins/Redis/cpp_redis/tacopie/CMakeLists.txt
+++ b/Plugins/Redis/cpp_redis/tacopie/CMakeLists.txt
@@ -23,7 +23,7 @@
 ###
 # config
 ###
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.10)
 set(CMAKE_MACOSX_RPATH 1)
 include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
 

--- a/Plugins/SQL/Targets/MySQL.cpp
+++ b/Plugins/SQL/Targets/MySQL.cpp
@@ -11,6 +11,19 @@ namespace SQL {
 MySQL::MySQL()
 {
     mysql_init(&m_mysql);
+    /* 
+       SSL_CTX_set0_tmp_dh_pkey() might seg fault in WSL2 (probably also WSL1, too) environment.
+       
+       To prevent that from happening, disable SSL with:
+           NWNX_SQL_SSL_DISABLED=true
+
+       NOTE: this generally should not be needed, but e.g. in my case MySQL/SSL segfaults.
+    */
+    if (Config::Get<bool>("SSL_DISABLED", false))
+    {
+        uint use_ssl = SSL_MODE_DISABLED;
+        mysql_options(&m_mysql, MYSQL_OPT_SSL_MODE, (uint const*)&use_ssl);
+    }
     m_stmt = nullptr;
     m_lastError = "";
     m_paramCount = 0;


### PR DESCRIPTION
A segfault happened due MySQL/SSL mix in WSL2 environment:

  Backtrace:
    /home/anikaiful/unified/Binaries/NWNX_Core.so(_ZN7NWNXLib8Platform13GetStackTraceB5cxx11Eh+0x64) [0x7fe30f3c6004]
    /home/anikaiful/unified/Binaries/NWNX_Core.so(nwnx_signal_handler+0xd6) [0x7fe30f36d6c6]
    /lib/x86_64-linux-gnu/libc.so.6(+0x45320) [0x7fe30edc3320]
    /lib/x86_64-linux-gnu/libssl.so.3(+0x2e742) [0x7fe30c256742]
    /lib/x86_64-linux-gnu/libssl.so.3(SSL_CTX_set0_tmp_dh_pkey+0x33) [0x7fe30c265ed3]
    /lib/x86_64-linux-gnu/libmysqlclient.so.21(+0x9672d) [0x7fe2fd3a372d]
    /lib/x86_64-linux-gnu/libmysqlclient.so.21(+0x37a7e) [0x7fe2fd344a7e]
    /lib/x86_64-linux-gnu/libmysqlclient.so.21(+0x38700) [0x7fe2fd345700]
    /lib/x86_64-linux-gnu/libmysqlclient.so.21(+0x40efc) [0x7fe2fd34defc]
    /lib/x86_64-linux-gnu/libmysqlclient.so.21(mysql_real_connect+0x109) [0x7fe2fd34a479]

And thus I introduced:
    export NWNX_SQL_SSL_DISABLED=true

Less secure, but with that flag my nwnx:ee doesn't catch fire... :-S
