### PR TITLE
Creature Crit mods - Add UpdateCombatInformation Call

### DIFF
--- a/Plugins/Creature/Creature.cpp
+++ b/Plugins/Creature/Creature.cpp
@@ -1935,6 +1935,8 @@ NWNX_EXPORT ArgumentStack SetCriticalMultiplierModifier(ArgumentStack&& args)
             pCreature->nwnxSet(varname, modifier, persist);
         else
             pCreature->nwnxRemove(varname);
+
+        pCreature->m_pStats->UpdateCombatInformation();
     }
     return {};
 }
@@ -1985,6 +1987,8 @@ NWNX_EXPORT ArgumentStack SetCriticalMultiplierOverride(ArgumentStack&& args)
             pCreature->nwnxSet(varname, Override, persist);
         else
             pCreature->nwnxRemove(varname);
+
+        pCreature->m_pStats->UpdateCombatInformation();
     }
     return {};
 }
@@ -2111,6 +2115,8 @@ NWNX_EXPORT ArgumentStack SetCriticalRangeModifier(ArgumentStack&& args)
             pCreature->nwnxSet(varname, Modifier, persist);
         else
             pCreature->nwnxRemove(varname);
+
+        pCreature->m_pStats->UpdateCombatInformation();
     }
     return {};
 }
@@ -2161,6 +2167,8 @@ NWNX_EXPORT ArgumentStack SetCriticalRangeOverride(ArgumentStack&& args)
             pCreature->nwnxSet(varname, Override, persist);
         else
             pCreature->nwnxRemove(varname);
+
+        pCreature->m_pStats->UpdateCombatInformation();
     }
     return {};
 }


### PR DESCRIPTION
A very overdue fix to make this update immediately on the character sheets, instead of needing to reequip or otherwise cause the update some other way.