### PR TITLE
NWNX_Events: Added messagebus support for the  InitOnFirstSubscribe function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ https://github.com/nwnxee/unified/compare/build8193.37.13...HEAD
 - Tweaks: added `NWNX_TWEAKS_RESIST_ENERGY_STACKS_WITH_EPIC_ENERGY_RESISTANCE` to make Resist Energy feats stack with Epic Energy Resistance.
 - Tweaks: added `NWNX_TWEAKS_UNHARDCODE_SPECIAL_ABILITY_TARGET_TYPE` to allow special abilities to be used on target types other than creatures.
 - Events: Added events `NWNX_ON_ABILITY_CHANGE_{BEFORE|AFTER}` which fire when an ability of a player changes.
+- Events: Added `NWNX_EVENT_INIT_ON_FIRST_SUBSCRIBE` messagebus message as a wrapper for the `InitOnFirstSubscribe` function. Broadcasts `NWNX_EVENT_INIT_ON_FIRST_SUBSCRIBE_CALLBACK` message when a registered event gets subscribed to.
 
 ##### New Plugins
 - N/A

--- a/Plugins/Events/Events.cpp
+++ b/Plugins/Events/Events.cpp
@@ -40,6 +40,15 @@ static auto s_idPush = MessageBus::Subscribe("NWNX_EVENT_PUSH_EVENT_DATA",
         PushEventData(message[0], message[1]);
     });
 
+static auto s_idInitOnFirstSubscribe = MessageBus::Subscribe("NWNX_EVENT_INIT_ON_FIRST_SUBSCRIBE",
+    [](const std::vector<std::string> &message)
+    {
+        ASSERT(message.size() == 1);
+        InitOnFirstSubscribe(message[0], [message]() {
+            MessageBus::Broadcast("NWNX_EVENT_INIT_ON_FIRST_SUBSCRIBE_CALLBACK",  { message[0] });
+        });
+    });
+
 static std::string GetEventData(const std::string& tag);
 static void CreateNewEventDataIfNeeded();
 static void RunEventInit(const std::string& eventName);


### PR DESCRIPTION
So other plugins using the NWNX_Events event system have access to the InitOnFirstSubscribe functionality to only register hooks if they're needed