### PR TITLE
SkillRanks: fix UB in GetAreaModifier dereferencing empty std::optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ https://github.com/nwnxee/unified/compare/build8193.37.13...HEAD
 - MaxLevel: Fixed returning an invalid number of known spells in some cases.
 - Fixed `NWNX_TWEAKS_RESIST_ENERGY_STACKS_WITH_EPIC_ENERGY_RESISTANCE` not working correctly when the character has more than one resist energy feat.
 - Fixed `NWNX_TWEAKS_SNEAK_ATTACK_IGNORE_CRIT_IMMUNITY` only considering 3 classes for determining the level difference of attacker and defender.
+- SkillRanks: Fixed `GetAreaModifier()` dereferencing an empty `std::optional` (undefined behavior) when the queried area had no modifier set for the skill. Now returns `0` in that case.
 
 ## 8193.37.13
 https://github.com/nwnxee/unified/compare/build8193.36.10...build8193.37.13

--- a/Plugins/SkillRanks/SkillRanks.cpp
+++ b/Plugins/SkillRanks/SkillRanks.cpp
@@ -890,7 +890,7 @@ ArgumentStack SkillRanks::GetAreaModifier(ArgumentStack&& args)
     ASSERT_OR_THROW(skillId >= Constants::Skill::MIN);
     ASSERT_OR_THROW(skillId < Globals::Rules()->m_nNumSkills);
 
-    int32_t retVal = *pArea->nwnxGet<int>(areaModPOSKey + std::to_string(skillId));
+    int32_t retVal = pArea->nwnxGet<int>(areaModPOSKey + std::to_string(skillId)).value_or(0);
 
     return ScriptAPI::Arguments(retVal);
 }


### PR DESCRIPTION
`SkillRanks::GetAreaModifier` dereferenced the `std::optional<int>` returned by `pArea->nwnxGet<int>(...)` without checking whether it had a value. When `SetAreaModifier` had never been called for that `(area, skillId)` pair, the optional was empty and `*` on it was undefined behaviour.

Fixed by using `.value_or(0)` to return the natural identity for an unset modifier. This matches how the plugin's internal skill-resolution path already treats an empty optional (it skips the `+= *areaMod` accumulation), so observable behaviour for callers is consistent.

Fixes #1855