### PR TITLE
Add ID to the NWNX_ON_ITEMPROPERTY_EFFECT_* events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ https://github.com/nwnxee/unified/compare/build8193.37.13...HEAD
 
 ### Changed
 - Damage: Added bRangedAttack to the NWNX_Damage_AttackEventData struct.
+- Events: Added ID to the NWNX_ON_ITEMPROPERTY_EFFECT_* events data.
 
 ### Deprecated
 - N/A

--- a/Plugins/Events/Events/ItemPropertyEvents.cpp
+++ b/Plugins/Events/Events/ItemPropertyEvents.cpp
@@ -166,6 +166,7 @@ static int32_t OnItemPropertyAppliedHook(CNWSItemPropertyHandler* pThis, CNWSIte
         PushEventData("LOADING_GAME", std::to_string(bLoadingGame));
         PushEventData("INVENTORY_SLOT", std::to_string(pCreature->m_pInventory->GetArraySlotFromSlotFlag(nInventorySlot)));
         PushEventData("PROPERTY", std::to_string(ipType));
+        PushEventData("ID", std::to_string(pItemProperty->m_nID));
         PushEventData("SUBTYPE", std::to_string(pItemProperty->m_nSubType));
         PushEventData("TAG", pItemProperty->m_sCustomTag.CStr());
         PushEventData("COST_TABLE", std::to_string(pItemProperty->m_nCostTable));
@@ -227,6 +228,7 @@ static int32_t OnItemPropertyRemovedHook(CNWSItemPropertyHandler* pThis, CNWSIte
         PushEventData("LOADING_GAME", "0");
         PushEventData("INVENTORY_SLOT", std::to_string(pCreature->m_pInventory->GetArraySlotFromSlotFlag(nInventorySlot)));
         PushEventData("PROPERTY", std::to_string(ipType));
+        PushEventData("ID", std::to_string(pItemProperty->m_nID));
         PushEventData("SUBTYPE", std::to_string(pItemProperty->m_nSubType));
         PushEventData("TAG", pItemProperty->m_sCustomTag.CStr());
         PushEventData("COST_TABLE", std::to_string(pItemProperty->m_nCostTable));

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1779,6 +1779,7 @@ _______________________________________
     LOADING_GAME          | int    | TRUE if the itemproperty is being applied when loading into the game and not due to equipping the item. |
     INVENTORY_SLOT        | int    | The INVENTORY_SLOT_* the item is (un)equipped to/from. |
     PROPERTY              | int    | The ITEM_PROPERTY_* type. |
+    ID                    | int    | The ID of the item property. |
     SUBTYPE               | int    | The subtype of the itemproperty. |
     TAG                   | string | The optional tag set by TagItemProperty() |
     COST_TABLE            | int    | The index into iprp_costtable.2da |


### PR DESCRIPTION
Needed this for a system I am working on and I realized that there's no reason for it not to be in nwnx proper.