### PR TITLE
NWNX_TWEAKS_CHARLIST_SORT_BY_LAST_PLAYED_DATE: env var takes number of characters to sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ https://github.com/nwnxee/unified/compare/build8193.37.13...HEAD
 - Tweaks: Added `NWNX_TWEAKS_CHARLIST_SORT_BY_LAST_PLAYED_DATE` to enable character list sorting by last played date
 - Events: Added events `NWNX_ON_DECREMENT_REMAINING_FEAT_USES_{BEFORE|AFTER}` which fire when the remaining uses of a feat are decremented
 - Experimental: added `NWNX_EXPERIMENTAL_UFM_HOTFIX` to attempt to fix a server hang in CNetLayerWindow::UnpacketizeFullMessages.
+- Tweaks: added `NWNX_TWEAKS_CHARLIST_SORT_BY_LAST_PLAYED_DATE_NUM_CHARS` to set the number of servervault characters which will be sorted by date.
 
 ##### New Plugins
 - N/A

--- a/Plugins/Tweaks/README.md
+++ b/Plugins/Tweaks/README.md
@@ -51,8 +51,9 @@ Tweaks stuff. See below.
 | `NWNX_TWEAKS_CUTSCENE_MODE_NO_TURD` | true or false | SetCutsceneMode() will not cause a TURD to be dropped. |
 | `NWNX_TWEAKS_CAN_USE_ITEMS_WHILE_POLYMORPHED` | true or false | Allow all items to be used while polymorphed. |
 | `NWNX_TWEAKS_RESIST_ENERGY_STACKS_WITH_EPIC_ENERGY_RESISTANCE` | true or false | Resist Energy feats stack with Epic Energy Resistance. |
-| `NWNX_TWEAKS_UNHARDCODE_SPECIAL_ABILITY_TARGET_TYPE` | true or false | Allows special abilities to be used on target types other than creatures. | 
-| `NWNX_TWEAKS_CHARLIST_SORT_BY_LAST_PLAYED_DATE` | true or false | Servervault characters will be sorted by last time played date, instead of character name in the character list |
+| `NWNX_TWEAKS_UNHARDCODE_SPECIAL_ABILITY_TARGET_TYPE` | true or false | Allows special abilities to be used on target types other than creatures. |
+| `NWNX_TWEAKS_CHARLIST_SORT_BY_LAST_PLAYED_DATE` | true or false | Servervault characters will be sorted by last time played date, instead of character name in the character list. |
+| `NWNX_TWEAKS_CHARLIST_SORT_BY_LAST_PLAYED_DATE_NUM_CHARS` | Between 1 and 2097152 | This number of servervault characters will be sorted by date, the rest alphabetically. Defaults to the max value if not set. `NWNX_TWEAKS_CHARLIST_SORT_BY_LAST_PLAYED_DATE` has to be `true` for this to have an effect. |
 
 ## Environment variable values
 

--- a/Plugins/Tweaks/SortCharListByLastPlayedDate.cpp
+++ b/Plugins/Tweaks/SortCharListByLastPlayedDate.cpp
@@ -27,6 +27,7 @@ using namespace NWNXLib::API::Constants;
 
 static BOOL SendServerToPlayerCharListHook(CNWSMessage* pMessage, CNWSPlayer* pPlayer);
 static Hooks::Hook s_SendServerToPlayerCharListHook;
+static size_t s_NumCharactersToSort;
 
 struct CharacterInfoWithFiletime : NWPlayerCharacterList_st
 {
@@ -39,19 +40,33 @@ void SortCharListByLastPlayedDate()
     if (!Config::Get<bool>("CHARLIST_SORT_BY_LAST_PLAYED_DATE", false))
         return;
 
-    LOG_INFO("Character list will be sorted by last played date");
+    const int MAX_SORT_VALUE = 2097152; // 2^7 * 2^7 * 2^7 = 2^21 = 2097152, see below in SetCharacterListIndex
+
+    s_NumCharactersToSort = Config::Get<int>("CHARLIST_SORT_BY_LAST_PLAYED_DATE_NUM_CHARS", static_cast<int>(MAX_SORT_VALUE));
+
+    if (s_NumCharactersToSort < 1 || s_NumCharactersToSort > MAX_SORT_VALUE)
+    {
+        LOG_ERROR("Plugin NOT active! The value for CHARLIST_SORT_BY_LAST_PLAYED_DATE_NUM_CHARS has to be between 1 and %d", MAX_SORT_VALUE);
+        return;
+    }
+
+    if (s_NumCharactersToSort == MAX_SORT_VALUE)
+        LOG_INFO("Character list will be sorted by last played date");
+    else
+        LOG_INFO("Character list will be sorted by last played date for %d character(s)", s_NumCharactersToSort);
+
     s_SendServerToPlayerCharListHook = Hooks::HookFunction(&CNWSMessage::SendServerToPlayerCharList, &SendServerToPlayerCharListHook, Hooks::Order::Final);
 }
 
 static void SetCharacterListIndex(CharacterInfoWithFiletime* pCharInfo, int nIndex)
 {
-    // Set lowest bit of each rgb component to 1, reducing the range of available indices from 2^24 to 2^21 
+    // Set lowest bit of each rgb component to 1, reducing the range of available indices from 2^24 to 2^21
     // while avoiding null bytes and preserving uniqueness + order
     nIndex = nIndex << 1;
     int b = (nIndex & 0xFF) | 1;
     int g = ((nIndex >> 7) & 0xFF) | 1;
     int r = ((nIndex >> 14) & 0xFF) | 1;
-        
+
     auto& pStrList = pCharInfo->sLocFirstName.m_pExoLocStringInternal->m_lstString;
     for (auto *pNode = pStrList.GetHeadPos(); pNode; pNode = pNode->pNext)
     {
@@ -65,7 +80,7 @@ static std::time_t GetBICFileTime(const CExoString& sVaultPath, const CResRef& s
     CExoString sFilename = sVaultPath + CExoString(sBicResRef) + ".bic";
 
     struct stat fileStats;
-    if (stat(sFilename.c_str(), &fileStats) == 0) 
+    if (stat(sFilename.c_str(), &fileStats) == 0)
         return fileStats.st_mtime;
     else
         return 0;
@@ -129,7 +144,7 @@ static BOOL SendServerToPlayerCharListHook(CNWSMessage* pMessage, CNWSPlayer* pP
                     {
                         BOOL bSuccess;
                         CResStruct topLevelStruct;
-                        
+
                         pRes->GetTopLevelStruct(&topLevelStruct);
 
                         CharacterInfoWithFiletime charInfo;
@@ -140,7 +155,7 @@ static BOOL SendServerToPlayerCharListHook(CNWSMessage* pMessage, CNWSPlayer* pP
                         charInfo.nPortraitId = pRes->ReadFieldWORD(&topLevelStruct, "PortraitId", bSuccess, 0xFFFF);
                         charInfo.resPortrait = pRes->ReadFieldCResRef(&topLevelStruct, "Portrait", bSuccess);
                         charInfo.fLastFileModified = GetBICFileTime(sPlayerServerVault, charInfo.resFileName);
-                        
+
                         CResList classList;
                         if (pRes->GetList(&classList, &topLevelStruct, "ClassList"))
                         {
@@ -163,8 +178,8 @@ static BOOL SendServerToPlayerCharListHook(CNWSMessage* pMessage, CNWSPlayer* pP
                     else
                     {
                         LOG_ERROR("Corrupt BIC file in servervault of player: '%s' (%s) -> '%s.bic', character skipped.",
-                            pPlayer->GetPlayerName().CStr(), 
-                            pPlayerInfo->m_cCDKey.sPublic.CStr(), 
+                            pPlayer->GetPlayerName().CStr(),
+                            pPlayerInfo->m_cCDKey.sPublic.CStr(),
                             sBicResRef.CStr());
                     }
                 }
@@ -235,13 +250,13 @@ static BOOL SendServerToPlayerCharListHook(CNWSMessage* pMessage, CNWSPlayer* pP
             }
         }
 
-        std::sort(lstChars.begin(), lstChars.end(), 
+        std::sort(lstChars.begin(), lstChars.end(),
         [](const CharacterInfoWithFiletime& a, const CharacterInfoWithFiletime& b)
         {
-            return a.fLastFileModified > b.fLastFileModified; 
+            return a.fLastFileModified > b.fLastFileModified;
         });
 
-        for (size_t i=0; i < lstChars.size(); i++)
+        for (size_t i=0; i < std::min(s_NumCharactersToSort, lstChars.size()); i++)
         {
             SetCharacterListIndex(&lstChars[i], i);
         }


### PR DESCRIPTION
I added no special env var value to mean "all", one can just set it to the maximum instead I figured. 2 million characters should be enough for anyone.