### PR TITLE
Add silent console functionnality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ https://github.com/nwnxee/unified/compare/build8193.37.13...HEAD
 ### Changed
 - Damage: Added bRangedAttack to the NWNX_Damage_AttackEventData struct.
 - Events: Added ID to the NWNX_ON_ITEMPROPERTY_EFFECT_* events data.
+- Utils: Change LOG_INFO to LOG_DEBUG for console commands.
 
 ### Deprecated
 - N/A

--- a/Plugins/Util/Util.cpp
+++ b/Plugins/Util/Util.cpp
@@ -464,7 +464,7 @@ NWNX_EXPORT ArgumentStack RegisterServerConsoleCommand(ArgumentStack&& args)
         if (Globals::AppManager()->m_pServerExoApp->GetServerMode() != 2)
             return;
 
-        LOG_INFO("Executing NWScript Server Console Command: '%s' with args: %s", command, args);
+        LOG_DEBUG("Executing NWScript Server Console Command: '%s' with args: %s", command, args);
 
         std::string scriptChunk = s_serverConsoleCommandMap[command];
         bool wrapIntoMain = scriptChunk.find("void main()") == std::string::npos;


### PR DESCRIPTION
In an effort to add console commands to my module, I got a bit OCD on the fact that there's decorations around a typical log message.

It's always possible to set variables to remove all decorations (eg: NWNX_CORE_LOG_DATE=0), but then the logs themselves lose value.

The following patch:

- Adds an environment variable (`NWNX_UTIL_SILENT_CONSOLE`) which will prevent "Executing NWScript..." with the non-standard command `ban list` as an example:
- 
```
# before:
ban list
I [2025-09-24 12:56:27] Executing NWScript Server Console Command: 'ban' with args: list
I [2025-09-24 13:01:44] (Server) CD Keys: 0
 
IP Addresses: 0
 
Player Names: 0

# after
ban list
I [2025-09-24 13:01:44] (Server) CD Keys: 0
 
IP Addresses: 0
 
Player Names: 0
```

Variable defaults to off, and thus previous behavior.

- Adds a Util function to print a string directly via std::cout, and not have any decorations. The first `ban list`, uses the typical log functions, and the second uses Raw Print. Raw Print supports additional CRLF in the string.

```
# before
ban list
I [2025-09-24 12:58:11] (Server) CD Keys: 0
 
IP Addresses: 0
 
Player Names: 0

# after
ban list
CD Keys: 0
 
IP Addresses: 0
 
Player Names: 0
```

The corresponding source code is:

```
      NWNX_Util_RawPrint(NWNX_Administration_GetBannedList());
```

PS: `ban list` is a custom console command I created to mimic `listbans` console command