### PR TITLE
Add a RawPrint method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ https://github.com/nwnxee/unified/compare/build8193.37.13...HEAD
 - Store: GetBlackMarket(), SetBlackMarket()
 - Util: SetStartingLocation()
 - Object: GetLocalizedDescription(), SetLocalizedDescription()
+- Util: RawPrint()
 
 ### Changed
 - Damage: Added bRangedAttack to the NWNX_Damage_AttackEventData struct.

--- a/Plugins/Util/NWScript/nwnx_util.nss
+++ b/Plugins/Util/NWScript/nwnx_util.nss
@@ -276,6 +276,10 @@ int NWNX_Util_UpdateResourceDirectory(string sAlias);
 /// @return TRUE if successful, FALSE on error.
 int NWNX_Util_SetStartingLocation(string sResRef, location locLocation, vector vDirection);
 
+/// @brief Print a string with no log decorations.
+/// @param sString String to print
+void NWNX_Util_RawPrint(string sString);
+
 /// @}
 
 string NWNX_Util_GetCurrentScriptName(int depth = 0)
@@ -605,3 +609,8 @@ int NWNX_Util_SetStartingLocation(string sResRef, location locLocation, vector v
     return NWNXPopInt();
 }
 
+void NWNX_Util_RawPrint(string sString)
+{
+    NWNXPushString(sString);
+    NWNXCall(NWNX_Util, "RawPrint");
+}

--- a/Plugins/Util/Util.cpp
+++ b/Plugins/Util/Util.cpp
@@ -505,6 +505,13 @@ NWNX_EXPORT ArgumentStack UnregisterServerConsoleCommand(ArgumentStack&& args)
     return {};
 }
 
+NWNX_EXPORT ArgumentStack RawPrint(ArgumentStack&& args)
+{
+  std::string sLogMessage = args.extract<std::string>();
+  std::cout << sLogMessage << std::endl;
+  return {};
+}
+
 NWNX_EXPORT ArgumentStack PluginExists(ArgumentStack&& args)
 {
     return Plugin::Find(args.extract<std::string>()) ? 1 : 0;


### PR DESCRIPTION
This patch allows to print information without log decoration. There may be already a way to do this, but I haven't found it.

This is helpful for new and added command line (nwserver cli) dynamic commands.