### PR TITLE
Fix NWNX_TWEAKS_RESIST_ENERGY_STACKS_WITH_EPIC_ENERGY_RESISTANCE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,13 +35,14 @@ https://github.com/nwnxee/unified/compare/build8193.37.13...HEAD
 ### Fixed
 - Fixed `NWNX_TWEAKS_SETAREA_CALLS_SETPOSITION` not working with `NWNX_ON_MATERIALCHANGE_*`.
 - MaxLevel: Fixed returning an invalid number of known spells in some cases.
+- Fixed `NWNX_TWEAKS_RESIST_ENERGY_STACKS_WITH_EPIC_ENERGY_RESISTANCE` not working correctly when the character has more than one resist energy feat.
 
 ## 8193.37.13
 https://github.com/nwnxee/unified/compare/build8193.36.10...build8193.37.13
 
 **Notice: NWNX API Update**
 
-The NWNX API has been updated, resulting in the removal of nwnx.nss. All nwnx_*.nss files have been modified to use the new API functions. 
+The NWNX API has been updated, resulting in the removal of nwnx.nss. All nwnx_*.nss files have been modified to use the new API functions.
 
 What You Need to Do:
 

--- a/Plugins/Tweaks/ResistEnergyStacksWithEpicEnergyResistance.cpp
+++ b/Plugins/Tweaks/ResistEnergyStacksWithEpicEnergyResistance.cpp
@@ -24,7 +24,7 @@ void ResistEnergyStacksWithEpicEnergyResistance()
 
             uint64_t hashedFeatLabel = 0;
 
-            if (thisCreature->m_pStats->HasFeat(Constants::Feat::ResistEnergy_Acid))
+            if (nFlags == Constants::DamageType::Acid && thisCreature->m_pStats->HasFeat(Constants::Feat::ResistEnergy_Acid))
             {
                 if (thisCreature->m_pStats->HasFeat(Constants::Feat::EpicEnergyResistance_Acid10))
                     hashedFeatLabel = CRULES_HASHEDSTR("EPIC_ENERGY_RESISTANCE_AMOUNT_10");
@@ -47,7 +47,7 @@ void ResistEnergyStacksWithEpicEnergyResistance()
                 else if (thisCreature->m_pStats->HasFeat(Constants::Feat::EpicEnergyResistance_Acid1))
                     hashedFeatLabel = CRULES_HASHEDSTR("EPIC_ENERGY_RESISTANCE_AMOUNT_1");
             }
-            else if (thisCreature->m_pStats->HasFeat(Constants::Feat::ResistEnergy_Cold))
+            else if (nFlags == Constants::DamageType::Cold && thisCreature->m_pStats->HasFeat(Constants::Feat::ResistEnergy_Cold))
             {
                 if (thisCreature->m_pStats->HasFeat(Constants::Feat::EpicEnergyResistance_Cold10))
                     hashedFeatLabel = CRULES_HASHEDSTR("EPIC_ENERGY_RESISTANCE_AMOUNT_10");
@@ -70,7 +70,7 @@ void ResistEnergyStacksWithEpicEnergyResistance()
                 else if (thisCreature->m_pStats->HasFeat(Constants::Feat::EpicEnergyResistance_Cold1))
                     hashedFeatLabel = CRULES_HASHEDSTR("EPIC_ENERGY_RESISTANCE_AMOUNT_1");
             }
-            else if (thisCreature->m_pStats->HasFeat(Constants::Feat::ResistEnergy_Electrical))
+            else if (nFlags == Constants::DamageType::Electrical && thisCreature->m_pStats->HasFeat(Constants::Feat::ResistEnergy_Electrical))
             {
                 if (thisCreature->m_pStats->HasFeat(Constants::Feat::EpicEnergyResistance_Electrical10))
                     hashedFeatLabel = CRULES_HASHEDSTR("EPIC_ENERGY_RESISTANCE_AMOUNT_10");
@@ -93,7 +93,7 @@ void ResistEnergyStacksWithEpicEnergyResistance()
                 else if (thisCreature->m_pStats->HasFeat(Constants::Feat::EpicEnergyResistance_Electrical1))
                     hashedFeatLabel = CRULES_HASHEDSTR("EPIC_ENERGY_RESISTANCE_AMOUNT_1");
             }
-            else if (thisCreature->m_pStats->HasFeat(Constants::Feat::ResistEnergy_Fire))
+            else if (nFlags == Constants::DamageType::Fire && thisCreature->m_pStats->HasFeat(Constants::Feat::ResistEnergy_Fire))
             {
                 if (thisCreature->m_pStats->HasFeat(Constants::Feat::EpicEnergyResistance_Fire10))
                     hashedFeatLabel = CRULES_HASHEDSTR("EPIC_ENERGY_RESISTANCE_AMOUNT_10");
@@ -116,7 +116,7 @@ void ResistEnergyStacksWithEpicEnergyResistance()
                 else if (thisCreature->m_pStats->HasFeat(Constants::Feat::EpicEnergyResistance_Fire1))
                     hashedFeatLabel = CRULES_HASHEDSTR("EPIC_ENERGY_RESISTANCE_AMOUNT_1");
             }
-            else if (thisCreature->m_pStats->HasFeat(Constants::Feat::ResistEnergy_Sonic))
+            else if (nFlags == Constants::DamageType::Sonic && thisCreature->m_pStats->HasFeat(Constants::Feat::ResistEnergy_Sonic))
             {
                 if (thisCreature->m_pStats->HasFeat(Constants::Feat::EpicEnergyResistance_Sonic10))
                     hashedFeatLabel = CRULES_HASHEDSTR("EPIC_ENERGY_RESISTANCE_AMOUNT_10");


### PR DESCRIPTION
Fix NWNX_TWEAKS_RESIST_ENERGY_STACKS_WITH_EPIC_ENERGY_RESISTANCE to work correctly with having multiple feats