### PR TITLE
Add NWNX_ON_OBJECT_ADD_TO_AREA_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ https://github.com/nwnxee/unified/compare/build8193.37.13...HEAD
 - Tweaks: Added `NWNX_TWEAKS_CHARLIST_SORT_BY_LAST_PLAYED_DATE` to enable character list sorting by last played date
 - Events: Added events `NWNX_ON_DECREMENT_REMAINING_FEAT_USES_{BEFORE|AFTER}` which fire when the remaining uses of a feat are decremented
 - Experimental: added `NWNX_EXPERIMENTAL_UFM_HOTFIX` to attempt to fix a server hang in CNetLayerWindow::UnpacketizeFullMessages.
+- Events: Added events `NWNX_ON_OBJECT_ADD_TO_AREA_{BEFORE|AFTER}` which fire when an object is added to the area.
 
 ##### New Plugins
 - N/A

--- a/Plugins/Events/Events/ObjectEvents.cpp
+++ b/Plugins/Events/Events/ObjectEvents.cpp
@@ -1,4 +1,5 @@
 #include "Events.hpp"
+#include "API/CNWSArea.hpp"
 #include "API/CNWSObject.hpp"
 #include "API/CNWSPlaceable.hpp"
 #include "API/CNWSCreature.hpp"
@@ -16,6 +17,7 @@ static Hooks::Hook s_OpenInventoryHook;
 static Hooks::Hook s_CloseInventoryHook;
 static Hooks::Hook s_BroadcastSafeProjectileHook;
 static Hooks::Hook s_SetExperienceHook;
+static Hooks::Hook s_AddObjectToAreaHook;
 
 static int32_t AddLockObjectActionHook(CNWSObject*, ObjectID);
 static int32_t AddUnlockObjectActionHook(CNWSObject*, ObjectID, ObjectID, int32_t);
@@ -24,6 +26,7 @@ static void OpenInventoryHook(CNWSPlaceable*, ObjectID);
 static void CloseInventoryHook(CNWSPlaceable*, ObjectID, BOOL);
 static void BroadcastSafeProjectileHook(CNWSObject*, ObjectID, ObjectID, Vector, Vector, uint32_t, uint8_t, uint32_t, uint8_t, uint8_t);
 static void SetExperienceHook(CNWSCreatureStats*, uint32_t, BOOL);
+static BOOL AddObjectToAreaHook(CNWSArea*, OBJECT_ID, BOOL);
 
 void ObjectEvents() __attribute__((constructor));
 void ObjectEvents()
@@ -61,6 +64,11 @@ void ObjectEvents()
     InitOnFirstSubscribe("NWNX_ON_SET_EXPERIENCE_.*", []() {
         s_SetExperienceHook = Hooks::HookFunction(&CNWSCreatureStats::SetExperience,
             &SetExperienceHook, Hooks::Order::Early);
+    });
+
+    InitOnFirstSubscribe("NWNX_ON_OBJECT_ADD_TO_AREA_.*", []() {
+        s_AddObjectToAreaHook = Hooks::HookFunction(&CNWSArea::AddObjectToArea,
+            &AddObjectToAreaHook, Hooks::Order::Early);
     });
 }
 
@@ -226,6 +234,29 @@ void SetExperienceHook(CNWSCreatureStats *thisPtr, uint32_t nValue, BOOL bDoLeve
         PushEventData("XP", std::to_string(nValue));
         SignalEvent("NWNX_ON_SET_EXPERIENCE_AFTER", thisPtr->m_pBaseCreature->m_idSelf);
     }
+}
+
+BOOL AddObjectToAreaHook(CNWSArea* thisPtr, OBJECT_ID id, BOOL bRunScripts)
+{
+    auto PushAndSignal = [&](const std::string& ev) -> bool {
+        PushEventData("AREA", Utils::ObjectIDToString(thisPtr->m_idSelf));
+        return SignalEvent(ev, id);
+    };
+
+    BOOL retVal;
+    if (PushAndSignal("NWNX_ON_OBJECT_ADD_TO_AREA_BEFORE"))
+    {
+        retVal = s_AddObjectToAreaHook->CallOriginal<BOOL>(thisPtr, id, bRunScripts);
+    }
+    else
+    {
+        retVal = false;
+    }
+
+    PushEventData("ACTION_RESULT", std::to_string(retVal));
+    PushAndSignal("NWNX_ON_OBJECT_ADD_TO_AREA_AFTER");
+
+    return retVal;
 }
 
 }

--- a/Plugins/Events/NWScript/nwnx_events.nss
+++ b/Plugins/Events/NWScript/nwnx_events.nss
@@ -1816,6 +1816,17 @@ _______________________________________
     @note The event only fires for players. It might fire a few times during (before) client enter when all the items are equipped and one or more of them have a bonus to abilities. To detect and possibly skip events happening before client enter one can use `GetIsObjectValid(GetArea(OBJECT_SELF))`.
 
     @warning The nwscript function GetAbilityModifier() will return the **old** modifier when used in this event. Use the MOD event data to get the new value.
+_______________________________________
+    ## Add object to area events
+    - NWNX_ON_OBJECT_ADD_TO_AREA_BEFORE
+    - NWNX_ON_OBJECT_ADD_TO_AREA_AFTER
+
+    `OBJECT_SELF` = The object.
+    `AREA` = The area.
+
+    Event Data Tag        | Type   | Notes
+    ----------------------|--------|-------
+    AREA                  | int    | The area the object is being added to. |
 */
 
 /// @name Events Event Constants
@@ -2170,6 +2181,8 @@ const string NWNX_ON_ITEMPROPERTY_EFFECT_APPLIED_BEFORE = "NWNX_ON_ITEMPROPERTY_
 const string NWNX_ON_ITEMPROPERTY_EFFECT_APPLIED_AFTER = "NWNX_ON_ITEMPROPERTY_EFFECT_APPLIED_AFTER";
 const string NWNX_ON_ITEMPROPERTY_EFFECT_REMOVED_BEFORE = "NWNX_ON_ITEMPROPERTY_EFFECT_REMOVED_BEFORE";
 const string NWNX_ON_ITEMPROPERTY_EFFECT_REMOVED_AFTER = "NWNX_ON_ITEMPROPERTY_EFFECT_REMOVED_AFTER";
+const string NWNX_ON_OBJECT_ADD_TO_AREA_BEFORE = "NWNX_ON_OBJECT_ADD_TO_AREA_BEFORE";
+const string NWNX_ON_OBJECT_ADD_TO_AREA_AFTER = "NWNX_ON_OBJECT_ADD_TO_AREA_AFTER";
 /// @}
 
 /// @name Events ObjectType Constants


### PR DESCRIPTION
Adds the event to get the objects added to the area.

Why is this needed? When a mob dies, there's no event to get which objects were added to the floor of the area. Also, the objects are added with a slight delay to the floor. The default "item lost" script does not fire. Please note that the creature treasure mode is set to "leave lootable corpse"

For my area garbage collector, when a mob dies, I currently add a delay event to scan the whole area and detect new items not already in my gc.

An alternative is  adding the mob death location to the delay, and only scanning a radius around the area.

With this event, when the mob dies, we get an event for the "remains" object.

Note: this will also fire for other events such as a PC entering the area.