### PR TITLE
Fixed typo in Deserialize()

### DIFF
--- a/NWNXLib/POS.cpp
+++ b/NWNXLib/POS.cpp
@@ -163,7 +163,7 @@ public:
     {
         if (m_IntMap)     m_IntMap->clear();
         if (m_FloatMap)   m_FloatMap->clear();
-        if (m_StringMap)  m_IntMap->clear();
+        if (m_StringMap)  m_StringMap->clear();
         if (m_PointerMap) m_PointerMap->clear();
 
     #define SSCANF_OR_ABORT(s, fmt, val) \


### PR DESCRIPTION
m_IntMap was being cleared twice instead of m_StringMap.