### PR TITLE
Fix `NWNX_TWEAKS_SETAREA_CALLS_SETPOSITION` not working with `NWNX_ON_MATERIALCHANGE_*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ https://github.com/nwnxee/unified/compare/build8193.37.13...HEAD
 - N/A
 
 ### Fixed
-- N/A
+- Fixed `NWNX_TWEAKS_SETAREA_CALLS_SETPOSITION` not working with `NWNX_ON_MATERIALCHANGE_*`.
 
 ## 8193.37.13
 https://github.com/nwnxee/unified/compare/build8193.36.10...build8193.37.13


### PR DESCRIPTION
Previously broken in https://github.com/nwnxee/unified/pull/1749 due to it excessively firing `NWNX_ON_MATERIALCHANGE_*`, should now work correctly.