### PR TITLE
Hide the player password from logs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ https://github.com/nwnxee/unified/compare/build8193.37.13...HEAD
 - Damage: Added bRangedAttack to the NWNX_Damage_AttackEventData struct.
 - Events: Added ID to the NWNX_ON_ITEMPROPERTY_EFFECT_* events data.
 - Utils: Change LOG_INFO to LOG_DEBUG for console commands.
+- Admin: Player/DM password functions no longer print the passwords to the log.
 
 ### Deprecated
 - N/A

--- a/Plugins/Administration/Administration.cpp
+++ b/Plugins/Administration/Administration.cpp
@@ -57,15 +57,14 @@ static CExoLinkedListNode* FindTURD(std::string playerName, std::string characte
 NWNX_EXPORT ArgumentStack GetPlayerPassword(ArgumentStack&&)
 {
     const CExoString password = Globals::AppManager()->m_pServerExoApp->GetNetLayer()->GetPlayerPassword();
-    LOG_DEBUG("Returned player password '%s'.", password.m_sString);
     return std::string(password.m_sString ? password.m_sString : "");
 }
 
 NWNX_EXPORT ArgumentStack SetPlayerPassword(ArgumentStack&& args)
 {
     const auto newPass = args.extract<std::string>();
-    LOG_NOTICE("Set player password to '%s'.", newPass);
     Globals::AppManager()->m_pServerExoApp->GetNetLayer()->SetPlayerPassword(newPass.c_str());
+    LOG_DEBUG("Set player password.");
     return {};
 }
 
@@ -79,15 +78,14 @@ NWNX_EXPORT ArgumentStack ClearPlayerPassword(ArgumentStack&&)
 NWNX_EXPORT ArgumentStack GetDMPassword(ArgumentStack&&)
 {
     const CExoString password = Globals::AppManager()->m_pServerExoApp->GetNetLayer()->GetGameMasterPassword();
-    LOG_DEBUG("Returned DM password '%s'.", password.m_sString);
     return std::string(password.m_sString ? password.m_sString : "");
 }
 
 NWNX_EXPORT ArgumentStack SetDMPassword(ArgumentStack&& args)
 {
     const auto newPass = args.extract<std::string>();
-    LOG_NOTICE("Set DM password to '%s'.", newPass);
     Globals::AppManager()->m_pServerExoApp->GetNetLayer()->SetGameMasterPassword(newPass.c_str());
+    LOG_DEBUG("Set DM password.");
     return {};
 }
 


### PR DESCRIPTION
In case there is a need for PCI DSS certification... /jk

It just kinda of bothered me seeing the password in the log files.

The default is to show the password, thus keeping the previous behavior. Hiding the password is opt-in.