### PR TITLE
Add SetStartingLocation()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ https://github.com/nwnxee/unified/compare/build8193.37.13...HEAD
 - Player: GetOpenStore()
 - Creature: GetNumberOfBonusSpells(), ModifyNumberBonusSpells()
 - Store: GetBlackMarket(), SetBlackMarket()
+- Util: SetStartingLocation()
 
 ### Changed
 - Damage: Added bRangedAttack to the NWNX_Damage_AttackEventData struct.

--- a/Plugins/Util/NWScript/nwnx_util.nss
+++ b/Plugins/Util/NWScript/nwnx_util.nss
@@ -269,6 +269,13 @@ string NWNX_Util_GetModuleTlkFile();
 /// @return TRUE if successful, FALSE on error.
 int NWNX_Util_UpdateResourceDirectory(string sAlias);
 
+/// @brief Set the starting location.
+/// @param sResRef ResRef of area.
+/// @param locLocation The location to move the starting point to.
+/// @param vDirection  Direction of starting point.
+/// @return TRUE if successful, FALSE on error.
+int NWNX_Util_SetStartingLocation(string sResRef, location locLocation, vector vDirection);
+
 /// @}
 
 string NWNX_Util_GetCurrentScriptName(int depth = 0)
@@ -588,3 +595,13 @@ int NWNX_Util_UpdateResourceDirectory(string sAlias)
     NWNXCall(NWNX_Util, "UpdateResourceDirectory");
     return NWNXPopInt();
 }
+
+int NWNX_Util_SetStartingLocation(string sResRef, location locLocation, vector vDirection)
+{
+    NWNXPushVector(vDirection);
+    NWNXPushLocation(locLocation);
+    NWNXPushString(sResRef);
+    NWNXCall(NWNX_Util, "SetStartingLocation");
+    return NWNXPopInt();
+}
+

--- a/Plugins/Util/Util.cpp
+++ b/Plugins/Util/Util.cpp
@@ -23,6 +23,7 @@
 #include "API/CResGFF.hpp"
 #include "API/CNWSArea.hpp"
 #include "API/CNWSModule.hpp"
+#include "API/NWMODULEENTRYINFO.hpp"
 
 #include <string>
 #include <cstdio>
@@ -807,4 +808,28 @@ NWNX_EXPORT ArgumentStack UpdateResourceDirectory(ArgumentStack&& args)
     const auto alias = args.extract<std::string>();
       ASSERT_OR_THROW(!alias.empty());
     return Globals::ExoResMan()->UpdateResourceDirectory(alias + ":");
+}
+
+NWNX_EXPORT ArgumentStack SetStartingLocation(ArgumentStack&& args)
+{
+    const auto strResRef = args.extract<std::string>();
+      ASSERT_OR_THROW(!strResRef.empty());
+    const auto locSpawn = args.extract<CScriptLocation>();
+    const auto vDirection = args.extract<Vector>();
+
+    auto resRef = CResRef(strResRef);
+    if (!Globals::ExoResMan()->Exists(resRef, Constants::ResRefType::ARE, nullptr))
+    {
+        LOG_WARNING("SetStartingLocation: ResRef '%s' does not exist", resRef.GetResRefStr());
+        return false;
+    }
+
+    CNWSModule *pMod = Utils::GetModule();
+    pMod->m_pModuleEntryInfo->refArea = resRef;
+    pMod->m_pModuleEntryInfo->nX = locSpawn.m_vPosition.x;
+    pMod->m_pModuleEntryInfo->nY = locSpawn.m_vPosition.y;
+    pMod->m_pModuleEntryInfo->nZ = locSpawn.m_vPosition.z;
+    pMod->m_pModuleEntryInfo->fDirX = vDirection.x;
+    pMod->m_pModuleEntryInfo->fDirY = vDirection.y;
+    return true;
 }


### PR DESCRIPTION
Add function SetStartingLocation(), the companion of GetStartingLocation.

This allows 2 things:

- not having to move the starting point in the toolset, which often results in crashes for me.
- moving the starting point for DestroyArea()

Returns TRUE/FALSE