### PR TITLE
MaxLevel: GetSpellsKnownPerLevelHook rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ https://github.com/nwnxee/unified/compare/build8193.37.13...HEAD
 
 ### Fixed
 - Fixed `NWNX_TWEAKS_SETAREA_CALLS_SETPOSITION` not working with `NWNX_ON_MATERIALCHANGE_*`.
+- MaxLevel: Fixed returning an invalid number of known spells in some cases.
 
 ## 8193.37.13
 https://github.com/nwnxee/unified/compare/build8193.36.10...build8193.37.13


### PR DESCRIPTION
This fixes the issue with Bards not having their cantrips when getting them on a class level other than 1 due to low charisma attribute. Other problems with the previous implementation might have existed but this is the one that I noticed.

@Daztek I found the [[maybe_unused]] attribute after a short Google search and don't know if it is appropriate here.