### PR TITLE
Weapon: change the log level to debug for NWNX_WEAPON_SETDATA_DC_BYPASS

### DIFF
--- a/Plugins/Weapon/Weapon.cpp
+++ b/Plugins/Weapon/Weapon.cpp
@@ -492,7 +492,7 @@ ArgumentStack Weapon::SetEventData(ArgumentStack&& args)
     switch(nOption)
     {
         case NWNX_WEAPON_SETDATA_DC_BYPASS:
-            LOG_INFO("Set NWNX_WEAPON_SETDATA_DC_BYPASS to %d", nVal);
+            LOG_DEBUG("Set NWNX_WEAPON_SETDATA_DC_BYPASS to %d", nVal);
             m_DCData.bBypass = nVal;
             break;
     }


### PR DESCRIPTION
My log is full of these messages and I don't think it is important enough for the INFO level.
Might be only me though, so feel free to just close this PR.